### PR TITLE
Enable SCons build cache in CI workflows

### DIFF
--- a/.github/workflows/baseline_qa.yml
+++ b/.github/workflows/baseline_qa.yml
@@ -81,9 +81,18 @@ jobs:
           mesa-vulkan-drivers \
           xvfb
 
+    - name: Restore SCons build cache
+      uses: actions/cache@v4
+      with:
+        path: .scons_cache
+        key: scons-linux-${{ hashFiles('SConstruct', 'methods.py') }}-${{ github.sha }}
+        restore-keys: |
+          scons-linux-${{ hashFiles('SConstruct', 'methods.py') }}-
+          scons-linux-
+
     - name: Build module-enabled Godot editor
       run: |
-        scons platform=linuxbsd target=editor dev_build=yes tests=yes -j"$(nproc)"
+        scons platform=linuxbsd target=editor dev_build=yes tests=yes cache_path=.scons_cache cache_limit=10 -j"$(nproc)"
 
     - name: Resolve module-enabled Godot binary
       id: godot_binary

--- a/.github/workflows/gaussian_production_gates.yml
+++ b/.github/workflows/gaussian_production_gates.yml
@@ -190,7 +190,7 @@ jobs:
       - name: Build Godot editor with tests
         shell: pwsh
         run: |
-          python -m SCons platform=windows target=editor dev_build=yes tests=yes gs_native_arch=no -j12
+          python -m SCons platform=windows target=editor dev_build=yes tests=yes gs_native_arch=no cache_path=C:/godotgs-scons-cache cache_limit=50 -j12
 
       - name: Resolve Godot binary
         id: godot_bin


### PR DESCRIPTION
## Summary
- Add SCons `CacheDir` support to both CI workflows for faster incremental builds
- Linux ephemeral runner: `actions/cache@v4` persists `.scons_cache` between runs (10 GiB limit)
- Windows self-hosted runner: persistent local cache at `C:/godotgs-scons-cache` (50 GiB limit)
- `SConstruct` already supports `cache_path` and `cache_limit` arguments — no build system changes needed

## Test plan
- [ ] Linux CI build uses cache (first run populates, subsequent runs are faster)
- [ ] Windows self-hosted build uses persistent cache
- [ ] Build output is identical with and without cache

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)