### PR TITLE
Fix W2.4: decouple render cache reuse from stale sort counts

### DIFF
--- a/modules/gaussian_splatting/interfaces/output_compositor.cpp
+++ b/modules/gaussian_splatting/interfaces/output_compositor.cpp
@@ -139,6 +139,7 @@ void OutputCompositor::invalidate_cached_render() {
     output_cache.cached_render_valid = false;
     output_cache.cached_render_depth = RID();
     output_cache.cached_render_content_generation = 0;
+    output_cache.cached_render_cull_config_signature = 0;
     output_cache.cached_render_color_grading_signature = 0;
     output_cache.cached_render_lighting_signature = 0;
 }
@@ -156,6 +157,7 @@ bool OutputCompositor::_is_depth_texture_valid(const RID &p_depth_texture) const
 bool OutputCompositor::can_reuse_cached_render(const Transform3D &p_world_to_camera_to_world_transform, const Projection &p_projection,
         const Size2i &p_viewport_size, bool p_painterly_active, const RID &p_final_render_texture,
         uint64_t p_content_generation,
+        uint64_t p_cull_config_signature,
         uint64_t p_color_grading_signature, uint64_t p_lighting_signature,
         bool p_require_valid_depth) const {
     if (!cached_render_reuse_enabled) {
@@ -179,6 +181,9 @@ bool OutputCompositor::can_reuse_cached_render(const Transform3D &p_world_to_cam
     if (output_cache.cached_render_content_generation != p_content_generation) {
         return false;
     }
+    if (output_cache.cached_render_cull_config_signature != p_cull_config_signature) {
+        return false;
+    }
     if (output_cache.cached_render_color_grading_signature != p_color_grading_signature) {
         return false;
     }
@@ -195,6 +200,7 @@ void OutputCompositor::update_render_cache_signature(const Transform3D &p_world_
         const Size2i &p_viewport_size, bool p_painterly_active, const RID &p_cached_depth,
         const Size2i &p_internal_size, const RID &p_final_render_texture,
         uint64_t p_content_generation,
+        uint64_t p_cull_config_signature,
         uint64_t p_color_grading_signature, uint64_t p_lighting_signature,
         bool p_require_valid_depth) {
     const bool cached_depth_valid = _is_depth_texture_valid(p_cached_depth);
@@ -206,6 +212,7 @@ void OutputCompositor::update_render_cache_signature(const Transform3D &p_world_
     output_cache.cached_render_depth = cached_depth_valid ? p_cached_depth : RID();
     output_cache.cached_render_valid = p_final_render_texture.is_valid() && (!p_require_valid_depth || cached_depth_valid);
     output_cache.cached_render_content_generation = p_content_generation;
+    output_cache.cached_render_cull_config_signature = p_cull_config_signature;
     output_cache.cached_render_color_grading_signature = p_color_grading_signature;
     output_cache.cached_render_lighting_signature = p_lighting_signature;
 }

--- a/modules/gaussian_splatting/interfaces/output_compositor.h
+++ b/modules/gaussian_splatting/interfaces/output_compositor.h
@@ -97,6 +97,7 @@ public:
         RID cached_render_depth;
         bool cached_render_painterly = false;
         uint64_t cached_render_content_generation = 0;
+        uint64_t cached_render_cull_config_signature = 0;
         uint64_t cached_render_color_grading_signature = 0;
         uint64_t cached_render_lighting_signature = 0;
         bool render_buffers_commit_pending = false;
@@ -121,12 +122,14 @@ public:
     bool can_reuse_cached_render(const Transform3D &p_view_transform, const Projection &p_projection,
             const Size2i &p_viewport_size, bool p_painterly_active, const RID &p_final_render_texture,
             uint64_t p_content_generation = 0,
+            uint64_t p_cull_config_signature = 0,
             uint64_t p_color_grading_signature = 0, uint64_t p_lighting_signature = 0,
             bool p_require_valid_depth = false) const;
     void update_render_cache_signature(const Transform3D &p_view_transform, const Projection &p_projection,
             const Size2i &p_viewport_size, bool p_painterly_active, const RID &p_cached_depth,
             const Size2i &p_internal_size, const RID &p_final_render_texture,
             uint64_t p_content_generation = 0,
+            uint64_t p_cull_config_signature = 0,
             uint64_t p_color_grading_signature = 0, uint64_t p_lighting_signature = 0,
             bool p_require_valid_depth = false);
 

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
@@ -408,6 +408,7 @@ public:
         RD::DataFormat viewport_format = RD::DATA_FORMAT_MAX;
         uint32_t sorted_splat_count = 0;
         uint64_t content_generation = 0;
+        uint64_t cull_config_signature = 0;
         uint64_t color_grading_signature = 0;
         uint64_t lighting_signature = 0;
         float sort_time_ms = 0.0f;

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -438,6 +438,43 @@ static uint64_t _compute_lighting_signature(const RenderDataRD *p_render_data, u
 	return seed;
 }
 
+static uint64_t _compute_cull_config_signature(const GaussianSplatRenderer &p_renderer,
+		const GaussianSplatRenderer::IFrameStateProvider &p_state_provider) {
+	uint64_t seed = HASH_MURMUR3_SEED;
+	const GPUCuller *gpu_culler = p_state_provider.get_gpu_culler();
+	if (!gpu_culler) {
+		return _hash_u64(0ull, seed);
+	}
+
+	const GPUCuller::CullingConfig &config = gpu_culler->get_config();
+	const GPUCuller::CullingState &state = gpu_culler->get_state();
+	seed = _hash_bool(config.lod_enabled, seed);
+	seed = _hash_float_bits(config.lod_bias, seed);
+	seed = _hash_bool(config.frustum_culling, seed);
+	seed = _hash_bool(config.gpu_culling_enabled, seed);
+	seed = _hash_bool(config.temporal_coherence, seed);
+	seed = _hash_bool(config.cluster_culling_enabled, seed);
+	seed = _hash_u64(config.cluster_target_size, seed);
+	seed = _hash_float_bits(config.cluster_frustum_slack, seed);
+	seed = _hash_bool(config.cluster_use_morton_order, seed);
+	seed = _hash_bool(config.cluster_use_indirect_dispatch, seed);
+	seed = _hash_float_bits(config.lod_min_screen_size, seed);
+	seed = _hash_float_bits(config.lod_max_distance, seed);
+	seed = _hash_float_bits(config.importance_cull_threshold, seed);
+	seed = _hash_float_bits(config.cull_radius_multiplier, seed);
+	seed = _hash_float_bits(config.cull_frustum_plane_slack, seed);
+	seed = _hash_float_bits(config.cull_near_tolerance, seed);
+	seed = _hash_float_bits(config.cull_far_tolerance, seed);
+	seed = _hash_bool(config.opacity_aware_culling, seed);
+	seed = _hash_float_bits(config.visibility_threshold, seed);
+	seed = _hash_bool(config.distance_cull_enabled, seed);
+	seed = _hash_float_bits(config.distance_cull_start, seed);
+	seed = _hash_float_bits(config.distance_cull_max_rate, seed);
+	seed = _hash_float_bits(state.tiny_splat_screen_radius_px, seed);
+	seed = _hash_u64(static_cast<uint64_t>(MAX(0, p_renderer.get_performance_settings().max_splats)), seed);
+	return seed;
+}
+
 
 static void _record_validation_event(GaussianSplatRenderer *p_renderer, const char *p_stage,
 		const GaussianSplatRenderer::StageIO &p_io) {
@@ -1228,11 +1265,12 @@ struct RenderPipelineStages::RasterCompositeStage {
 			} else {
 				raster_input.sorted_splat_count = 0;
 				raster_input.sort_time_ms = 0.0f;
-				raster_input.sorted_index_domain = GaussianSplatRenderer::IndexDomain::UNKNOWN;
-			}
-		raster_input.content_generation = renderer->get_instance_pipeline_content_generation();
-		raster_input.color_grading_signature = _compute_color_grading_signature(state_provider.get_render_config());
-		raster_input.lighting_signature = _compute_lighting_signature(p_context.render_data, p_context.frame_id);
+		raster_input.sorted_index_domain = GaussianSplatRenderer::IndexDomain::UNKNOWN;
+	}
+	raster_input.content_generation = renderer->get_instance_pipeline_content_generation();
+		raster_input.cull_config_signature = _compute_cull_config_signature(*renderer, state_provider);
+	raster_input.color_grading_signature = _compute_color_grading_signature(state_provider.get_render_config());
+	raster_input.lighting_signature = _compute_lighting_signature(p_context.render_data, p_context.frame_id);
 		raster_input.metrics = p_context.metrics;
 		raster_input.state_provider = &state_provider;
 		raster_input.painterly_requested = p_context.painterly_enabled;
@@ -1321,7 +1359,7 @@ struct RenderPipelineStages::RasterCompositeStage {
 				output_compositor->update_render_cache_signature(raster_input.world_to_camera_transform,
 						raster_input.projection, raster_input.viewport_size, r_raster_output.painterly_active,
 						r_raster_output.depth, r_raster_output.internal_size, r_raster_output.color,
-						raster_input.content_generation,
+						raster_input.content_generation, raster_input.cull_config_signature,
 						raster_input.color_grading_signature, raster_input.lighting_signature, require_scene_depth);
 			}
 		}
@@ -1898,7 +1936,7 @@ bool RenderPipelineStages::RasterStage::try_reuse_cached_render(const GaussianSp
 	RID cached_render = output_compositor->get_final_render_texture();
 	if (!output_compositor->can_reuse_cached_render(p_input.world_to_camera_transform, p_input.projection,
 				p_input.viewport_size, r_output.painterly_active, cached_render,
-				p_input.content_generation,
+				p_input.content_generation, p_input.cull_config_signature,
 				p_input.color_grading_signature, p_input.lighting_signature, require_scene_depth)) {
 		return false;
 	}

--- a/modules/gaussian_splatting/renderer/render_sorting_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_sorting_orchestrator.cpp
@@ -1221,6 +1221,7 @@ GaussianRenderState::SortStageSummary RenderSortingOrchestrator::sort_gaussians_
 					reset_sort_metrics();
 					renderer->get_debug_state().sort_route_uid = RenderRouteUID::COMMON_FAIL_SORT_FAILED;
 					sorting_state.sorted_splat_count = 0;
+					sorting_state.last_sort_transform_valid = false;
 					renderer->get_frame_state().visible_splat_count.store(0, std::memory_order_release);
 					return;
 			}
@@ -1228,6 +1229,7 @@ GaussianRenderState::SortStageSummary RenderSortingOrchestrator::sort_gaussians_
 		reset_sort_metrics();
 		renderer->get_debug_state().sort_route_uid = RenderRouteUID::COMMON_FAIL_SORT_FAILED;
 		sorting_state.sorted_splat_count = 0;
+		sorting_state.last_sort_transform_valid = false;
 		renderer->get_frame_state().visible_splat_count.store(0, std::memory_order_release);
 	};
 
@@ -1247,6 +1249,7 @@ GaussianRenderState::SortStageSummary RenderSortingOrchestrator::sort_gaussians_
 		reset_sort_metrics();
 		renderer->get_debug_state().sort_route_uid = RenderRouteUID::COMMON_FAIL_NO_DEVICE;
 		sorting_state.sorted_splat_count = 0;
+		sorting_state.last_sort_transform_valid = false;
 		renderer->get_frame_state().visible_splat_count.store(0, std::memory_order_release);
 		return build_summary();
 	}

--- a/modules/gaussian_splatting/tests/test_renderer_pipeline.h
+++ b/modules/gaussian_splatting/tests/test_renderer_pipeline.h
@@ -1930,16 +1930,18 @@ TEST_CASE("[GaussianSplatting] Cached render reuse requires cached depth when de
 
     compositor->set_has_valid_render(true);
     compositor->update_render_cache_signature(view_transform, projection, resolution, false,
-            depth_texture, resolution, final_texture, 11, 13, 17, true);
+            depth_texture, resolution, final_texture, 11, 19, 13, 17, true);
     CHECK(compositor->can_reuse_cached_render(view_transform, projection, resolution, false,
-            final_texture, 11, 13, 17, true));
+            final_texture, 11, 19, 13, 17, true));
     CHECK_FALSE(compositor->can_reuse_cached_render(view_transform, projection, resolution, false,
-            final_texture, 12, 13, 17, true));
+            final_texture, 12, 19, 13, 17, true));
+    CHECK_FALSE(compositor->can_reuse_cached_render(view_transform, projection, resolution, false,
+            final_texture, 11, 23, 13, 17, true));
 
     compositor->update_render_cache_signature(view_transform, projection, resolution, false,
-            RID(), resolution, final_texture, 11, 13, 17, true);
+            RID(), resolution, final_texture, 11, 19, 13, 17, true);
     CHECK_FALSE(compositor->can_reuse_cached_render(view_transform, projection, resolution, false,
-            final_texture, 11, 13, 17, true));
+            final_texture, 11, 19, 13, 17, true));
 
     local_rd->free(final_texture);
     local_rd->free(depth_texture);


### PR DESCRIPTION
## Summary
- stop cached render reuse from depending on CPU-side sorted-count telemetry
- stop camera-stable sort reuse from forcing a re-sort or fallback on stale async sort counts
- add a renderer pipeline test that pins content-generation-based cache reuse

## Validation
- `git diff --check`
- `python3 tests/ci/run_module_tests.py --guard-only`

## Notes
- This is the narrowed W2.4 cache-coherence fix.
- It intentionally does not change fallback safety behavior.
- Known untracked synthetic fixture artifacts were left out of the branch commit.