### PR TITLE
Add demo video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Godot Gaussian Splatting
 
+<video src="media/demo.webm" autoplay loop muted playsinline></video>
+
 GodotGS is a Godot 4.5 fork with an in-tree Gaussian Splatting module.
 
 ## Start Here

--- a/media/demo.webm
+++ b/media/demo.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e46a52786dec3a98c90cbdba8bbdfcda09148a53423071ec00e5b665b15774a
+size 2823082


### PR DESCRIPTION
## Summary
- Convert screen recording (MP4, 20MB) to WebM VP9 (2.7MB) for efficient repo storage
- Embed video at the top of README with autoplay/loop/muted for a seamless first impression
- Store video asset in new `media/` directory

## Test plan
- [ ] Verify video renders and autoplays on the GitHub repo page
- [ ] Confirm video loops silently without user interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)