### PR TITLE
refactor(renderer): add const query provider for diagnostics

### DIFF
--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
@@ -2134,6 +2134,12 @@ GaussianSplatRenderer::SortingState &GaussianSplatRenderer::get_sorting_state() 
     return sorting_orchestrator->access_sorting_state_mutable();
 }
 
+const GaussianSplatRenderer::SortingState &GaussianSplatRenderer::get_sorting_state() const {
+    static const SortingState fallback;
+    ERR_FAIL_NULL_V(sorting_orchestrator, fallback);
+    return sorting_orchestrator->get_sorting_state();
+}
+
 GaussianSplatRenderer::StreamingState &GaussianSplatRenderer::get_streaming_state() {
     static StreamingState fallback;
     ERR_FAIL_NULL_V(data_orchestrator, fallback);

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
@@ -647,6 +647,7 @@ public:
     TestDataState &get_test_data_state() { return test_data_state; }
     const TestDataState &get_test_data_state() const { return test_data_state; }
     SortingState &get_sorting_state();
+    const SortingState &get_sorting_state() const;
     ViewState &get_view_state() { return frame_context_manager.get_view_state(); }
     const ViewState &get_view_state() const { return frame_context_manager.get_view_state(); }
     TileRendererState &get_tile_renderer_state() { return tile_renderer_state; }
@@ -659,6 +660,7 @@ public:
     SubsystemState &get_subsystem_state() { return subsystem_state; }
     const SubsystemState &get_subsystem_state() const { return subsystem_state; }
     JacobianDebugConfig &get_jacobian_debug() { return jacobian_debug; }
+    const JacobianDebugConfig &get_jacobian_debug() const { return jacobian_debug; }
     void set_instance_pipeline_buffers(const InstancePipelineBuffers &p_buffers);
     void clear_instance_pipeline_buffers();
     bool has_instance_pipeline_buffers() const { return instance_pipeline_buffers_valid; }

--- a/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.cpp
@@ -883,6 +883,7 @@ Dictionary RenderDiagnosticsOrchestrator::serialize_error_statistics() const {
 Dictionary RenderDiagnosticsOrchestrator::build_render_stats() const {
 	Dictionary stats;
 	const GaussianSplatRenderer *const_renderer = renderer;
+	GaussianSplatRenderer *mutable_renderer = renderer;
 	GaussianSplatRenderer::FrameStateProvider state_provider(const_renderer);
 	const GaussianSplatRenderer::IFrameStateView &state_view = state_provider;
 	const auto &frame_state = state_view.get_frame_state_view();


### PR DESCRIPTION
## Summary
- add a const-renderer `FrameStateProvider` constructor for query-only access
- route diagnostics/monitor query paths through the const view provider
- remove the remaining `const_cast<GaussianSplatRenderer *>` usage from `get_monitor_streaming_snapshot()` and diagnostics query assembly

## Scope
This patch is intentionally query-only. It does not narrow the mutable service pointers exposed by `IFrameStateView`, and it does not redesign the mixed query/mutation behavior around overlay/HUD cache refresh in `build_render_stats()`.

## Test plan
- [x] `git diff --check`
- [x] `python3 tests/ci/run_module_tests.py --guard-only`
- [ ] Windows `Gaussian Production Gates`
