### PR TITLE
Refactor W3.3b: move renderer facade helpers to orchestrators

### DIFF
--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
@@ -387,13 +387,6 @@ bool GaussianSplatRenderer::validate_cull_projection_contract(RenderDataRD *p_re
 	return false;
 }
 
-void GaussianSplatRenderer::_forget_resource_owner(const RID &p_rid) {
-    // Phase 8/C: Delegate to RenderDeviceManager (inline fallback removed)
-    if (subsystem_state.device_manager.is_valid()) {
-        subsystem_state.device_manager->forget_resource(p_rid);
-    }
-}
-
 void GaussianSplatRenderer::_forget_tile_renderer_outputs() {
     if (subsystem_state.rasterizer.is_valid()) {
         subsystem_state.rasterizer->clear_output_resource_tracking();
@@ -681,7 +674,8 @@ GaussianSplatRenderer::GaussianSplatRenderer(RenderingDevice *p_device) {
                 render_sorted_splats(p_render_data, p_world_to_camera_transform, p_projection,
                         p_render_projection, p_defer_render_buffers_commit);
             });
-    resource_orchestrator = std::make_unique<RenderResourceOrchestrator>(this, &get_device_state());
+    resource_orchestrator = std::make_unique<RenderResourceOrchestrator>(
+            this, &get_device_state(), &pipeline_features_effective, &pipeline_features_warning_cache);
     data_orchestrator = std::make_unique<RenderDataOrchestrator>(
             this,
             [this]() { _release_shared_dynamic_asset(); },
@@ -1448,29 +1442,6 @@ void GaussianSplatRenderer::_set_manual_viewport_format(RD::DataFormat p_format,
 void GaussianSplatRenderer::_set_active_viewport_format(RD::DataFormat p_format, const char *p_context) {
     (void)p_context;
     get_view_state().active_viewport_color_format = p_format;
-}
-
-void GaussianSplatRenderer::_update_pipeline_features(RenderingDevice *p_device) {
-    String warnings;
-    PipelineFeatureSet effective = g_pipeline_feature_set.get_effective(
-            p_device,
-            g_gpu_sorting_config.enable_compute_raster,
-            true,
-            &warnings);
-
-    if (!warnings.is_empty() && warnings != pipeline_features_warning_cache) {
-        GS_LOG_WARN_DEFAULT("[Pipeline Feature Set] Capability validation warnings:");
-        PackedStringArray lines = warnings.split("\n", false);
-        for (int i = 0; i < lines.size(); ++i) {
-            const String &line = lines[i];
-            if (!line.is_empty()) {
-                GS_LOG_WARN_DEFAULT(vformat("[Pipeline Feature Set] %s", line));
-            }
-        }
-    }
-
-    pipeline_features_warning_cache = warnings;
-    pipeline_features_effective = effective;
 }
 
 void GaussianSplatRenderer::_prepare_render_frame_context(RenderDataRD *p_render_data, const Transform3D &p_world_to_camera_transform,

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
@@ -528,15 +528,12 @@ public:
             GaussianSplatManager::ScopedSubmissionLock &r_lock) const;
     RenderingDevice *get_texture_owner_device(const RID &p_texture) const;
     RD::TextureFormat _get_texture_format(RenderingDevice *p_device, RID p_texture) const;
-    void _forget_resource_owner(const RID &p_rid);
     void _set_manual_viewport_format(RD::DataFormat p_format, const char *p_context);
     void _set_active_viewport_format(RD::DataFormat p_format, const char *p_context);
     void _free_owned_resource(RenderingDevice *p_fallback_device, RID &p_rid);
     // Removed: _upload_test_splats_to_gpu (dead code)
-    void _refresh_gpu_sorter(const char *p_context);
     // Removed: _flush_depth_submission (dead code)
     void _update_gpu_pass_metrics_from_tile_renderer();
-    void _update_pipeline_features(RenderingDevice *p_device);
     void _prepare_render_frame_context(RenderDataRD *p_render_data, const Transform3D &p_world_to_camera_transform,
             const Projection &p_projection, const Projection &p_render_projection, bool p_defer_render_buffers_commit,
             RenderFrameContext &r_context);
@@ -645,9 +642,9 @@ public:
     void track_resource_owner(const RID &p_rid, RenderingDevice *p_device, bool p_owned = true, const char *p_label = nullptr) {
         _track_resource_owner(p_rid, p_device, p_owned, p_label);
     }
-    void forget_resource_owner(const RID &p_rid) { _forget_resource_owner(p_rid); }
+    void forget_resource_owner(const RID &p_rid);
     void free_owned_resource(RenderingDevice *p_fallback_device, RID &p_rid) { _free_owned_resource(p_fallback_device, p_rid); }
-    void refresh_gpu_sorter(const char *p_context) { _refresh_gpu_sorter(p_context); }
+    void refresh_gpu_sorter(const char *p_context);
     void update_gpu_pass_metrics_from_tile_renderer() { _update_gpu_pass_metrics_from_tile_renderer(); }
     void update_debug_raster_metrics(const RasterPerformance &p_perf, const RasterStats &p_stats);
     void clear_debug_overlay_dirty_flags();
@@ -689,7 +686,7 @@ public:
     RD::TextureFormat get_texture_format(RenderingDevice *p_device, RID p_texture) const { return _get_texture_format(p_device, p_texture); }
     void set_manual_viewport_format(RD::DataFormat p_format, const char *p_context) { _set_manual_viewport_format(p_format, p_context); }
     void set_active_viewport_format(RD::DataFormat p_format, const char *p_context) { _set_active_viewport_format(p_format, p_context); }
-    void update_pipeline_features(RenderingDevice *p_device) { _update_pipeline_features(p_device); }
+    void update_pipeline_features(RenderingDevice *p_device);
     CullStageOutput cull_for_view(const Transform3D &p_world_to_camera_transform, const Projection &p_projection, const Size2i &p_viewport_size) {
         return _cull_for_view(p_world_to_camera_transform, p_projection, p_viewport_size);
     }

--- a/modules/gaussian_splatting/renderer/render_debug_state_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_debug_state_orchestrator.cpp
@@ -1238,7 +1238,7 @@ int GaussianSplatRenderer::get_debug_splat_audit_sample_count() const {
 void GaussianSplatRenderer::reload_pipeline_feature_set() {
 	g_pipeline_feature_set.load_from_project_settings();
 	pipeline_features_warning_cache = String();
-	_update_pipeline_features(get_device_state().rd);
+	update_pipeline_features(get_device_state().rd);
 }
 
 void GaussianSplatRenderer::set_jacobian_bypass_radius_depth_floor(bool p_enabled) {

--- a/modules/gaussian_splatting/renderer/render_device_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_device_orchestrator.cpp
@@ -200,6 +200,11 @@ void RenderDeviceOrchestrator::track_resource_owner(const RID &p_rid, RenderingD
 	device_manager->track_resource(p_rid, p_device, p_owned, p_label);
 }
 
+void RenderDeviceOrchestrator::forget_resource_owner(const RID &p_rid) {
+	ERR_FAIL_NULL_MSG(device_manager, "RenderDeviceManager not initialized");
+	device_manager->forget_resource(p_rid);
+}
+
 RenderingDevice *RenderDeviceOrchestrator::get_resource_owner(const RID &p_rid, RenderingDevice *p_fallback) const {
 	// Phase 8/C: Delegate to RenderDeviceManager (inline fallback removed)
 	if (device_manager) {
@@ -468,6 +473,10 @@ Dictionary GaussianSplatRenderer::_build_device_capability_report() const {
 
 void GaussianSplatRenderer::_track_resource_owner(const RID &p_rid, RenderingDevice *p_device, bool p_owned, const char *p_label) {
 	device_orchestrator->track_resource_owner(p_rid, p_device, p_owned, p_label);
+}
+
+void GaussianSplatRenderer::forget_resource_owner(const RID &p_rid) {
+	device_orchestrator->forget_resource_owner(p_rid);
 }
 
 RenderingDevice *GaussianSplatRenderer::_get_resource_owner(const RID &p_rid, RenderingDevice *p_fallback) const {

--- a/modules/gaussian_splatting/renderer/render_device_orchestrator.h
+++ b/modules/gaussian_splatting/renderer/render_device_orchestrator.h
@@ -27,6 +27,7 @@ public:
 	Dictionary build_device_capability_report() const;
 
 	void track_resource_owner(const RID &p_rid, RenderingDevice *p_device, bool p_owned, const char *p_label);
+	void forget_resource_owner(const RID &p_rid);
 	RenderingDevice *get_resource_owner(const RID &p_rid, RenderingDevice *p_fallback) const;
 	RenderingDevice *get_texture_owner_device(const RID &p_texture) const;
 	RenderingDevice *acquire_submission_device_for(RenderingDevice *p_device,

--- a/modules/gaussian_splatting/renderer/render_resource_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_resource_orchestrator.cpp
@@ -12,11 +12,17 @@
 #include <cstring>
 
 RenderResourceOrchestrator::RenderResourceOrchestrator(GaussianSplatRenderer *p_renderer,
-		GaussianSplatRenderer::DeviceState *p_device_state) :
+		GaussianSplatRenderer::DeviceState *p_device_state,
+		PipelineFeatureSet *p_pipeline_features_effective,
+		String *p_pipeline_features_warning_cache) :
 		renderer(p_renderer),
-		device_state(p_device_state) {
+		device_state(p_device_state),
+		pipeline_features_effective(p_pipeline_features_effective),
+		pipeline_features_warning_cache(p_pipeline_features_warning_cache) {
 	ERR_FAIL_NULL(renderer);
 	ERR_FAIL_NULL(device_state);
+	ERR_FAIL_NULL(pipeline_features_effective);
+	ERR_FAIL_NULL(pipeline_features_warning_cache);
 	resource_state.gpu_resources_initialized = false;
 	resource_state.gpu_initialization_pending = false;
 	resource_state.buffer_manager.instantiate();
@@ -451,6 +457,32 @@ void RenderResourceOrchestrator::create_gpu_resources_safe() {
 	}
 }
 
+void RenderResourceOrchestrator::update_pipeline_features(RenderingDevice *p_device) {
+	ERR_FAIL_NULL(pipeline_features_effective);
+	ERR_FAIL_NULL(pipeline_features_warning_cache);
+
+	String warnings;
+	PipelineFeatureSet effective = g_pipeline_feature_set.get_effective(
+			p_device,
+			g_gpu_sorting_config.enable_compute_raster,
+			true,
+			&warnings);
+
+	if (!warnings.is_empty() && warnings != *pipeline_features_warning_cache) {
+		GS_LOG_WARN_DEFAULT("[Pipeline Feature Set] Capability validation warnings:");
+		PackedStringArray lines = warnings.split("\n", false);
+		for (int i = 0; i < lines.size(); ++i) {
+			const String &line = lines[i];
+			if (!line.is_empty()) {
+				GS_LOG_WARN_DEFAULT(vformat("[Pipeline Feature Set] %s", line));
+			}
+		}
+	}
+
+	*pipeline_features_warning_cache = warnings;
+	*pipeline_features_effective = effective;
+}
+
 void RenderResourceOrchestrator::update_gpu_pass_metrics_from_tile_renderer() {
 	if (!renderer->get_tile_renderer_state().renderer.is_valid()) {
 		renderer->get_performance_state().metrics.gpu_tile_binning_time_ms = 0.0f;
@@ -590,6 +622,10 @@ void GaussianSplatRenderer::_create_gpu_resources_safe() {
 
 void GaussianSplatRenderer::_update_gpu_pass_metrics_from_tile_renderer() {
 	resource_orchestrator->update_gpu_pass_metrics_from_tile_renderer();
+}
+
+void GaussianSplatRenderer::update_pipeline_features(RenderingDevice *p_device) {
+	resource_orchestrator->update_pipeline_features(p_device);
 }
 
 RID GaussianSplatRenderer::_load_graphics_shader(const Vector<String> &p_vertex_paths,

--- a/modules/gaussian_splatting/renderer/render_resource_orchestrator.h
+++ b/modules/gaussian_splatting/renderer/render_resource_orchestrator.h
@@ -5,7 +5,8 @@
 
 class RenderResourceOrchestrator {
 public:
-	RenderResourceOrchestrator(GaussianSplatRenderer *p_renderer, GaussianSplatRenderer::DeviceState *p_device_state);
+	RenderResourceOrchestrator(GaussianSplatRenderer *p_renderer, GaussianSplatRenderer::DeviceState *p_device_state,
+			PipelineFeatureSet *p_pipeline_features_effective, String *p_pipeline_features_warning_cache);
 
 	GaussianSplatRenderer::PipelineState &get_pipeline_state() { return pipeline_state; }
 	const GaussianSplatRenderer::PipelineState &get_pipeline_state() const { return pipeline_state; }
@@ -16,12 +17,15 @@ public:
 	void create_gpu_resources_safe();
 	RID load_graphics_shader(const Vector<String> &p_vertex_paths, const Vector<String> &p_fragment_paths);
 	void update_gpu_pass_metrics_from_tile_renderer();
+	void update_pipeline_features(RenderingDevice *p_device);
 
 private:
 	GaussianSplatRenderer::PipelineState pipeline_state;
 	GaussianSplatRenderer::ResourceState resource_state;
 	GaussianSplatRenderer *renderer = nullptr;
 	GaussianSplatRenderer::DeviceState *device_state = nullptr;
+	PipelineFeatureSet *pipeline_features_effective = nullptr;
+	String *pipeline_features_warning_cache = nullptr;
 };
 
 #endif

--- a/modules/gaussian_splatting/renderer/render_sorting_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_sorting_orchestrator.cpp
@@ -1336,7 +1336,7 @@ void RenderSortingOrchestrator::force_sort_for_view(const Transform3D &p_world_t
 	(void)sort_gaussians_for_view(view_transform, cull_output.visible_domain);
 }
 
-void GaussianSplatRenderer::_refresh_gpu_sorter(const char *p_context) {
+void GaussianSplatRenderer::refresh_gpu_sorter(const char *p_context) {
 	sorting_orchestrator->refresh_gpu_sorter(p_context);
 }
 


### PR DESCRIPTION
## Summary
- Move 3 facade helpers to their natural orchestrator owners:
  - `_forget_resource_owner` → `RenderDeviceOrchestrator::forget_resource_owner`
  - `_refresh_gpu_sorter` → `RenderSortingOrchestrator::refresh_gpu_sorter`
  - `_update_pipeline_features` → `RenderResourceOrchestrator::update_pipeline_features`
- Orchestrators use existing back-reference pattern (no PIMPL, no new service locator)
- Public facade methods now delegate to orchestrators

Partial #58

## Test plan
- [x] Guard suite passed
- [x] Windows build clean
- [x] Module tests: 144 tests, 4066 assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)