### PR TITLE
fix(ci): add fetch-depth: 0 to Linux CPU-only checkout

### DIFF
--- a/.github/workflows/baseline_qa.yml
+++ b/.github/workflows/baseline_qa.yml
@@ -187,6 +187,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
+        fetch-depth: 0
         submodules: recursive
 
     - name: Setup Python


### PR DESCRIPTION
## Summary
- The Linux CPU-only job in `baseline_qa.yml` defaulted to `fetch-depth: 1` (shallow clone)
- This caused `run_module_tests.py` renderer guard to fail — it couldn't resolve any git base ref (`HEAD~1`, `origin/master`, etc. are all missing in a shallow clone)
- All other CI checkout steps already use `fetch-depth: 0`; this aligns the Linux job

## Root cause
PR #128 (develop → master) CI failure: "Module Test Suite (GaussianSplatting)" exits with code 1 in 0.2s because the renderer guard returns "Unable to determine git base ref for renderer guard in CI."

## Test plan
- [ ] Merge this, then re-run CI on PR #128 — the "CPU-Only QA Tests (Linux)" job should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)