### PR TITLE
gaussian: free inspector settings object on dialog teardown

### DIFF
--- a/modules/gaussian_splatting/editor/gaussian_import_settings_dialog.cpp
+++ b/modules/gaussian_splatting/editor/gaussian_import_settings_dialog.cpp
@@ -227,6 +227,16 @@ GaussianImportSettingsDialog::GaussianImportSettingsDialog() {
 	_build_ui();
 }
 
+GaussianImportSettingsDialog::~GaussianImportSettingsDialog() {
+	if (settings_data) {
+		memdelete(settings_data);
+		settings_data = nullptr;
+	}
+	if (singleton == this) {
+		singleton = nullptr;
+	}
+}
+
 // ---------------------------------------------------------------------------
 // UI construction
 // ---------------------------------------------------------------------------

--- a/modules/gaussian_splatting/editor/gaussian_import_settings_dialog.h
+++ b/modules/gaussian_splatting/editor/gaussian_import_settings_dialog.h
@@ -101,6 +101,7 @@ public:
 	static GaussianImportSettingsDialog *get_singleton();
 
 	GaussianImportSettingsDialog();
+	~GaussianImportSettingsDialog();
 };
 
 #endif // TOOLS_ENABLED


### PR DESCRIPTION
### Motivation
- Prevent leaking the `GaussianImportSettingsData` inspector backing object when the advanced import dialog is created and destroyed repeatedly (for example during editor/plugin reload), and ensure the dialog singleton pointer is cleared on teardown.

### Description
- Add a destructor declaration to `GaussianImportSettingsDialog` and implement `GaussianImportSettingsDialog::~GaussianImportSettingsDialog()` to `memdelete(settings_data)`, null the pointer, and reset the `singleton` when destroying the active instance.

### Testing
- Verified changes and local diffs with `git status --short` and `git diff -- modules/gaussian_splatting/editor/gaussian_import_settings_dialog.*` and inspected the modified lines with `nl -ba modules/gaussian_splatting/editor/gaussian_import_settings_dialog.* | sed -n '214,255p'`, all showing the intended destructor and cleanup code were added successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c28baa8c5c83238567b153705e88ce)