### PR TITLE
Fix README demo video playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Godot Gaussian Splatting
 
-<video src="media/demo.mp4" autoplay loop muted playsinline></video>
+https://github.com/user-attachments/assets/71542f8d-ccf6-433c-b920-66fdf9ae8c84
 
 GodotGS is a Godot 4.5 fork with an in-tree Gaussian Splatting module.
 

--- a/media/demo.webm
+++ b/media/demo.webm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2e46a52786dec3a98c90cbdba8bbdfcda09148a53423071ec00e5b665b15774a
-size 2823082


### PR DESCRIPTION
## Summary
- GitHub doesn't render `<video>` tags with relative `src` paths — the video from PR #148 doesn't play
- Replace with GitHub CDN attachment URL so the video plays inline
- Remove the now-unnecessary `media/demo.webm` from the repo

## Test plan
- [ ] Verify video plays inline on the repo README page after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)