### PR TITLE
fix: correctness stabilization for gaussian splatting module

### DIFF
--- a/modules/gaussian_splatting/core/gaussian_data.h
+++ b/modules/gaussian_splatting/core/gaussian_data.h
@@ -127,6 +127,24 @@ struct GaussianData {
  * @note Must remain 16-byte aligned (144 bytes total). Do not reorder fields
  *       without updating the corresponding GLSL struct definition.
  */
+enum GaussianDCEncoding : uint32_t {
+    GAUSSIAN_DC_ENCODING_LEGACY_BIAS = 0u,
+    GAUSSIAN_DC_ENCODING_LINEAR_RGB = 1u,
+};
+
+static constexpr uint32_t GAUSSIAN_RENDER_META_DC_ENCODING_MASK = 0x1u;
+
+constexpr uint32_t gaussian_set_dc_encoding(uint32_t p_render_meta, GaussianDCEncoding p_encoding) {
+    return (p_render_meta & ~GAUSSIAN_RENDER_META_DC_ENCODING_MASK) |
+            (uint32_t(p_encoding) & GAUSSIAN_RENDER_META_DC_ENCODING_MASK);
+}
+
+constexpr GaussianDCEncoding gaussian_get_dc_encoding(uint32_t p_render_meta) {
+    return (p_render_meta & GAUSSIAN_RENDER_META_DC_ENCODING_MASK) != 0u
+            ? GAUSSIAN_DC_ENCODING_LINEAR_RGB
+            : GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
+}
+
 struct Gaussian {
     Vector3 position;
     float opacity;
@@ -151,8 +169,9 @@ struct Gaussian {
     Vector2 brush_axes;
     uint32_t painterly_meta; // lower 16 bits: palette id, upper 16 bits: painterly flags / brush override ids
 
-    // Final padding to reach 144 bytes (16-byte aligned)
-    float _padding2[3]; // 12 bytes to reach 144 total
+    // Render metadata and final padding to reach 144 bytes.
+    uint32_t render_meta = 0; // lower bit stores GaussianDCEncoding
+    float _padding2[2] = { 0.0f, 0.0f };
 };
 
 static_assert(sizeof(Gaussian) % 16 == 0, "Gaussian struct must remain 16-byte aligned for GPU uploads");

--- a/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
@@ -1,12 +1,42 @@
 #include "gaussian_splat_asset.h"
 #include "../io/gaussian_data_loader.h"
+#include "../io/ply_loader.h"
+#include "../io/spz_loader.h"
 #include "../core/gaussian_data.h"
 #include "core/error/error_macros.h"
 #include "core/io/file_access.h"
 #include "core/math/basis.h"
 #include "core/math/math_funcs.h"
 #include "core/math/quaternion.h"
+#include "core/os/os.h"
 #include "../logger/gs_logger.h"
+
+namespace {
+
+static double _elapsed_msec(uint64_t p_start_usec) {
+	const uint64_t now = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : p_start_usec;
+	return double(now - p_start_usec) / 1000.0;
+}
+
+static Dictionary _build_runtime_load_timing(const String &p_stage,
+		bool p_cache_hit,
+		double p_source_ms,
+		double p_materialize_ms,
+		double p_total_ms,
+		const Dictionary &p_source_stats) {
+	Dictionary timing;
+	timing[StringName("stage")] = p_stage;
+	timing[StringName("cache_hit")] = p_cache_hit;
+	timing[StringName("source_stage_ms")] = p_source_ms;
+	timing[StringName("asset_materialization_ms")] = p_materialize_ms;
+	timing[StringName("total_load_ms")] = p_total_ms;
+	if (!p_source_stats.is_empty()) {
+		timing[StringName("source_stats")] = p_source_stats;
+	}
+	return timing;
+}
+
+} // namespace
 
 uint32_t GaussianSplatAsset::instance_count = 0;
 
@@ -884,42 +914,116 @@ Error GaussianSplatAsset::load_from_file(const String &p_path) {
         return ERR_FILE_NOT_FOUND;
     }
 
-    GaussianDataLoadResult load_result;
-    Error err = load_gaussian_data_from_file(p_path, load_result);
-    if (err != OK) {
-        GS_LOG_ERROR_DEFAULT("Failed to load splat file: " + p_path);
-        return err;
-    }
+	uint64_t total_start_usec = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : 0;
+	uint64_t source_start_usec = total_start_usec;
 
-    if (load_result.used_ply) {
-        if (!load_result.missing_optional.is_empty()) {
-            for (int i = 0; i < load_result.missing_optional.size(); i++) {
-                GS_LOG_STREAMING_DEBUG(vformat("PLY load: missing optional data %s", load_result.missing_optional[i]));
-            }
-        }
+	Ref<::GaussianData> gaussian_data;
+	PackedStringArray missing_required;
+	PackedStringArray missing_optional;
+	Dictionary source_stats;
+	String file_label = p_path.get_extension().to_upper();
+	String source_stage = "raw";
+	bool cache_hit = false;
 
-        if (!load_result.missing_required.is_empty()) {
-            String missing_required_text;
-            for (int i = 0; i < load_result.missing_required.size(); i++) {
-                if (i > 0) {
-                    missing_required_text += ", ";
-                }
-                missing_required_text += load_result.missing_required[i];
-            }
-            GS_LOG_ERROR_DEFAULT(vformat("PLY file missing required properties: %s", missing_required_text));
-            return ERR_FILE_CORRUPT;
-        }
-    }
+	const String extension = p_path.get_extension().to_lower();
+	Error err = OK;
+	if (extension == "ply") {
+		Ref<PLYLoader> ply_loader;
+		ply_loader.instantiate();
 
-    Ref<::GaussianData> gaussian_data = load_result.data;
-    Error populate_err = populate_from_gaussian_data(gaussian_data);
-    if (populate_err != OK) {
-        return populate_err;
-    }
+		err = ply_loader->load_file(p_path);
+		if (err == OK) {
+			ply_loader->get_property_deficiencies(missing_required, missing_optional);
+			source_stats = ply_loader->get_load_statistics();
+			cache_hit = source_stats.get(StringName("cache_hit"), false);
+			source_stage = cache_hit ? "cache" : "raw";
+			gaussian_data = ply_loader->get_gaussian_data();
+			file_label = "PLY";
+		}
+	} else if (extension == "spz") {
+		Ref<SPZLoader> spz_loader;
+		spz_loader.instantiate();
 
-    const String file_label = load_result.used_spz ? "SPZ" : "PLY";
-    GS_LOG_STREAMING_INFO(vformat("Loaded %s file: %d splats from %s", file_label, splat_count, p_path));
-    return OK;
+		err = spz_loader->load_file(p_path);
+		if (err == OK) {
+			source_stats = spz_loader->get_load_statistics();
+			gaussian_data = spz_loader->get_gaussian_data();
+			file_label = "SPZ";
+			source_stage = "raw";
+		}
+	} else {
+		GaussianDataLoadResult load_result;
+		err = load_gaussian_data_from_file(p_path, load_result);
+		if (err == OK) {
+			gaussian_data = load_result.data;
+			missing_required = load_result.missing_required;
+			missing_optional = load_result.missing_optional;
+			file_label = load_result.used_spz ? "SPZ" : "PLY";
+			source_stage = "raw";
+		}
+	}
+
+	if (err != OK) {
+		GS_LOG_ERROR_DEFAULT("Failed to load splat file: " + p_path);
+		return err;
+	}
+
+	if (file_label == "PLY") {
+		if (!missing_optional.is_empty()) {
+			for (int i = 0; i < missing_optional.size(); i++) {
+				GS_LOG_STREAMING_DEBUG(vformat("PLY load: missing optional data %s", missing_optional[i]));
+			}
+		}
+
+		if (!missing_required.is_empty()) {
+			String missing_required_text;
+			for (int i = 0; i < missing_required.size(); i++) {
+				if (i > 0) {
+					missing_required_text += ", ";
+				}
+				missing_required_text += missing_required[i];
+			}
+			GS_LOG_ERROR_DEFAULT(vformat("PLY file missing required properties: %s", missing_required_text));
+			return ERR_FILE_CORRUPT;
+		}
+	}
+
+	if (gaussian_data.is_null() || gaussian_data->get_count() <= 0) {
+		GS_LOG_ERROR_DEFAULT("Loaded splat file produced no Gaussian data: " + p_path);
+		return ERR_FILE_CORRUPT;
+	}
+
+	const double source_stage_ms = _elapsed_msec(source_start_usec);
+
+	uint64_t materialize_start_usec = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : source_start_usec;
+	Error populate_err = populate_from_gaussian_data(gaussian_data);
+	const double materialize_ms = _elapsed_msec(materialize_start_usec);
+	if (populate_err != OK) {
+		return populate_err;
+	}
+
+	// Preserve the authoritative GaussianData loaded from disk so later bootstrap
+	// does not reconstruct it from the asset arrays.
+	gaussian_data_cache = gaussian_data;
+
+	const double total_load_ms = _elapsed_msec(total_start_usec);
+	import_metadata[StringName("runtime_load_timing")] = _build_runtime_load_timing(
+			source_stage, cache_hit, source_stage_ms, materialize_ms, total_load_ms, source_stats);
+	import_metadata[StringName("runtime_load_source")] = source_stage;
+	import_metadata[StringName("runtime_load_cache_hit")] = cache_hit;
+	import_metadata[StringName("runtime_load_source_path")] = p_path;
+
+	GS_LOG_STREAMING_INFO(vformat(
+			"[LoadTiming][GaussianSplatAsset] file=%s path=%s splats=%d source_stage=%s cache_hit=%s source_ms=%.2f materialize_ms=%.2f total_ms=%.2f",
+			file_label,
+			p_path,
+			splat_count,
+			source_stage,
+			cache_hit ? "yes" : "no",
+			source_stage_ms,
+			materialize_ms,
+			total_load_ms));
+	return OK;
 }
 
 Error GaussianSplatAsset::save_to_file(const String &p_path) const {
@@ -939,11 +1043,17 @@ Ref<::GaussianData> GaussianSplatAsset::get_gaussian_data() const {
     }
 
     Ref<::GaussianData> data;
+    uint64_t rebuild_start_usec = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : 0;
     if (!populate_gaussian_data(data)) {
         return Ref<::GaussianData>();
     }
 
     gaussian_data_cache = data;
+    const double rebuild_ms = _elapsed_msec(rebuild_start_usec);
+    GS_LOG_STREAMING_INFO(vformat(
+            "[LoadTiming][GaussianSplatAsset] rebuilt GaussianData from asset arrays: splats=%d rebuild_ms=%.2f",
+            splat_count,
+            rebuild_ms));
     return gaussian_data_cache;
 }
 
@@ -971,6 +1081,18 @@ bool GaussianSplatAsset::populate_gaussian_data(Ref<::GaussianData> &r_data) con
     Dictionary asset_metadata = get_import_metadata();
     if (asset_metadata.has(StringName("gaussian_2d_mode"))) {
         r_data->set_2d_mode((bool)asset_metadata[StringName("gaussian_2d_mode")]);
+    }
+    if (asset_metadata.has(StringName("dc_encoding"))) {
+        const String dc_encoding = String(asset_metadata[StringName("dc_encoding")]).to_lower();
+        GaussianDCEncoding staged_dc_encoding = GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
+        if (dc_encoding == "linear_rgb") {
+            staged_dc_encoding = GAUSSIAN_DC_ENCODING_LINEAR_RGB;
+        }
+        for (int i = 0; i < r_data->get_count(); i++) {
+            Gaussian g = r_data->get_gaussian(i);
+            g.render_meta = gaussian_set_dc_encoding(g.render_meta, staged_dc_encoding);
+            r_data->set_gaussian(i, g);
+        }
     }
 
     return true;
@@ -1028,9 +1150,19 @@ Error GaussianSplatAsset::populate_from_gaussian_data(const Ref<::GaussianData> 
     bool bounds_initialized = false;
     Vector3 min_pos;
     Vector3 max_pos;
+    GaussianDCEncoding asset_dc_encoding = GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
+    bool asset_dc_encoding_initialized = false;
+    bool mixed_dc_encoding = false;
 
     for (int i = 0; i < count; i++) {
         Gaussian g = p_gaussian_data->get_gaussian(i);
+        GaussianDCEncoding gaussian_dc_encoding = gaussian_get_dc_encoding(g.render_meta);
+        if (!asset_dc_encoding_initialized) {
+            asset_dc_encoding = gaussian_dc_encoding;
+            asset_dc_encoding_initialized = true;
+        } else if (asset_dc_encoding != gaussian_dc_encoding) {
+            mixed_dc_encoding = true;
+        }
         const uint32_t base3 = uint32_t(i) * 3u;
         const uint32_t base4 = uint32_t(i) * 4u;
         const int first_base = i * int(sh_first_order_terms) * 3;
@@ -1146,6 +1278,13 @@ Error GaussianSplatAsset::populate_from_gaussian_data(const Ref<::GaussianData> 
     import_metadata[StringName("sh_first_order_terms")] = (int)sh_first_order_terms;
     import_metadata[StringName("sh_high_order_terms")] = (int)sh_high_order_terms;
     import_metadata[StringName("sh_degree")] = (int)p_gaussian_data->get_sh_degree();
+    if (asset_dc_encoding_initialized && !mixed_dc_encoding) {
+        import_metadata[StringName("dc_encoding")] = asset_dc_encoding == GAUSSIAN_DC_ENCODING_LINEAR_RGB
+                ? String("linear_rgb")
+                : String("legacy_bias");
+    } else {
+        import_metadata.erase(StringName("dc_encoding"));
+    }
     import_metadata[StringName("has_normals")] = normals.size() == splat_count * 3;
     import_metadata[StringName("has_palette_ids")] = palette_ids.size() == splat_count;
     import_metadata[StringName("has_painterly_flags")] = painterly_flags.size() == splat_count;

--- a/modules/gaussian_splatting/core/gaussian_splat_merge_utils.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_merge_utils.cpp
@@ -22,6 +22,23 @@ static Quaternion _safe_quaternion_from_asset(const TypedArray<Quaternion> &p_ro
     return Quaternion();
 }
 
+static GaussianDCEncoding _resolve_asset_dc_encoding(const Ref<GaussianSplatAsset> &p_asset) {
+    if (p_asset.is_null()) {
+        return GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
+    }
+
+    const Dictionary import_metadata = p_asset->get_import_metadata();
+    if (!import_metadata.has(StringName("dc_encoding"))) {
+        return GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
+    }
+
+    const String dc_encoding = String(import_metadata[StringName("dc_encoding")]).to_lower();
+    if (dc_encoding == "linear_rgb") {
+        return GAUSSIAN_DC_ENCODING_LINEAR_RGB;
+    }
+    return GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
+}
+
 static void _rebuild_chunk_cache(const Ref<GaussianData> &p_data, float p_chunk_size,
         Vector<GaussianSplatRenderer::StaticChunk> &r_chunks, AABB &r_bounds) {
     r_chunks.clear();
@@ -263,6 +280,7 @@ bool gaussian_splat_merge_sources(const Vector<GaussianSplatMergeSource> &source
         Basis rotation_basis = basis.orthonormalized();
         Quaternion world_rotation = rotation_basis.get_rotation_quaternion();
         Vector3 world_scale = basis.get_scale_abs();
+        const GaussianDCEncoding source_dc_encoding = _resolve_asset_dc_encoding(asset);
 
         for (uint32_t splat = 0; splat < splat_count; splat++) {
             const uint32_t target_index = write_offset + splat;
@@ -306,6 +324,10 @@ bool gaussian_splat_merge_sources(const Vector<GaussianSplatMergeSource> &source
             } else {
                 merged_bounds = merged_bounds.merge(splat_bounds);
             }
+
+            Gaussian g = merged_data->get_gaussian((int)target_index);
+            g.render_meta = gaussian_set_dc_encoding(g.render_meta, source_dc_encoding);
+            merged_data->set_gaussian((int)target_index, g);
         }
 
         if (source.is_2d) {

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -74,7 +74,10 @@ GaussianSplatSceneDirector::SharedWorld *GaussianSplatSceneDirector::_get_or_cre
 			static bool warned_missing_device = false;
 			if (!warned_missing_device) {
 				warned_missing_device = true;
-				GS_LOG_RENDERER_ERROR("[GaussianSplatSceneDirector] Unable to acquire local RenderingDevice for shared renderer");
+				GS_LOG_RENDERER_ERROR(
+						"[GaussianSplatSceneDirector] Unable to acquire primary RenderingDevice for shared renderer (scenario=" +
+						String::num_uint64((uint64_t)scenario.get_id()) +
+						"). Gaussian splat instances in this world will be collected but skipped because no renderer can be attached.");
 			}
 			return entry;
 		}
@@ -248,8 +251,9 @@ void GaussianSplatSceneDirector::_release_asset_record(SharedWorld &p_world, uin
 
 
 void GaussianSplatSceneDirector::register_instance(ObjectID p_node_id, const Ref<GaussianSplatAsset> &p_asset,
-        const Transform3D &p_transform, float p_opacity, float p_lod_bias, uint32_t p_flags,
-        float p_wind_intensity, uint32_t p_wind_mode, const Vector3 &p_wind_direction, float p_wind_frequency) {
+        const Transform3D &p_transform, float p_opacity, float p_lod_bias, uint32_t p_flags, bool p_casts_shadow,
+        float p_wind_intensity, uint32_t p_wind_mode, const Vector3 &p_wind_direction, float p_wind_frequency,
+        bool p_visible) {
 	MutexLock lock(world_mutex);
 	SharedWorld *world = _get_world_for_instance(p_node_id);
 	if (!world) {
@@ -297,6 +301,14 @@ void GaussianSplatSceneDirector::register_instance(ObjectID p_node_id, const Ref
 		}
 		if (record.flags != p_flags) {
 			record.flags = p_flags;
+			dirty = true;
+		}
+		if (record.casts_shadow != p_casts_shadow) {
+			record.casts_shadow = p_casts_shadow;
+			dirty = true;
+		}
+		if (record.visible != p_visible) {
+			record.visible = p_visible;
 			dirty = true;
 		}
 		if (!Math::is_equal_approx(record.wind_intensity, wind_intensity)) {
@@ -358,6 +370,8 @@ void GaussianSplatSceneDirector::register_instance(ObjectID p_node_id, const Ref
 	record.asset_id = asset_id;
 	record.flags = p_flags;
 	record.last_lod = 0;
+	record.casts_shadow = p_casts_shadow;
+	record.visible = p_visible;
 	record.dirty = true;
 
 	world->instance_lookup[p_node_id] = world->instances.size();
@@ -393,8 +407,8 @@ void GaussianSplatSceneDirector::update_instance_transform(ObjectID p_node_id, c
 }
 
 void GaussianSplatSceneDirector::update_instance_params(ObjectID p_node_id, float p_opacity, float p_lod_bias,
-		uint32_t p_flags, float p_wind_intensity, uint32_t p_wind_mode,
-		const Vector3 &p_wind_direction, float p_wind_frequency) {
+		uint32_t p_flags, bool p_casts_shadow, float p_wind_intensity, uint32_t p_wind_mode,
+		const Vector3 &p_wind_direction, float p_wind_frequency, bool p_visible) {
 	MutexLock lock(world_mutex);
 	SharedWorld *world = _get_world_for_instance(p_node_id);
 	if (!world) {
@@ -424,6 +438,14 @@ void GaussianSplatSceneDirector::update_instance_params(ObjectID p_node_id, floa
 	}
 	if (record.flags != p_flags) {
 		record.flags = p_flags;
+		dirty = true;
+	}
+	if (record.casts_shadow != p_casts_shadow) {
+		record.casts_shadow = p_casts_shadow;
+		dirty = true;
+	}
+	if (record.visible != p_visible) {
+		record.visible = p_visible;
 		dirty = true;
 	}
 	if (!Math::is_equal_approx(record.wind_intensity, wind_intensity)) {
@@ -506,8 +528,8 @@ void GaussianSplatSceneDirector::update_instance_lods(const Vector3 &p_camera_po
 			}
 			if (desired_lod == static_cast<int>(current_lod)) {
 				if (log_enabled) {
-					GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%llu asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (no change)",
-							(uint64_t)record.node_id, record.asset_id, distance, bias, effective_distance, current_lod, desired_lod));
+					GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (no change)",
+							String::num_uint64((uint64_t)record.node_id), record.asset_id, distance, bias, effective_distance, current_lod, desired_lod));
 				}
 				continue;
 			}
@@ -517,8 +539,8 @@ void GaussianSplatSceneDirector::update_instance_lods(const Vector3 &p_camera_po
 				const float zone = use_fallback ? MAX(0.5f, 0.05f * threshold) : p_hysteresis_zone;
 				if (effective_distance < threshold + zone) {
 					if (log_enabled) {
-						GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%llu asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (hold-up)",
-								(uint64_t)record.node_id, record.asset_id, distance, bias, effective_distance, current_lod, desired_lod));
+						GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (hold-up)",
+								String::num_uint64((uint64_t)record.node_id), record.asset_id, distance, bias, effective_distance, current_lod, desired_lod));
 					}
 					continue;
 				}
@@ -527,8 +549,8 @@ void GaussianSplatSceneDirector::update_instance_lods(const Vector3 &p_camera_po
 				const float zone = use_fallback ? MAX(0.5f, 0.05f * threshold) : p_hysteresis_zone;
 				if (effective_distance > threshold - zone) {
 					if (log_enabled) {
-						GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%llu asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (hold-down)",
-								(uint64_t)record.node_id, record.asset_id, distance, bias, effective_distance, current_lod, desired_lod));
+						GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (hold-down)",
+								String::num_uint64((uint64_t)record.node_id), record.asset_id, distance, bias, effective_distance, current_lod, desired_lod));
 					}
 					continue;
 				}
@@ -538,8 +560,8 @@ void GaussianSplatSceneDirector::update_instance_lods(const Vector3 &p_camera_po
 			record.dirty = true;
 			any_changed = true;
 			if (log_enabled) {
-				GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%llu asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u -> %u",
-						(uint64_t)record.node_id, record.asset_id, distance, bias, effective_distance,
+				GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u -> %u",
+						String::num_uint64((uint64_t)record.node_id), record.asset_id, distance, bias, effective_distance,
 						current_lod, record.last_lod));
 			}
 		}
@@ -579,8 +601,8 @@ void GaussianSplatSceneDirector::update_instance_lods_for_renderer(const Gaussia
 		}
 		if (desired_lod == static_cast<int>(current_lod)) {
 			if (log_enabled) {
-				GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%llu asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (no change)",
-						(uint64_t)record.node_id, record.asset_id, distance, bias, effective_distance, current_lod, desired_lod));
+				GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (no change)",
+						String::num_uint64((uint64_t)record.node_id), record.asset_id, distance, bias, effective_distance, current_lod, desired_lod));
 			}
 			continue;
 		}
@@ -590,8 +612,8 @@ void GaussianSplatSceneDirector::update_instance_lods_for_renderer(const Gaussia
 			const float zone = use_fallback ? MAX(0.5f, 0.05f * threshold) : p_hysteresis_zone;
 			if (effective_distance < threshold + zone) {
 				if (log_enabled) {
-					GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%llu asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (hold-up)",
-							(uint64_t)record.node_id, record.asset_id, distance, bias, effective_distance, current_lod, desired_lod));
+					GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (hold-up)",
+							String::num_uint64((uint64_t)record.node_id), record.asset_id, distance, bias, effective_distance, current_lod, desired_lod));
 				}
 				continue;
 			}
@@ -600,8 +622,8 @@ void GaussianSplatSceneDirector::update_instance_lods_for_renderer(const Gaussia
 			const float zone = use_fallback ? MAX(0.5f, 0.05f * threshold) : p_hysteresis_zone;
 			if (effective_distance > threshold - zone) {
 				if (log_enabled) {
-					GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%llu asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (hold-down)",
-							(uint64_t)record.node_id, record.asset_id, distance, bias, effective_distance, current_lod, desired_lod));
+					GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (hold-down)",
+							String::num_uint64((uint64_t)record.node_id), record.asset_id, distance, bias, effective_distance, current_lod, desired_lod));
 				}
 				continue;
 			}
@@ -611,8 +633,8 @@ void GaussianSplatSceneDirector::update_instance_lods_for_renderer(const Gaussia
 		record.dirty = true;
 		any_changed = true;
 		if (log_enabled) {
-			GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%llu asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u -> %u",
-					(uint64_t)record.node_id, record.asset_id, distance, bias, effective_distance,
+			GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u -> %u",
+					String::num_uint64((uint64_t)record.node_id), record.asset_id, distance, bias, effective_distance,
 					current_lod, record.last_lod));
 		}
 	}
@@ -637,6 +659,9 @@ void GaussianSplatSceneDirector::build_instance_buffer(LocalVector<InstanceDataG
 	for (const KeyValue<RID, SharedWorld> &E : worlds) {
 		const SharedWorld &world = E.value;
 		for (const InstanceRecord &record : world.instances) {
+			if (!record.visible) {
+				continue;
+			}
 			const SharedWorld::AssetRecord *asset_record = world.asset_records.getptr(record.asset_id);
 			if (!asset_record || asset_record->data.is_null()) {
 				continue;
@@ -699,7 +724,7 @@ void GaussianSplatSceneDirector::build_instance_buffer(LocalVector<InstanceDataG
 }
 
 void GaussianSplatSceneDirector::build_instance_buffer_for_renderer(const GaussianSplatRenderer *p_renderer,
-		LocalVector<InstanceDataGPU> &out) const {
+		LocalVector<InstanceDataGPU> &out, bool p_shadow_casters_only) const {
 	MutexLock lock(world_mutex);
 	out.clear();
 
@@ -718,6 +743,12 @@ void GaussianSplatSceneDirector::build_instance_buffer_for_renderer(const Gaussi
 	uint32_t traced_translation_zero = 0;
 	uint32_t traced_fully_identity = 0;
 	for (const InstanceRecord &record : world->instances) {
+		if (!record.visible) {
+			continue;
+		}
+		if (p_shadow_casters_only && !record.casts_shadow) {
+			continue;
+		}
 		const SharedWorld::AssetRecord *asset_record = world->asset_records.getptr(record.asset_id);
 		if (!asset_record || asset_record->data.is_null()) {
 			if (log_enabled) {
@@ -793,9 +824,9 @@ void GaussianSplatSceneDirector::build_instance_buffer_for_renderer(const Gaussi
 			traced_fully_identity += (rotation_identity && scale_identity && translation_zero) ? 1u : 0u;
 		}
 		if (log_enabled) {
-			GS_LOG_RENDERER_DEBUG(vformat("[InstanceBuffer] idx=%d node=%llu asset=%u lod=%u flags=0x%08X pos=(%.3f,%.3f,%.3f) scale=%.3f",
+			GS_LOG_RENDERER_DEBUG(vformat("[InstanceBuffer] idx=%d node=%s asset=%u lod=%u flags=0x%08X pos=(%.3f,%.3f,%.3f) scale=%.3f",
 					out.size() - 1,
-					(uint64_t)record.node_id, record.asset_id, record.last_lod, record.flags,
+					String::num_uint64((uint64_t)record.node_id), record.asset_id, record.last_lod, record.flags,
 					entry.translation_scale[0], entry.translation_scale[1], entry.translation_scale[2], entry.translation_scale[3]));
 		}
 	}
@@ -827,8 +858,53 @@ uint64_t GaussianSplatSceneDirector::get_instance_generation_for_renderer(const 
 	return world->instance_generation;
 }
 
+uint32_t GaussianSplatSceneDirector::get_instance_count_for_renderer(const GaussianSplatRenderer *p_renderer) const {
+	MutexLock lock(world_mutex);
+	const SharedWorld *world = _find_world_for_renderer(p_renderer);
+	if (!world) {
+		return 0;
+	}
+	return world->instances.size();
+}
+
+namespace {
+
+static int _metadata_int(const Dictionary &p_metadata, const StringName &p_key, int p_default) {
+	if (!p_metadata.has(p_key)) {
+		return p_default;
+	}
+	const Variant value = p_metadata[p_key];
+	if (value.get_type() == Variant::FLOAT) {
+		return int((double)value);
+	}
+	return int(value);
+}
+
+static double _metadata_double(const Dictionary &p_metadata, const StringName &p_key, double p_default) {
+	if (!p_metadata.has(p_key)) {
+		return p_default;
+	}
+	const Variant value = p_metadata[p_key];
+	if (value.get_type() == Variant::INT) {
+		return double(int64_t(value));
+	}
+	return (double)value;
+}
+
+static bool _asset_requests_full_fidelity_runtime(const Ref<GaussianSplatAsset> &p_asset) {
+	if (p_asset.is_null()) {
+		return false;
+	}
+	const Dictionary import_metadata = p_asset->get_import_metadata();
+	const int import_max_splats = _metadata_int(import_metadata, StringName("max_splats"), -1);
+	const double density_multiplier = _metadata_double(import_metadata, StringName("density_multiplier"), 1.0);
+	return import_max_splats == 0 && density_multiplier >= 0.999;
+}
+
+} // namespace
+
 void GaussianSplatSceneDirector::collect_instance_assets_for_renderer(const GaussianSplatRenderer *p_renderer,
-		LocalVector<InstanceAssetRegistration> &out) const {
+		LocalVector<InstanceAssetRegistration> &out, bool p_shadow_casters_only) const {
 	MutexLock lock(world_mutex);
 	out.clear();
 
@@ -837,15 +913,31 @@ void GaussianSplatSceneDirector::collect_instance_assets_for_renderer(const Gaus
 		return;
 	}
 
-	out.reserve(world->asset_records.size());
-	for (const KeyValue<uint32_t, SharedWorld::AssetRecord> &E : world->asset_records) {
-		if (E.key == 0 || E.value.data.is_null()) {
+	HashSet<uint32_t> selected_asset_ids;
+	selected_asset_ids.reserve(world->asset_records.size());
+	for (const InstanceRecord &record : world->instances) {
+		if (!record.visible) {
+			continue;
+		}
+		if (p_shadow_casters_only && !record.casts_shadow) {
+			continue;
+		}
+		if (record.asset_id != 0) {
+			selected_asset_ids.insert(record.asset_id);
+		}
+	}
+
+	out.reserve(selected_asset_ids.size());
+	for (const uint32_t &asset_id : selected_asset_ids) {
+		const SharedWorld::AssetRecord *record = world->asset_records.getptr(asset_id);
+		if (!record || record->data.is_null()) {
 			continue;
 		}
 		InstanceAssetRegistration entry;
-		entry.asset_id = E.key;
-		entry.data = E.value.data;
-		entry.edited_version = E.value.edited_version;
+		entry.asset_id = asset_id;
+		entry.data = record->data;
+		entry.edited_version = record->edited_version;
+		entry.requests_full_fidelity_runtime = _asset_requests_full_fidelity_runtime(record->asset);
 		out.push_back(entry);
 	}
 }

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
@@ -5,6 +5,7 @@
 #include "core/object/object_id.h"
 #include "core/os/mutex.h"
 #include "core/templates/hash_map.h"
+#include "core/templates/hash_set.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/vector.h"
 #include "core/math/transform_3d.h"
@@ -31,23 +32,28 @@ public:
     GaussianSplatSceneDirector();
     ~GaussianSplatSceneDirector();
 
-    void register_instance(ObjectID p_node_id, const Ref<GaussianSplatAsset> &p_asset, const Transform3D &p_transform,
-            float p_opacity, float p_lod_bias, uint32_t p_flags,
-            float p_wind_intensity = 1.0f, uint32_t p_wind_mode = INSTANCE_WIND_INHERIT,
-            const Vector3 &p_wind_direction = Vector3(), float p_wind_frequency = 1.0f);
-    void update_instance_transform(ObjectID p_node_id, const Transform3D &p_transform);
-    void update_instance_params(ObjectID p_node_id, float p_opacity, float p_lod_bias, uint32_t p_flags,
-            float p_wind_intensity = 1.0f, uint32_t p_wind_mode = INSTANCE_WIND_INHERIT,
-            const Vector3 &p_wind_direction = Vector3(), float p_wind_frequency = 1.0f);
-    void unregister_instance(ObjectID p_node_id);
+	void register_instance(ObjectID p_node_id, const Ref<GaussianSplatAsset> &p_asset, const Transform3D &p_transform,
+			float p_opacity, float p_lod_bias, uint32_t p_flags, bool p_casts_shadow = false,
+			float p_wind_intensity = 1.0f, uint32_t p_wind_mode = INSTANCE_WIND_INHERIT,
+			const Vector3 &p_wind_direction = Vector3(), float p_wind_frequency = 1.0f,
+			bool p_visible = true);
+	void update_instance_transform(ObjectID p_node_id, const Transform3D &p_transform);
+	void update_instance_params(ObjectID p_node_id, float p_opacity, float p_lod_bias, uint32_t p_flags, bool p_casts_shadow = false,
+			float p_wind_intensity = 1.0f, uint32_t p_wind_mode = INSTANCE_WIND_INHERIT,
+			const Vector3 &p_wind_direction = Vector3(), float p_wind_frequency = 1.0f,
+			bool p_visible = true);
+	void unregister_instance(ObjectID p_node_id);
     void update_instance_lods(const Vector3 &p_camera_pos, const LODConfig &p_lod_config, float p_hysteresis_zone);
     void update_instance_lods_for_renderer(const GaussianSplatRenderer *p_renderer, const Vector3 &p_camera_pos,
             const LODConfig &p_lod_config, float p_hysteresis_zone);
     void build_instance_buffer(LocalVector<InstanceDataGPU> &out) const;
-    void build_instance_buffer_for_renderer(const GaussianSplatRenderer *p_renderer, LocalVector<InstanceDataGPU> &out) const;
-    uint64_t get_instance_generation_for_renderer(const GaussianSplatRenderer *p_renderer) const;
+	void build_instance_buffer_for_renderer(const GaussianSplatRenderer *p_renderer, LocalVector<InstanceDataGPU> &out,
+			bool p_shadow_casters_only = false) const;
+	uint32_t get_instance_count_for_renderer(const GaussianSplatRenderer *p_renderer) const;
+	uint64_t get_instance_generation_for_renderer(const GaussianSplatRenderer *p_renderer) const;
 
-    void collect_instance_assets_for_renderer(const GaussianSplatRenderer *p_renderer, LocalVector<InstanceAssetRegistration> &out) const;
+	void collect_instance_assets_for_renderer(const GaussianSplatRenderer *p_renderer, LocalVector<InstanceAssetRegistration> &out,
+			bool p_shadow_casters_only = false) const;
 
     Ref<GaussianSplatRenderer> get_shared_renderer(World3D *p_world);
 
@@ -62,13 +68,15 @@ private:
         float lod_bias = 0.0f;
         float wind_intensity = 1.0f;
         uint32_t wind_mode = INSTANCE_WIND_INHERIT;
-        Vector3 wind_direction = Vector3();
-        float wind_frequency = 1.0f;
-        uint32_t asset_id = 0;
-        uint32_t flags = 0;
-        uint32_t last_lod = 0;
-        bool dirty = true;
-    };
+		Vector3 wind_direction = Vector3();
+		float wind_frequency = 1.0f;
+		uint32_t asset_id = 0;
+		uint32_t flags = 0;
+		uint32_t last_lod = 0;
+		bool casts_shadow = false;
+		bool visible = true;
+		bool dirty = true;
+	};
 
     struct SharedWorld {
         RID scenario;

--- a/modules/gaussian_splatting/io/resource_importer_gsplatworld.cpp
+++ b/modules/gaussian_splatting/io/resource_importer_gsplatworld.cpp
@@ -3,6 +3,7 @@
 #ifdef TOOLS_ENABLED
 
 #include "core/error/error_macros.h"
+#include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
 #include "../core/gaussian_data.h"
@@ -255,6 +256,9 @@ Error ResourceImporterGSplatWorld::import(ResourceUID::ID p_source_id, const Str
 		const Error final_err = imported_decode_err != OK ? imported_decode_err : ERR_FILE_CORRUPT;
 		GS_LOG_ERROR_DEFAULT(vformat("GaussianSplatWorld importer produced unreadable output %s (error %d)",
 				save_path, final_err));
+		if (FileAccess::exists(save_path)) {
+			DirAccess::remove_absolute(save_path);
+		}
 		return final_err;
 	}
 

--- a/modules/gaussian_splatting/nodes/gaussian_splat_dynamic_instance_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_dynamic_instance_3d.cpp
@@ -135,7 +135,7 @@ bool GaussianSplatDynamicInstance3D::_register_instance_registry() {
         return false;
     }
     director->register_instance(get_instance_id(), asset, get_global_transform(),
-            1.0f, 1.0f, _get_instance_flags());
+            1.0f, 1.0f, _get_instance_flags(), false);
     return true;
 }
 

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -34,6 +34,14 @@
 // Project settings helpers provided by gs_project_settings.h (gs::settings namespace).
 namespace {
 static bool _is_frame_log_enabled() { return gs::settings::is_frame_log_enabled(); }
+
+static bool _is_multi_instance_shared_renderer_active(const Ref<GaussianSplatRenderer> &p_renderer) {
+    if (!p_renderer.is_valid()) {
+        return false;
+    }
+    GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
+    return director && director->get_instance_count_for_renderer(p_renderer.ptr()) > 1u;
+}
 } // namespace
 
 void GaussianSplatNode3D::_bind_methods() {
@@ -421,6 +429,13 @@ void GaussianSplatNode3D::_notification(int p_what) {
 }
 
 void GaussianSplatNode3D::_validate_property(PropertyInfo &p_property) const {
+    if (_is_multi_instance_shared_renderer_active(renderer)) {
+        if (p_property.name.begins_with("painterly/") || p_property.name == "rendering/color_grading") {
+            p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+            return;
+        }
+    }
+
     // Hide painterly settings if disabled
     if (!enable_painterly) {
         if (p_property.name.begins_with("painterly/") && p_property.name != "painterly/enabled") {
@@ -795,6 +810,7 @@ void GaussianSplatNode3D::_finalize_manual_splat_setup(int splat_count) {
     _sync_gaussian_storage();
     _register_shared_renderer();
     _mark_render_state_dirty();
+    update_gizmos();
     update_configuration_warnings();
 }
 
@@ -806,6 +822,8 @@ void GaussianSplatNode3D::set_quality_preset(QualityPreset p_preset) {
     quality_preset = p_preset;
     _apply_quality_preset();
     _update_quality_settings();
+    _mark_render_state_dirty();
+    _update_instance_params_in_director();
 
     notify_property_list_changed();
 }
@@ -813,6 +831,7 @@ void GaussianSplatNode3D::set_quality_preset(QualityPreset p_preset) {
 void GaussianSplatNode3D::set_lod_bias(float p_bias) {
     lod_bias = CLAMP(p_bias, 0.1f, 4.0f);
     _update_quality_settings();
+    _mark_render_state_dirty();
     _update_instance_params_in_director();
 }
 
@@ -820,6 +839,7 @@ void GaussianSplatNode3D::set_max_render_distance(float p_distance) {
     max_render_distance = MAX(0.0f, p_distance);
     _update_visibility();
     _update_quality_settings();
+    _mark_render_state_dirty();
 }
 
 void GaussianSplatNode3D::set_max_splat_count(int p_count) {
@@ -828,6 +848,7 @@ void GaussianSplatNode3D::set_max_splat_count(int p_count) {
     if (renderer.is_valid()) {
         _apply_renderer_settings();
     }
+    _mark_render_state_dirty();
     _update_instance_params_in_director();
 }
 
@@ -842,32 +863,45 @@ void GaussianSplatNode3D::set_enable_painterly(bool p_enabled) {
     if (renderer.is_valid()) {
         _apply_renderer_settings();
     }
+    _mark_render_state_dirty();
     notify_property_list_changed();
 }
 
 void GaussianSplatNode3D::set_edge_threshold(float p_threshold) {
+    if (_is_multi_instance_shared_renderer_active(renderer)) {
+        return;
+    }
     edge_threshold = CLAMP(p_threshold, 0.0f, 1.0f);
     _apply_painterly_settings();
     _update_quality_settings();
     if (renderer.is_valid()) {
         _apply_renderer_settings();
     }
+    _mark_render_state_dirty();
 }
 
 void GaussianSplatNode3D::set_stroke_opacity(float p_opacity) {
+    if (_is_multi_instance_shared_renderer_active(renderer)) {
+        return;
+    }
     stroke_opacity = CLAMP(p_opacity, 0.0f, 1.0f);
     _apply_painterly_settings();
     if (renderer.is_valid()) {
         _apply_renderer_settings();
     }
+    _mark_render_state_dirty();
 }
 
 void GaussianSplatNode3D::set_stroke_width(float p_width) {
+    if (_is_multi_instance_shared_renderer_active(renderer)) {
+        return;
+    }
     stroke_width = CLAMP(p_width, 0.1f, 5.0f);
     _apply_painterly_settings();
     if (renderer.is_valid()) {
         _apply_renderer_settings();
     }
+    _mark_render_state_dirty();
 }
 
 void GaussianSplatNode3D::set_color_variation(float p_variation) {
@@ -876,18 +910,26 @@ void GaussianSplatNode3D::set_color_variation(float p_variation) {
 }
 
 void GaussianSplatNode3D::set_temporal_blend(float p_blend) {
+    if (_is_multi_instance_shared_renderer_active(renderer)) {
+        return;
+    }
     temporal_blend = CLAMP(p_blend, 0.01f, 1.0f);
     _apply_painterly_settings();
     _update_quality_settings();
     if (renderer.is_valid()) {
         _apply_renderer_settings();
     }
+    _mark_render_state_dirty();
 }
 
 void GaussianSplatNode3D::set_painterly_seed(uint32_t p_seed) {
+    if (_is_multi_instance_shared_renderer_active(renderer)) {
+        return;
+    }
     painterly_seed = MIN(p_seed, (uint32_t)65535);
     _apply_painterly_settings();
     _update_quality_settings();
+    _mark_render_state_dirty();
 }
 
 void GaussianSplatNode3D::set_update_mode(ViewportUpdateMode p_mode) {
@@ -923,13 +965,17 @@ void GaussianSplatNode3D::set_cast_shadow(bool p_enabled) {
                     cast_shadow ? RS::SHADOW_CASTING_SETTING_ON : RS::SHADOW_CASTING_SETTING_OFF);
         }
     }
+    _sync_gaussian_storage();
+    _update_instance_params_in_director();
 }
 
 void GaussianSplatNode3D::set_use_frustum_culling(bool p_enabled) {
     use_frustum_culling = p_enabled;
+    _update_visibility();
     if (renderer.is_valid()) {
         _apply_renderer_settings();
     }
+    _mark_render_state_dirty();
 }
 
 void GaussianSplatNode3D::set_use_occlusion_culling(bool p_enabled) {
@@ -942,6 +988,7 @@ void GaussianSplatNode3D::set_opacity(float p_opacity) {
     if (renderer.is_valid()) {
         _apply_renderer_settings();
     }
+    _mark_render_state_dirty();
     _update_instance_params_in_director();
 }
 
@@ -1307,6 +1354,17 @@ void GaussianSplatNode3D::process_gaussian_render() {
 
     _update_visibility();
 
+    if (renderer.is_valid()) {
+        const bool shared_renderer_multi_instance = _is_multi_instance_shared_renderer_active(renderer);
+        if (shared_renderer_multi_instance_state != shared_renderer_multi_instance) {
+            shared_renderer_multi_instance_state = shared_renderer_multi_instance;
+            _apply_renderer_settings();
+            notify_property_list_changed();
+        }
+    } else {
+        shared_renderer_multi_instance_state = false;
+    }
+
     bool should_update = false;
     switch (update_mode) {
         case UPDATE_MODE_ALWAYS:
@@ -1375,6 +1433,7 @@ void GaussianSplatNode3D::_load_asset() {
 
 void GaussianSplatNode3D::_update_asset() {
     asset_helper.update_asset();
+    update_gizmos();
 }
 
 void GaussianSplatNode3D::_clear_asset() {
@@ -1394,70 +1453,70 @@ void GaussianSplatNode3D::_update_bounds() {
 }
 
 void GaussianSplatNode3D::_update_visibility() {
-    if (!is_inside_tree()) {
-        visible_in_viewport = false;
-        return;
-    }
-
-    if (!parent_visible || !is_visible_in_tree()) {
-        visible_in_viewport = false;
-        return;
-    }
+    const bool previous_visibility = visible_in_viewport;
+    bool new_visibility = false;
 
     // In editor, preview_enabled controls actual rendering visibility (not just gizmos).
     // At runtime, preview_enabled is ignored so splats always render when visible.
 #ifdef TOOLS_ENABLED
-    if (Engine::get_singleton()->is_editor_hint() && !preview_enabled) {
-        visible_in_viewport = false;
-        return;
-    }
+    const bool preview_blocked = Engine::get_singleton()->is_editor_hint() && !preview_enabled;
+#else
+    const bool preview_blocked = false;
 #endif
 
-    if (bounds_dirty) {
-        _update_bounds();
-    }
+    if (is_inside_tree() && parent_visible && is_visible_in_tree() && !preview_blocked) {
+        if (bounds_dirty) {
+            _update_bounds();
+        }
 
-    // Use the same viewport as rendering for consistent culling.
-    // In editor, use _find_editor_scene_viewport() to match update_splats() behavior.
-    Viewport *viewport = Engine::get_singleton()->is_editor_hint() ? _find_editor_scene_viewport() : get_viewport();
-    if (!viewport) {
-        viewport = get_viewport(); // Fallback to node's viewport
-    }
-    if (!viewport) {
-        visible_in_viewport = false;
-        return;
-    }
+        // Use the same viewport as rendering for consistent culling.
+        // In editor, use _find_editor_scene_viewport() to match update_splats() behavior.
+        Viewport *viewport = Engine::get_singleton()->is_editor_hint() ? _find_editor_scene_viewport() : get_viewport();
+        if (!viewport) {
+            viewport = get_viewport();
+        }
 
-    Camera3D *camera = viewport->get_camera_3d();
-    if (!camera) {
-        visible_in_viewport = true;
-        return;
-    }
+        if (viewport) {
+            Camera3D *camera = viewport->get_camera_3d();
+            if (!camera) {
+                new_visibility = true;
+            } else {
+                new_visibility = true;
+                const Transform3D camera_to_world_transform = camera->get_camera_transform();
+                const Vector3 camera_position = camera_to_world_transform.origin;
 
-    const Transform3D camera_to_world_transform = camera->get_camera_transform();
-    const Vector3 camera_position = camera_to_world_transform.origin;
+                if (max_render_distance > 0.0f) {
+                    const Vector3 center = world_aabb.get_center();
+                    const float radius = world_aabb.get_longest_axis_size() * 0.5f;
+                    const float distance_to_center = camera_position.distance_to(center);
 
-    if (max_render_distance > 0.0f) {
-        const Vector3 center = world_aabb.get_center();
-        const float radius = world_aabb.get_longest_axis_size() * 0.5f;
-        const float distance_to_center = camera_position.distance_to(center);
+                    if (distance_to_center - radius > max_render_distance) {
+                        new_visibility = false;
+                    }
+                }
 
-        if (distance_to_center - radius > max_render_distance) {
-            visible_in_viewport = false;
-            return;
+                if (new_visibility && use_frustum_culling) {
+                    RendererSceneCull::Frustum frustum(camera->get_frustum());
+                    RendererSceneCull::InstanceBounds bounds(world_aabb);
+                    if (!bounds.in_frustum(frustum)) {
+                        new_visibility = false;
+                    }
+                }
+            }
         }
     }
 
-    if (use_frustum_culling) {
-        RendererSceneCull::Frustum frustum(camera->get_frustum());
-        RendererSceneCull::InstanceBounds bounds(world_aabb);
-        if (!bounds.in_frustum(frustum)) {
-            visible_in_viewport = false;
-            return;
+    visible_in_viewport = new_visibility;
+    if (render_instance.is_valid()) {
+        if (RenderingServer *rs = RS::get_singleton()) {
+            rs->instance_set_visible(render_instance, parent_visible && visible_in_viewport && is_visible_in_tree());
         }
     }
 
-    visible_in_viewport = true;
+    if (previous_visibility != visible_in_viewport) {
+        _update_instance_params_in_director();
+        emit_signal("viewport_visibility_changed", visible_in_viewport);
+    }
 }
 
 void GaussianSplatNode3D::_update_quality_settings() {
@@ -1576,7 +1635,7 @@ void GaussianSplatNode3D::_update_render_instance() {
 
         Transform3D xform = get_global_transform();
         rs->instance_set_transform(render_instance, xform);
-        rs->instance_set_visible(render_instance, parent_visible && is_visible_in_tree());
+        rs->instance_set_visible(render_instance, parent_visible && visible_in_viewport && is_visible_in_tree());
 
         // Instance pipeline uses per-instance transforms; no global instance transform is required.
     }
@@ -1600,13 +1659,14 @@ void GaussianSplatNode3D::_ensure_gaussian_base() {
         return;
     }
 
-    gaussian_base = storage->gaussian_allocate();
-    storage->gaussian_initialize(gaussian_base);
+	gaussian_base = storage->gaussian_allocate();
+	storage->gaussian_initialize(gaussian_base);
 #ifdef MODULE_GAUSSIAN_SPLATTING_ENABLED
-    storage->gaussian_set_renderer(gaussian_base, renderer);
+	storage->gaussian_set_renderer(gaussian_base, renderer);
 #endif
-    storage->gaussian_set_aabb(gaussian_base, world_aabb);
-    _set_instance_base(gaussian_base);
+	storage->gaussian_set_aabb(gaussian_base, world_aabb);
+	storage->gaussian_set_casts_shadow(gaussian_base, cast_shadow);
+	_set_instance_base(gaussian_base);
 }
 
 void GaussianSplatNode3D::_release_gaussian_base() {
@@ -1617,13 +1677,14 @@ void GaussianSplatNode3D::_release_gaussian_base() {
     _set_instance_base(RID());
 
     RendererRD::GaussianSplatStorage *storage = RendererRD::GaussianSplatStorage::get_singleton();
-    if (storage) {
+	if (storage) {
 #ifdef MODULE_GAUSSIAN_SPLATTING_ENABLED
-        storage->gaussian_set_renderer(gaussian_base, Ref<GaussianSplatRenderer>());
+		storage->gaussian_set_renderer(gaussian_base, Ref<GaussianSplatRenderer>());
 #endif
-        storage->gaussian_set_aabb(gaussian_base, AABB());
-        storage->gaussian_free(gaussian_base);
-    }
+		storage->gaussian_set_aabb(gaussian_base, AABB());
+		storage->gaussian_set_casts_shadow(gaussian_base, false);
+		storage->gaussian_free(gaussian_base);
+	}
 
     gaussian_base = RID();
 }
@@ -1639,9 +1700,10 @@ void GaussianSplatNode3D::_sync_gaussian_storage() {
     }
 
 #ifdef MODULE_GAUSSIAN_SPLATTING_ENABLED
-    storage->gaussian_set_renderer(gaussian_base, renderer);
+	storage->gaussian_set_renderer(gaussian_base, renderer);
 #endif
-    storage->gaussian_set_aabb(gaussian_base, world_aabb);
+	storage->gaussian_set_aabb(gaussian_base, world_aabb);
+	storage->gaussian_set_casts_shadow(gaussian_base, cast_shadow);
 }
 
 Viewport *GaussianSplatNode3D::_find_editor_scene_viewport() const {
@@ -1820,9 +1882,10 @@ void GaussianSplatNode3D::_register_instance_in_director() {
         return;
     }
     director->register_instance(get_instance_id(), asset, get_global_transform(),
-            opacity, lod_bias, _get_instance_flags(),
+            opacity, lod_bias, _get_instance_flags(), cast_shadow,
             _get_instance_wind_intensity(), _get_instance_wind_mode(),
-            _get_instance_wind_direction(), _get_instance_wind_frequency());
+            _get_instance_wind_direction(), _get_instance_wind_frequency(),
+            parent_visible && visible_in_viewport && is_visible_in_tree());
 }
 
 void GaussianSplatNode3D::_unregister_instance_in_director() {
@@ -1845,9 +1908,13 @@ void GaussianSplatNode3D::_update_instance_params_in_director() {
         return;
     }
     if (GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton()) {
-        director->update_instance_params(get_instance_id(), opacity, lod_bias, _get_instance_flags(),
+        director->update_instance_params(get_instance_id(), opacity, lod_bias, _get_instance_flags(), cast_shadow,
                 _get_instance_wind_intensity(), _get_instance_wind_mode(),
-                _get_instance_wind_direction(), _get_instance_wind_frequency());
+                _get_instance_wind_direction(), _get_instance_wind_frequency(),
+                parent_visible && visible_in_viewport && is_visible_in_tree());
+    }
+    if (renderer.is_valid()) {
+        renderer->invalidate_cached_render();
     }
 }
 
@@ -1867,6 +1934,40 @@ void GaussianSplatNode3D::_register_shared_renderer() {
         return;
     }
     _register_instance_in_director();
+
+    Ref<GaussianSplatAsset> bootstrap_asset = splat_asset.is_valid() ? splat_asset : runtime_asset;
+
+    // Bootstrap primary gaussian_data on the shared renderer so the resident
+    // fallback path can render while the streaming instance pipeline warms up.
+    // Without this, scene_state.gaussian_data stays null, the streaming warmup
+    // frames return false, and _render_resident_frame sees "no render data".
+    if (renderer.is_valid()) {
+        const auto &scene_state = renderer->get_scene_state();
+        if (scene_state.active_asset.is_null() && bootstrap_asset.is_valid()) {
+            renderer->set_gaussian_asset(bootstrap_asset);
+            if (debug_logs_enabled) {
+                GS_LOG_RENDERER_DEBUG(vformat("[NODE-REG] Bootstrap: set active_asset on renderer (asset_id=%s)",
+                        String::num_uint64((uint64_t)bootstrap_asset->get_instance_id())));
+            }
+        }
+        if (scene_state.gaussian_data.is_null()) {
+            Ref<GaussianData> bootstrap_data;
+            if (splat_asset.is_valid()) {
+                bootstrap_data = splat_asset->get_gaussian_data();
+            } else if (renderer_data.is_valid()) {
+                bootstrap_data = renderer_data;
+            } else if (runtime_asset.is_valid()) {
+                bootstrap_data = runtime_asset->get_gaussian_data();
+            }
+            if (bootstrap_data.is_valid() && bootstrap_data->get_count() > 0) {
+                renderer->set_gaussian_data(bootstrap_data);
+                if (debug_logs_enabled) {
+                    GS_LOG_RENDERER_DEBUG(vformat("[NODE-REG] Bootstrap: set primary gaussian_data on renderer (count=%d)",
+                            bootstrap_data->get_count()));
+                }
+            }
+        }
+    }
 }
 
 void GaussianSplatNode3D::_unregister_shared_renderer() {
@@ -1886,7 +1987,11 @@ void GaussianSplatNode3D::_on_asset_changed() {
 
 void GaussianSplatNode3D::_on_color_grading_changed() {
     if (renderer.is_valid()) {
-        renderer->set_color_grading(color_grading);
+        if (_is_multi_instance_shared_renderer_active(renderer)) {
+            renderer->set_color_grading(Ref<ColorGradingResource>());
+        } else {
+            renderer->set_color_grading(color_grading);
+        }
         renderer->invalidate_cached_render();
     }
 }
@@ -1955,10 +2060,15 @@ void GaussianSplatNode3D::set_color_grading(const Ref<ColorGradingResource> &p_g
     }
 
     if (renderer.is_valid()) {
-        renderer->set_color_grading(color_grading);
+        if (_is_multi_instance_shared_renderer_active(renderer)) {
+            renderer->set_color_grading(Ref<ColorGradingResource>());
+        } else {
+            renderer->set_color_grading(color_grading);
+        }
         renderer->invalidate_cached_render();
     }
 
+    _mark_render_state_dirty();
     notify_property_list_changed();
 }
 

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
@@ -206,6 +206,7 @@ private:
     Ref<GaussianSplatRenderer> renderer;
     Ref<::GaussianData> renderer_data;
     bool render_state_dirty = true;
+    bool shared_renderer_multi_instance_state = false;
 
     // Editor state
     bool preview_enabled = true;

--- a/modules/gaussian_splatting/nodes/gaussian_splat_world_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_world_3d.cpp
@@ -604,6 +604,7 @@ void GaussianSplatWorld3D::_ensure_gaussian_base() {
     storage->gaussian_set_renderer(gaussian_base, renderer);
 #endif
     storage->gaussian_set_aabb(gaussian_base, world_aabb);
+    storage->gaussian_set_casts_shadow(gaussian_base, cast_shadow);
 }
 
 void GaussianSplatWorld3D::_release_gaussian_base() {
@@ -617,6 +618,7 @@ void GaussianSplatWorld3D::_release_gaussian_base() {
         storage->gaussian_set_renderer(gaussian_base, Ref<GaussianSplatRenderer>());
 #endif
         storage->gaussian_set_aabb(gaussian_base, AABB());
+        storage->gaussian_set_casts_shadow(gaussian_base, false);
         storage->gaussian_free(gaussian_base);
     }
 
@@ -637,6 +639,7 @@ void GaussianSplatWorld3D::_sync_gaussian_storage() {
     storage->gaussian_set_renderer(gaussian_base, renderer);
 #endif
     storage->gaussian_set_aabb(gaussian_base, world_aabb);
+    storage->gaussian_set_casts_shadow(gaussian_base, cast_shadow);
 }
 
 void GaussianSplatWorld3D::_set_instance_base(const RID &p_base) {

--- a/modules/gaussian_splatting/renderer/gaussian_gpu_layout.h
+++ b/modules/gaussian_splatting/renderer/gaussian_gpu_layout.h
@@ -9,6 +9,37 @@
 
 static constexpr uint32_t GS_RENDER_PARAMS_LAYOUT_VERSION = 16; // Keep in sync with shaders/includes/gs_render_params.glsl
 static constexpr uint32_t GS_MAX_ASSET_LODS = 8;
+static constexpr uint32_t GS_SH_METADATA_FIRST_ORDER_MASK = 0x000000FFu;
+static constexpr uint32_t GS_SH_METADATA_HIGH_ORDER_MASK = 0x0000FF00u;
+static constexpr uint32_t GS_SH_METADATA_ENCODED_COUNT_MASK = 0x00FF0000u;
+static constexpr uint32_t GS_SH_METADATA_ENCODING_MASK = 0x7F000000u;
+static constexpr uint32_t GS_SH_METADATA_DC_ENCODING_MASK = 0x80000000u;
+static constexpr uint32_t GS_SH_ENCODING_RGB9E5 = 1u;
+static constexpr uint32_t GS_SH_ENCODING_F16 = 2u;
+
+inline uint32_t gs_pack_sh_metadata(uint32_t p_stored_first, uint32_t p_stored_high, uint32_t p_encoded_total,
+        GaussianDCEncoding p_dc_encoding, uint32_t p_sh_encoding) {
+    p_stored_first = MIN(p_stored_first, 0xFFu);
+    p_stored_high = MIN(p_stored_high, 0xFFu);
+    p_encoded_total = MIN(p_encoded_total, 0xFFu);
+    p_sh_encoding &= 0x7Fu;
+    const uint32_t dc_encoding_bit = p_dc_encoding == GAUSSIAN_DC_ENCODING_LINEAR_RGB ? GS_SH_METADATA_DC_ENCODING_MASK : 0u;
+    return (p_stored_first & GS_SH_METADATA_FIRST_ORDER_MASK) |
+            ((p_stored_high << 8u) & GS_SH_METADATA_HIGH_ORDER_MASK) |
+            ((p_encoded_total << 16u) & GS_SH_METADATA_ENCODED_COUNT_MASK) |
+            ((p_sh_encoding << 24u) & GS_SH_METADATA_ENCODING_MASK) |
+            dc_encoding_bit;
+}
+
+inline uint32_t gs_get_sh_encoding(uint32_t p_metadata) {
+    return (p_metadata & GS_SH_METADATA_ENCODING_MASK) >> 24u;
+}
+
+inline GaussianDCEncoding gs_get_dc_encoding(uint32_t p_metadata) {
+    return (p_metadata & GS_SH_METADATA_DC_ENCODING_MASK) != 0u
+            ? GAUSSIAN_DC_ENCODING_LINEAR_RGB
+            : GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
+}
 
 // Instance pipeline only: uses SplatRef indirection and asset-local quantization.
 
@@ -264,6 +295,17 @@ struct alignas(16) PackedGaussian {
 };
 
 static_assert(sizeof(PackedGaussian) == 144, "PackedGaussian must match shader layout (144 bytes)");
+static_assert(offsetof(PackedGaussian, position) == 0, "PackedGaussian.position offset mismatch");
+static_assert(offsetof(PackedGaussian, opacity) == 12, "PackedGaussian.opacity offset mismatch");
+static_assert(offsetof(PackedGaussian, scale) == 16, "PackedGaussian.scale offset mismatch");
+static_assert(offsetof(PackedGaussian, area) == 28, "PackedGaussian.area offset mismatch");
+static_assert(offsetof(PackedGaussian, rotation) == 32, "PackedGaussian.rotation offset mismatch");
+static_assert(offsetof(PackedGaussian, sh) == 48, "PackedGaussian.sh offset mismatch");
+static_assert(offsetof(PackedGaussian, normal) == 112, "PackedGaussian.normal offset mismatch");
+static_assert(offsetof(PackedGaussian, stroke_age) == 124, "PackedGaussian.stroke_age offset mismatch");
+static_assert(offsetof(PackedGaussian, brush_axes) == 128, "PackedGaussian.brush_axes offset mismatch");
+static_assert(offsetof(PackedGaussian, painterly_meta) == 136, "PackedGaussian.painterly_meta offset mismatch");
+static_assert(offsetof(PackedGaussian, sh_metadata) == 140, "PackedGaussian.sh_metadata offset mismatch");
 
 /**
  * @struct PackedGaussianQuantized

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
@@ -753,6 +753,18 @@ GaussianSplatRenderer::GaussianSplatRenderer(RenderingDevice *p_device) {
         GS_LOG_WARN_DEFAULT("[GaussianSplatRenderer] Local RenderingDevice unavailable; GPU operations will be deferred until device is available");
     }
 
+    RenderQualityOrchestrator::Dependencies quality_dependencies;
+    quality_dependencies.renderer = this;
+    quality_dependencies.gpu_culler = subsystem_state.gpu_culler.ptr();
+    quality_dependencies.test_data_state = &get_test_data_state();
+    quality_dependencies.runtime_ports.refresh_gpu_sorter = &GaussianSplatRenderer::refresh_gpu_sorter;
+    quality_dependencies.runtime_ports.track_resource_owner = &GaussianSplatRenderer::track_resource_owner;
+    quality_dependencies.runtime_ports.get_streaming_state_mut =
+            static_cast<StreamingState &(GaussianSplatRenderer::*)()>(&GaussianSplatRenderer::get_streaming_state);
+    quality_dependencies.runtime_ports.get_streaming_state_view =
+            static_cast<const StreamingState &(GaussianSplatRenderer::*)() const>(&GaussianSplatRenderer::get_streaming_state);
+    quality_orchestrator = std::make_unique<RenderQualityOrchestrator>(quality_dependencies);
+
     RenderSortingOrchestrator::Dependencies sorting_dependencies;
     sorting_dependencies.renderer = this;
     sorting_dependencies.gpu_culler = subsystem_state.gpu_culler.ptr();
@@ -774,17 +786,6 @@ GaussianSplatRenderer::GaussianSplatRenderer(RenderingDevice *p_device) {
         return ensure_rendering_device(p_context);
     };
     sorting_orchestrator = std::make_unique<RenderSortingOrchestrator>(sorting_dependencies);
-    RenderQualityOrchestrator::Dependencies quality_dependencies;
-    quality_dependencies.renderer = this;
-    quality_dependencies.gpu_culler = subsystem_state.gpu_culler.ptr();
-    quality_dependencies.test_data_state = &get_test_data_state();
-    quality_dependencies.runtime_ports.refresh_gpu_sorter = &GaussianSplatRenderer::refresh_gpu_sorter;
-    quality_dependencies.runtime_ports.track_resource_owner = &GaussianSplatRenderer::track_resource_owner;
-    quality_dependencies.runtime_ports.get_streaming_state_mut =
-            static_cast<StreamingState &(GaussianSplatRenderer::*)()>(&GaussianSplatRenderer::get_streaming_state);
-    quality_dependencies.runtime_ports.get_streaming_state_view =
-            static_cast<const StreamingState &(GaussianSplatRenderer::*)() const>(&GaussianSplatRenderer::get_streaming_state);
-    quality_orchestrator = std::make_unique<RenderQualityOrchestrator>(quality_dependencies);
 
     RenderConfigOrchestrator::Dependencies config_dependencies;
     config_dependencies.renderer = this;
@@ -1034,6 +1035,7 @@ void GaussianSplatRenderer::_teardown_resources() {
     // Phase 8: frustum cull resources now managed by GPUCuller interface
 
     if (streaming_state_ref.registered_gaussian_buffer.is_valid()) {
+        forget_resource_owner(streaming_state_ref.registered_gaussian_buffer);
         GaussianSplatManager *manager = GaussianSplatManager::get_singleton();
         if (manager) {
             manager->unregister_gaussian_buffer(streaming_state_ref.registered_gaussian_buffer);
@@ -1165,6 +1167,7 @@ void GaussianSplatRenderer::_notification(int p_what) {
 }
 
 void GaussianSplatRenderer::initialize() {
+    const uint64_t init_start_usec = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : 0;
     bool dispatch_submitted = false;
     if (_dispatch_call_on_render_thread_blocking(
                 callable_mp(this, &GaussianSplatRenderer::_initialize_on_render_thread),
@@ -1181,14 +1184,25 @@ void GaussianSplatRenderer::initialize() {
 
     // Manual initialization called from module
     // Try to initialize GPU resources
+    const uint64_t resources_start_usec = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : init_start_usec;
     _create_gpu_resources_safe();
+    const double resources_ms = double((OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : resources_start_usec) - resources_start_usec) / 1000.0;
 
+    double sorting_ms = 0.0;
     if (get_device_state().rd) {
+        const uint64_t sorting_start_usec = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : init_start_usec;
         initialize_sorting();
+        sorting_ms = double((OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : sorting_start_usec) - sorting_start_usec) / 1000.0;
     }
 
+    double bootstrap_ms = 0.0;
+    const uint32_t gaussian_count = get_scene_state().gaussian_data.is_valid()
+            ? get_scene_state().gaussian_data->get_count()
+            : 0;
     if (get_scene_state().gaussian_data.is_valid()) {
+        const uint64_t bootstrap_start_usec = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : init_start_usec;
         Error data_err = _update_gpu_buffers_with_real_data();
+        bootstrap_ms = double((OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : bootstrap_start_usec) - bootstrap_start_usec) / 1000.0;
         if (data_err == OK) {
             get_frame_state().visible_splat_count.store(get_scene_state().gaussian_data->get_count(), std::memory_order_release);
         } else {
@@ -1198,6 +1212,15 @@ void GaussianSplatRenderer::initialize() {
     } else {
         get_frame_state().visible_splat_count.store(0, std::memory_order_release);
     }
+
+    const double total_init_ms = double((OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : init_start_usec) - init_start_usec) / 1000.0;
+    GS_LOG_RENDERER_INFO(vformat(
+            "[LoadTiming][GaussianSplatRenderer] gaussian_count=%d resource_init_ms=%.2f sorting_init_ms=%.2f bootstrap_ms=%.2f total_init_ms=%.2f",
+            gaussian_count,
+            resources_ms,
+            sorting_ms,
+            bootstrap_ms,
+            total_init_ms));
 }
 
 void GaussianSplatRenderer::_initialize_on_render_thread(uint64_t p_request_id) {
@@ -1380,6 +1403,14 @@ bool GaussianSplatRenderer::_blit_shadow_depth(RID p_source_depth, RID p_shadow_
     u_source.append_id(p_source_depth);
 
     RID uniform_set = uniform_set_cache->get_cache(shadow_blit_state.shader, 0, u_source);
+    if (!uniform_set.is_valid()) {
+        static bool warned_invalid_shadow_blit_uniform_set = false;
+        if (!warned_invalid_shadow_blit_uniform_set) {
+            GS_LOG_WARN_DEFAULT("[GS Shadow] Failed to acquire shadow blit uniform set; skipping shadow depth blit.");
+            warned_invalid_shadow_blit_uniform_set = true;
+        }
+        return false;
+    }
     RD::FramebufferFormatID fb_format = rd->framebuffer_get_format(p_shadow_fb);
     RID pipeline = shadow_blit_state.pipeline_cache.get_render_pipeline(RD::INVALID_ID, fb_format);
 
@@ -1466,10 +1497,13 @@ bool GaussianSplatRenderer::render_directional_shadow_map(const Projection &p_li
     }
 
     Ref<OutputCompositor> saved_output_compositor = subsystem_state.output_compositor;
+    const bool saved_shadow_instance_filter = shadow_instance_filter_enabled;
     subsystem_state.output_compositor = shadow_output_compositor;
+    shadow_instance_filter_enabled = true;
 
     render_sorted_splats(nullptr, p_light_transform.affine_inverse(), projection, render_projection, false);
 
+    shadow_instance_filter_enabled = saved_shadow_instance_filter;
     subsystem_state.output_compositor = saved_output_compositor;
 
     if (!subsystem_state.rasterizer.is_valid()) {

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
@@ -101,6 +101,7 @@ struct InstanceAssetRegistration {
     uint32_t asset_id = 0;
     Ref<GaussianData> data;
     uint32_t edited_version = 0;
+    bool requests_full_fidelity_runtime = false;
 };
 
 /**
@@ -597,6 +598,7 @@ public:
     Ref<class OutputCompositor> shadow_output_compositor;
     uint64_t shadow_output_device_id = 0;
     ShadowBlitState shadow_blit_state;
+    bool shadow_instance_filter_enabled = false;
 
     bool _ensure_shadow_output_compositor(RenderingDevice *p_device);
     bool _ensure_shadow_blit_resources(RenderingDevice *p_device);
@@ -720,6 +722,8 @@ public:
     void set_manual_viewport_format(RD::DataFormat p_format, const char *p_context) { _set_manual_viewport_format(p_format, p_context); }
     void set_active_viewport_format(RD::DataFormat p_format, const char *p_context) { _set_active_viewport_format(p_format, p_context); }
     void update_pipeline_features(RenderingDevice *p_device);
+    void set_shadow_instance_filter_enabled(bool p_enabled) { shadow_instance_filter_enabled = p_enabled; }
+    bool is_shadow_instance_filter_enabled() const { return shadow_instance_filter_enabled; }
     CullStageOutput cull_for_view(const Transform3D &p_world_to_camera_transform, const Projection &p_projection, const Size2i &p_viewport_size) {
         return _cull_for_view(p_world_to_camera_transform, p_projection, p_viewport_size);
     }

--- a/modules/gaussian_splatting/renderer/render_data_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_data_orchestrator.cpp
@@ -3,8 +3,106 @@
 #include "gaussian_splat_renderer.h"
 #include "core/error/error_macros.h"
 #include "core/math/math_defs.h"
+#include "../core/gaussian_splat_scene_director.h"
 #include "../interfaces/gpu_sorting_pipeline.h"
 #include "../logger/gs_logger.h"
+
+namespace {
+
+static int _metadata_int(const Dictionary &p_metadata, const StringName &p_key, int p_default) {
+	if (!p_metadata.has(p_key)) {
+		return p_default;
+	}
+	const Variant value = p_metadata[p_key];
+	if (value.get_type() == Variant::FLOAT) {
+		return int((double)value);
+	}
+	return int(value);
+}
+
+static double _metadata_double(const Dictionary &p_metadata, const StringName &p_key, double p_default) {
+	if (!p_metadata.has(p_key)) {
+		return p_default;
+	}
+	const Variant value = p_metadata[p_key];
+	if (value.get_type() == Variant::INT) {
+		return double(int64_t(value));
+	}
+	return (double)value;
+}
+
+static bool _asset_requests_full_fidelity_runtime(const Ref<GaussianSplatAsset> &p_asset) {
+	if (p_asset.is_null()) {
+		return false;
+	}
+	const Dictionary import_metadata = p_asset->get_import_metadata();
+	const int import_max_splats = _metadata_int(import_metadata, StringName("max_splats"), -1);
+	const double density_multiplier = _metadata_double(import_metadata, StringName("density_multiplier"), 1.0);
+	return import_max_splats == 0 && density_multiplier >= 0.999;
+}
+
+static bool _renderer_requests_conservative_full_fidelity_runtime(const GaussianSplatRenderer *p_renderer,
+		const Ref<GaussianSplatAsset> &p_active_asset) {
+	if (_asset_requests_full_fidelity_runtime(p_active_asset)) {
+		return true;
+	}
+	if (!p_renderer) {
+		return false;
+	}
+	GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
+	if (!director) {
+		return false;
+	}
+
+	LocalVector<InstanceAssetRegistration> instance_assets;
+	director->collect_instance_assets_for_renderer(p_renderer, instance_assets,
+			p_renderer->is_shadow_instance_filter_enabled());
+	if (instance_assets.is_empty()) {
+		return false;
+	}
+	for (const InstanceAssetRegistration &entry : instance_assets) {
+		if (entry.requests_full_fidelity_runtime) {
+			return true;
+		}
+	}
+	if (p_active_asset.is_null()) {
+		return true;
+	}
+	const Ref<GaussianData> active_data = p_active_asset->get_gaussian_data();
+	if (active_data.is_null()) {
+		return true;
+	}
+	for (const InstanceAssetRegistration &entry : instance_assets) {
+		if (entry.data.is_null()) {
+			continue;
+		}
+		if (entry.data == active_data) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static uint32_t _resolve_runtime_upload_budget(const GaussianSplatRenderer *p_renderer,
+		const GaussianRenderState::SceneState &p_scene_state,
+		const GaussianRenderPerformance::PerformanceSettings *p_performance_settings) {
+	if (!p_scene_state.gaussian_data.is_valid()) {
+		return 0;
+	}
+	const uint32_t real_count = uint32_t(MAX(0, p_scene_state.gaussian_data->get_count()));
+	if (real_count == 0) {
+		return 0;
+	}
+	if (_renderer_requests_conservative_full_fidelity_runtime(p_renderer, p_scene_state.active_asset)) {
+		return real_count;
+	}
+	if (!p_performance_settings || p_performance_settings->max_splats <= 0) {
+		return real_count;
+	}
+	return MIN<uint32_t>(real_count, uint32_t(p_performance_settings->max_splats));
+}
+
+} // namespace
 
 static bool _is_data_orchestrator_log_enabled(const GaussianSplatRenderer::DebugConfig *p_debug_config) {
 	if (!p_debug_config) {
@@ -89,6 +187,7 @@ Error RenderDataOrchestrator::set_gaussian_data(const Ref<::GaussianData> &p_dat
 
 	if (streaming_state.registered_gaussian_buffer.is_valid() &&
 			incoming_data_id != streaming_state.registered_gaussian_data_id) {
+		renderer->forget_resource_owner(streaming_state.registered_gaussian_buffer);
 		GaussianSplatManager *manager = GaussianSplatManager::get_singleton();
 		if (manager) {
 			manager->unregister_gaussian_buffer(streaming_state.registered_gaussian_buffer);
@@ -310,7 +409,7 @@ Error RenderDataOrchestrator::update_gpu_buffers_with_real_data() {
 	streaming_state.cached_streamed_indices_valid = false;
 	sorting_state.sorted_splat_count = 0;
 
-	const uint32_t max_streamed = MIN<uint32_t>(real_count, (uint32_t)performance_settings->max_splats);
+	const uint32_t max_streamed = _resolve_runtime_upload_budget(renderer, scene_state, performance_settings);
 	if (max_streamed == 0) {
 		GS_LOG_WARN_DEFAULT("[GPU Streaming] Max splat budget is zero; skipping real data upload");
 		return ERR_PARAMETER_RANGE_ERROR;

--- a/modules/gaussian_splatting/renderer/render_quality_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_quality_orchestrator.cpp
@@ -1,12 +1,169 @@
 #include "render_quality_orchestrator.h"
 
 #include "../logger/gs_logger.h"
+#include "../core/gaussian_splat_scene_director.h"
 #include "core/error/error_macros.h"
 #include "core/math/math_defs.h"
 #include "core/math/math_funcs.h"
 #include "core/object/callable_method_pointer.h"
 #include "core/string/ustring.h"
+#include "core/templates/hash_map.h"
 #include "servers/rendering_server.h"
+
+namespace {
+
+struct FidelityOverrideSnapshot {
+	bool lod_enabled = true;
+	bool opacity_aware_culling = true;
+	float visibility_threshold = 0.01f;
+	bool distance_cull_enabled = true;
+	float distance_cull_start = 30.0f;
+	float distance_cull_max_rate = 0.5f;
+	float importance_threshold = 0.0f;
+	float importance_baseline = 0.0f;
+	float tiny_radius = 0.0f;
+	float tiny_baseline = 0.0f;
+	bool valid = false;
+};
+
+static HashMap<uint64_t, FidelityOverrideSnapshot> g_fidelity_override_snapshots;
+
+static int _metadata_int(const Dictionary &p_metadata, const StringName &p_key, int p_default) {
+	if (!p_metadata.has(p_key)) {
+		return p_default;
+	}
+	const Variant value = p_metadata[p_key];
+	if (value.get_type() == Variant::FLOAT) {
+		return int((double)value);
+	}
+	return int(value);
+}
+
+static double _metadata_double(const Dictionary &p_metadata, const StringName &p_key, double p_default) {
+	if (!p_metadata.has(p_key)) {
+		return p_default;
+	}
+	const Variant value = p_metadata[p_key];
+	if (value.get_type() == Variant::INT) {
+		return double(int64_t(value));
+	}
+	return (double)value;
+}
+
+static bool _asset_requests_full_fidelity_runtime(const Ref<GaussianSplatAsset> &p_asset) {
+	if (p_asset.is_null()) {
+		return false;
+	}
+	const Dictionary import_metadata = p_asset->get_import_metadata();
+	const int import_max_splats = _metadata_int(import_metadata, StringName("max_splats"), -1);
+	const double density_multiplier = _metadata_double(import_metadata, StringName("density_multiplier"), 1.0);
+	return import_max_splats == 0 && density_multiplier >= 0.999;
+}
+
+static bool _renderer_requests_conservative_full_fidelity_runtime(const GaussianSplatRenderer *p_renderer,
+		const Ref<GaussianSplatAsset> &p_active_asset) {
+	if (_asset_requests_full_fidelity_runtime(p_active_asset)) {
+		return true;
+	}
+	if (!p_renderer) {
+		return false;
+	}
+	GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
+	if (!director) {
+		return false;
+	}
+
+	LocalVector<InstanceAssetRegistration> instance_assets;
+	director->collect_instance_assets_for_renderer(p_renderer, instance_assets,
+			p_renderer->is_shadow_instance_filter_enabled());
+	if (instance_assets.is_empty()) {
+		return false;
+	}
+	for (const InstanceAssetRegistration &entry : instance_assets) {
+		if (entry.requests_full_fidelity_runtime) {
+			return true;
+		}
+	}
+	if (p_active_asset.is_null()) {
+		return true;
+	}
+	const Ref<GaussianData> active_data = p_active_asset->get_gaussian_data();
+	if (active_data.is_null()) {
+		return true;
+	}
+	for (const InstanceAssetRegistration &entry : instance_assets) {
+		if (entry.data.is_null()) {
+			continue;
+		}
+		if (entry.data == active_data) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static void _apply_source_fidelity_overrides(uint64_t p_renderer_key, GPUCuller *p_gpu_culler, bool p_enable) {
+	if (!p_gpu_culler) {
+		return;
+	}
+
+	GPUCuller::CullingConfig &config = p_gpu_culler->get_config();
+	GPUCuller::CullingState &state = p_gpu_culler->get_state();
+
+	if (p_enable) {
+		FidelityOverrideSnapshot *existing = g_fidelity_override_snapshots.getptr(p_renderer_key);
+		if (!existing) {
+			FidelityOverrideSnapshot snapshot;
+			snapshot.lod_enabled = config.lod_enabled;
+			snapshot.opacity_aware_culling = config.opacity_aware_culling;
+			snapshot.visibility_threshold = config.visibility_threshold;
+			snapshot.distance_cull_enabled = config.distance_cull_enabled;
+			snapshot.distance_cull_start = config.distance_cull_start;
+			snapshot.distance_cull_max_rate = config.distance_cull_max_rate;
+			snapshot.importance_threshold = config.importance_cull_threshold;
+			snapshot.importance_baseline = config.importance_cull_baseline;
+			snapshot.tiny_radius = state.tiny_splat_screen_radius_px;
+			snapshot.tiny_baseline = state.tiny_splat_screen_radius_baseline;
+			snapshot.valid = true;
+			g_fidelity_override_snapshots.insert(p_renderer_key, snapshot);
+		}
+
+		config.lod_enabled = false;
+		config.lod_cache_dirty = true;
+		config.importance_cull_threshold = 0.0f;
+		config.importance_cull_baseline = 0.0f;
+		config.opacity_aware_culling = false;
+		config.visibility_threshold = 0.0f;
+		config.distance_cull_enabled = false;
+		config.distance_cull_start = 0.0f;
+		config.distance_cull_max_rate = 0.0f;
+		config.cull_params_dirty = true;
+		state.tiny_splat_screen_radius_px = 0.0f;
+		state.tiny_splat_screen_radius_baseline = 0.0f;
+		return;
+	}
+
+	FidelityOverrideSnapshot *snapshot = g_fidelity_override_snapshots.getptr(p_renderer_key);
+	if (!snapshot || !snapshot->valid) {
+		return;
+	}
+
+	config.lod_enabled = snapshot->lod_enabled;
+	config.lod_cache_dirty = true;
+	config.opacity_aware_culling = snapshot->opacity_aware_culling;
+	config.visibility_threshold = snapshot->visibility_threshold;
+	config.distance_cull_enabled = snapshot->distance_cull_enabled;
+	config.distance_cull_start = snapshot->distance_cull_start;
+	config.distance_cull_max_rate = snapshot->distance_cull_max_rate;
+	config.importance_cull_threshold = snapshot->importance_threshold;
+	config.importance_cull_baseline = snapshot->importance_baseline;
+	config.cull_params_dirty = true;
+	state.tiny_splat_screen_radius_px = snapshot->tiny_radius;
+	state.tiny_splat_screen_radius_baseline = snapshot->tiny_baseline;
+	g_fidelity_override_snapshots.erase(p_renderer_key);
+}
+
+} // namespace
 
 RenderQualityOrchestrator::RenderQualityOrchestrator(const Dependencies &p_dependencies) :
 		renderer(p_dependencies.renderer),
@@ -272,19 +429,44 @@ GaussianRenderState::CullStageOutput RenderQualityOrchestrator::cull_for_view(co
 		return output;
 	}
 
+	const bool preserve_source_fidelity = _renderer_requests_conservative_full_fidelity_runtime(renderer, scene_state.active_asset);
+	const uint64_t renderer_key = renderer ? uint64_t(renderer->get_instance_id()) : 0u;
+	_apply_source_fidelity_overrides(renderer_key, gpu_culler, preserve_source_fidelity);
+
 	GPUCuller::CullingInputs inputs;
 	inputs.gaussian_data = scene_state.gaussian_data;
 	inputs.test_positions = &test_data_state->positions;
 	inputs.test_scales = &test_data_state->scales;
-	const int max_splats = performance_settings.max_splats;
+	const int source_splat_count = scene_state.gaussian_data.is_valid() ? scene_state.gaussian_data->get_count() : 0;
+	const int max_splats = preserve_source_fidelity && source_splat_count > 0
+			? source_splat_count
+			: performance_settings.max_splats;
 	inputs.max_splats = max_splats > 0 ? static_cast<uint32_t>(max_splats) : 0;
 	// Runtime sorting path is GPU/cached only; avoid readbacks that were only needed for CPU sort fallback.
 	inputs.readback_distances = false;
 	inputs.readback_importance = false;
 
+	const GaussianSplatRenderer::StreamingState &streaming_state = (renderer->*runtime_ports.get_streaming_state_view)();
+	const bool can_attempt_legacy_gpu_cull =
+			!streaming_state.current_streaming_system.is_valid() &&
+			streaming_state.registered_gaussian_buffer.is_valid();
+	if (can_attempt_legacy_gpu_cull) {
+		RenderingDevice *buffer_device = renderer->get_resource_owner(streaming_state.registered_gaussian_buffer,
+				renderer->get_device_state().rd);
+		if (!buffer_device) {
+			buffer_device = renderer->get_device_state().rd;
+		}
+		if (buffer_device) {
+			inputs.gpu_cull_attempted = true;
+			inputs.gpu_input.gaussian_buffer = streaming_state.registered_gaussian_buffer;
+			inputs.gpu_input.buffer_device = buffer_device;
+			inputs.gpu_input.total_splats = source_splat_count > 0 ? static_cast<uint32_t>(source_splat_count) : 0u;
+		}
+	}
+
 	if (inputs.gpu_cull_attempted && inputs.gpu_input.gaussian_buffer.is_valid() && inputs.gpu_input.buffer_device) {
 		(renderer->*runtime_ports.track_resource_owner)(
-				inputs.gpu_input.gaussian_buffer, inputs.gpu_input.buffer_device, true, nullptr);
+				inputs.gpu_input.gaussian_buffer, inputs.gpu_input.buffer_device, false, "legacy_gpu_cull_gaussian_buffer");
 	}
 
 	GPUCuller::CullingSummary summary =

--- a/modules/gaussian_splatting/renderer/render_sorting_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_sorting_orchestrator.cpp
@@ -645,10 +645,12 @@ GaussianRenderState::SortStageSummary RenderSortingOrchestrator::sort_gaussians_
 				return GaussianRenderState::IndexDomain::UNKNOWN;
 		}
 	};
+	bool sort_executed = false;
 	auto build_summary = [&]() {
 		GaussianRenderState::SortStageSummary summary;
 		summary.sorted_count = sorting_state.sorted_splat_count;
 		summary.sort_time_ms = frame_state_view.sort_time_ms;
+		summary.did_execute = sort_executed;
 		summary.input_domain = p_input_domain;
 		summary.output_domain = resolve_output_domain_for_input(p_input_domain);
 		return summary;
@@ -884,6 +886,7 @@ GaussianRenderState::SortStageSummary RenderSortingOrchestrator::sort_gaussians_
 		}
 		if (sorting_pipeline && sorting_pipeline->sort_gaussians_gpu(p_world_to_camera_transform,
 				_build_sort_frame_context(state_view, state_mut, view_state))) {
+			sort_executed = true;
 			debug_state.sort_route_uid = RenderRouteUID::INSTANCE_SORT_GPU;
 			sorting_state.last_sort_world_to_camera_transform = p_world_to_camera_transform;
 			sorting_state.last_sort_transform_valid = true;
@@ -983,51 +986,47 @@ GaussianRenderState::SortStageSummary RenderSortingOrchestrator::sort_gaussians_
 		}
 	}
 
-	auto publish_instance_identity_fallback = [&](const String &p_reason) -> bool {
-		if (strict_global_sort) {
-			// Even in strict mode, allow the identity fallback when the sort
-			// buffer is missing/invalid — refusing to render at all is worse
-			// than showing an unsorted frame.
-			if (sorting_pipeline && sorting_pipeline->get_sort_indices_buffer().is_valid()) {
+		auto publish_instance_identity_fallback = [&](const String &p_reason) -> bool {
+			if (strict_global_sort) {
+				// Correctness-first mode must never publish an unsorted identity frame.
 				return false;
 			}
-		}
-		if (!instance_pipeline_active || !sorting_pipeline) {
-			return false;
-		}
-		if (instance_visible_splats == 0) {
-			return false;
-		}
+			if (!instance_pipeline_active || !sorting_pipeline) {
+				return false;
+			}
+			if (instance_visible_splats == 0) {
+				return false;
+			}
 
-		sorting_state.sort_index_bytes.resize(instance_visible_splats * sizeof(uint32_t));
-		uint32_t *indices_ptr = reinterpret_cast<uint32_t *>(sorting_state.sort_index_bytes.ptrw());
-		for (uint32_t i = 0; i < instance_visible_splats; i++) {
-			indices_ptr[i] = i;
-		}
-		_bind_sort_pipeline_host_context(sorting_pipeline, renderer);
-		sorting_pipeline->ensure_sort_buffers(instance_visible_splats);
-		RID sort_indices_buffer = sorting_pipeline->get_sort_indices_buffer();
-		if (!sort_indices_buffer.is_valid()) {
-			return false;
-		}
-		RenderingDevice *target_device = renderer->get_resource_owner(sort_indices_buffer, renderer->get_device_state().rd);
-		if (!target_device) {
-			target_device = renderer->get_device_state().rd;
-		}
-		if (!target_device) {
-			return false;
-		}
-		target_device->buffer_update(sort_indices_buffer, 0,
-				sorting_state.sort_index_bytes.size(),
-				sorting_state.sort_index_bytes.ptr());
-		sorting_state.sorted_splat_count = instance_visible_splats;
-		_publish_rendered_splat_count(frame_state, performance_state, instance_visible_splats);
-		debug_state.sort_route_uid = RenderRouteUID::INSTANCE_SORT_IDENTITY_FALLBACK;
-		sorting_state.last_sort_transform_valid = false;
-		set_active_sort_algorithm("GPU (identity fallback)", p_reason);
-		GS_LOG_WARN_DEFAULT(vformat("[GPU Sort] %s; publishing identity order for instance sort domain", p_reason));
-		return true;
-	};
+			sorting_state.sort_index_bytes.resize(instance_visible_splats * sizeof(uint32_t));
+			uint32_t *indices_ptr = reinterpret_cast<uint32_t *>(sorting_state.sort_index_bytes.ptrw());
+			for (uint32_t i = 0; i < instance_visible_splats; i++) {
+				indices_ptr[i] = i;
+			}
+			_bind_sort_pipeline_host_context(sorting_pipeline, renderer);
+			sorting_pipeline->ensure_sort_buffers(instance_visible_splats);
+			RID sort_indices_buffer = sorting_pipeline->get_sort_indices_buffer();
+			if (!sort_indices_buffer.is_valid()) {
+				return false;
+			}
+			RenderingDevice *target_device = renderer->get_resource_owner(sort_indices_buffer, renderer->get_device_state().rd);
+			if (!target_device) {
+				target_device = renderer->get_device_state().rd;
+			}
+			if (!target_device) {
+				return false;
+			}
+			target_device->buffer_update(sort_indices_buffer, 0,
+					sorting_state.sort_index_bytes.size(),
+					sorting_state.sort_index_bytes.ptr());
+			sorting_state.sorted_splat_count = instance_visible_splats;
+			_publish_rendered_splat_count(frame_state, performance_state, instance_visible_splats);
+			debug_state.sort_route_uid = RenderRouteUID::INSTANCE_SORT_IDENTITY_FALLBACK;
+			sorting_state.last_sort_transform_valid = false;
+			set_active_sort_algorithm("GPU (identity fallback)", p_reason);
+			GS_LOG_WARN_DEFAULT(vformat("[GPU Sort] %s; publishing identity order for instance sort domain", p_reason));
+			return true;
+		};
 
 	if (!need_sort) {
 		const bool can_reuse_previous_sorted =
@@ -1044,11 +1043,11 @@ GaussianRenderState::SortStageSummary RenderSortingOrchestrator::sort_gaussians_
 		} else if (publish_instance_identity_fallback("Missing previous sorted buffer on camera-stable frame")) {
 			reset_sort_metrics();
 			return build_summary();
-		} else if ((!strict_global_sort || !sorting_pipeline->get_sort_indices_buffer().is_valid()) && !instance_pipeline_active && !cull_state.culled_indices.is_empty() && sorting_pipeline) {
+		} else if (!strict_global_sort && !instance_pipeline_active && !cull_state.culled_indices.is_empty() && sorting_pipeline) {
 			// Last resort bootstrap: if the previous sorted buffer is unavailable,
 			// keep rendering progress with current cull order instead of showing zero splats.
-			// This fallback is reachable even in strict mode when the cached sort buffer is missing,
-			// since rendering zero splats is worse than rendering with approximate cull order.
+			// Strict mode is excluded above because correctness-first mode must never
+			// publish approximate ordering.
 			const uint32_t copy_count = MIN<uint32_t>(available_splats,
 					static_cast<uint32_t>(cull_state.culled_indices.size()));
 			if (copy_count > 0) {
@@ -1076,7 +1075,7 @@ GaussianRenderState::SortStageSummary RenderSortingOrchestrator::sort_gaussians_
 				// Force a real re-sort on the next frame; this bootstrap order is not depth-sorted.
 				sorting_state.last_sort_transform_valid = false;
 			}
-		} else if (strict_global_sort && sorting_pipeline && available_splats > 0) {
+		} else if (strict_global_sort && available_splats > 0) {
 			// Strict mode cannot publish fallback ordering. If the stable-frame fast path
 			// has no reusable sorted buffer, force a real sort this frame instead of
 			// returning with stale/invalid state.
@@ -1163,8 +1162,9 @@ GaussianRenderState::SortStageSummary RenderSortingOrchestrator::sort_gaussians_
 		}
 
 		if (strict_global_sort && !positions_ready) {
-			GS_LOG_WARN_DEFAULT(vformat("[CPU Sort] Strict global sort: positions unavailable, rendering unsorted fallback (%s).",
+			GS_LOG_WARN_DEFAULT(vformat("[CPU Sort] Strict global sort: positions unavailable, refusing unsorted fallback (%s).",
 					p_reason));
+			return false;
 		}
 
 		if (positions_ready) {
@@ -1222,6 +1222,7 @@ GaussianRenderState::SortStageSummary RenderSortingOrchestrator::sort_gaussians_
 		uint64_t sort_end = OS::get_singleton()->get_ticks_usec();
 		float cpu_time_ms = (sort_end - sort_start) / 1000.0f;
 
+		sort_executed = true;
 		sorting_state.sorted_splat_count = available_splats;
 		_publish_rendered_splat_count(frame_state, performance_state, available_splats);
 		frame_state.sort_time_ms = cpu_time_ms;
@@ -1252,16 +1253,16 @@ GaussianRenderState::SortStageSummary RenderSortingOrchestrator::sort_gaussians_
 		return true;
 	};
 
-	auto execute_sort_fallback_policy = [&](GaussianSplatting::SortFallbackScenario p_scenario,
-											const String &p_reason,
-											const String &p_failure_log = String()) {
-		const GaussianSplatting::SortFallbackPolicyDecision policy =
-				GaussianSplatting::build_sort_fallback_policy(p_scenario, instance_pipeline_active);
-		const char *reuse_route_uid = instance_pipeline_active
-				? RenderRouteUID::INSTANCE_SORT_CACHED
-				: RenderRouteUID::COMMON_FAIL_SORT_FAILED;
-		for (uint32_t i = 0; i < policy.action_count; i++) {
-			switch (policy.actions[i]) {
+		auto execute_sort_fallback_policy = [&](GaussianSplatting::SortFallbackScenario p_scenario,
+												const String &p_reason,
+												const String &p_failure_log = String()) {
+			const GaussianSplatting::SortFallbackPolicyDecision policy =
+					GaussianSplatting::build_sort_fallback_policy(p_scenario, instance_pipeline_active, strict_global_sort);
+			const char *reuse_route_uid = instance_pipeline_active
+					? RenderRouteUID::INSTANCE_SORT_CACHED
+					: RenderRouteUID::COMMON_FAIL_SORT_FAILED;
+			for (uint32_t i = 0; i < policy.action_count; i++) {
+				switch (policy.actions[i]) {
 				case GaussianSplatting::SortFallbackAction::REUSE_PREVIOUS_SORT:
 					if (reuse_previous_sort(p_reason, reuse_route_uid)) {
 						return;
@@ -1339,6 +1340,7 @@ GaussianRenderState::SortStageSummary RenderSortingOrchestrator::sort_gaussians_
 	if (sorting_pipeline &&
 			sorting_pipeline->sort_gaussians_gpu(p_world_to_camera_transform,
 					_build_sort_frame_context(state_view, state_mut, view_state))) {
+		sort_executed = true;
 		debug_state.sort_route_uid = RenderRouteUID::INSTANCE_SORT_GPU;
 		sorting_state.last_sort_world_to_camera_transform = p_world_to_camera_transform;
 		sorting_state.last_sort_transform_valid = true;

--- a/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
@@ -78,6 +78,99 @@ static uint64_t _compute_instance_pipeline_resource_fingerprint(const ResourceSt
 
 constexpr uint32_t kInstanceAssetEmptySyncGraceFrames = 3u;
 
+static int _metadata_int(const Dictionary &p_metadata, const StringName &p_key, int p_default) {
+	if (!p_metadata.has(p_key)) {
+		return p_default;
+	}
+	const Variant value = p_metadata[p_key];
+	if (value.get_type() == Variant::FLOAT) {
+		return int((double)value);
+	}
+	return int(value);
+}
+
+static double _metadata_double(const Dictionary &p_metadata, const StringName &p_key, double p_default) {
+	if (!p_metadata.has(p_key)) {
+		return p_default;
+	}
+	const Variant value = p_metadata[p_key];
+	if (value.get_type() == Variant::INT) {
+		return double(int64_t(value));
+	}
+	return (double)value;
+}
+
+static bool _asset_requests_full_fidelity_runtime(const Ref<GaussianSplatAsset> &p_asset) {
+	if (p_asset.is_null()) {
+		return false;
+	}
+	const Dictionary import_metadata = p_asset->get_import_metadata();
+	const int import_max_splats = _metadata_int(import_metadata, StringName("max_splats"), -1);
+	const double density_multiplier = _metadata_double(import_metadata, StringName("density_multiplier"), 1.0);
+	return import_max_splats == 0 && density_multiplier >= 0.999;
+}
+
+static bool _renderer_requests_conservative_full_fidelity_runtime(const GaussianSplatRenderer *p_renderer,
+		const Ref<GaussianSplatAsset> &p_active_asset) {
+	if (_asset_requests_full_fidelity_runtime(p_active_asset)) {
+		return true;
+	}
+	if (!p_renderer) {
+		return false;
+	}
+	GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
+	if (!director) {
+		return false;
+	}
+
+	LocalVector<InstanceAssetRegistration> instance_assets;
+	director->collect_instance_assets_for_renderer(p_renderer, instance_assets,
+			p_renderer->is_shadow_instance_filter_enabled());
+	if (instance_assets.is_empty()) {
+		return false;
+	}
+	for (const InstanceAssetRegistration &entry : instance_assets) {
+		if (entry.requests_full_fidelity_runtime) {
+			return true;
+		}
+	}
+	if (p_active_asset.is_null()) {
+		return true;
+	}
+	const Ref<GaussianData> active_data = p_active_asset->get_gaussian_data();
+	if (active_data.is_null()) {
+		return true;
+	}
+	for (const InstanceAssetRegistration &entry : instance_assets) {
+		if (entry.data.is_null()) {
+			continue;
+		}
+		if (entry.data == active_data) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static uint32_t _resolve_runtime_budget_splats(const GaussianSplatRenderer *p_renderer,
+		const GaussianSplatRenderer::SceneState &p_scene_state,
+		const PerformanceSettings &p_perf_settings) {
+	if (!p_scene_state.gaussian_data.is_valid()) {
+		return 0;
+	}
+	const uint32_t real_count = uint32_t(MAX(0, p_scene_state.gaussian_data->get_count()));
+	if (real_count == 0) {
+		return 0;
+	}
+	if (_renderer_requests_conservative_full_fidelity_runtime(p_renderer, p_scene_state.active_asset)) {
+		return real_count;
+	}
+	if (p_perf_settings.max_splats <= 0) {
+		return real_count;
+	}
+	return MIN<uint32_t>(real_count, uint32_t(p_perf_settings.max_splats));
+}
+
 enum class LayoutHintValidationUsage : uint8_t {
 	IO = 0,
 	PRIMARY = 1,
@@ -548,7 +641,8 @@ const RenderStreamingOrchestrator::VisibleLODSelection &RenderStreamingOrchestra
 	const LODConfig &lod_config = p_streaming_system->get_lod_config();
 	const float hysteresis_zone = p_streaming_system->get_lod_hysteresis_zone();
 	p_director->update_instance_lods_for_renderer(renderer, p_camera_origin, lod_config, hysteresis_zone);
-	p_director->build_instance_buffer_for_renderer(renderer, visible_lod_selection._internal_get_instances());
+	p_director->build_instance_buffer_for_renderer(renderer, visible_lod_selection._internal_get_instances(),
+			renderer->is_shadow_instance_filter_enabled());
 
 	return visible_lod_selection;
 }
@@ -739,7 +833,8 @@ void RenderStreamingOrchestrator::sync_instance_pipeline_assets(GaussianStreamin
 		return;
 	}
 	instance_pipeline_assets_cache.clear();
-	director->collect_instance_assets_for_renderer(renderer, instance_pipeline_assets_cache);
+	director->collect_instance_assets_for_renderer(renderer, instance_pipeline_assets_cache,
+			renderer->is_shadow_instance_filter_enabled());
 	if (trace_enabled) {
 		GaussianSplatting::debug_trace_record_event("instance_pipeline",
 				vformat("SyncAssets collected=%d", instance_pipeline_assets_cache.size()),
@@ -1210,6 +1305,63 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 		performance_state.metrics.streaming_state = streaming_metrics;
 		return false;
 	}
+	const GaussianSplatRenderer::SceneState &scene_state = state_view.get_scene_state();
+	const PerformanceSettings &perf_settings = renderer->get_performance_settings();
+	const uint32_t desired_runtime_splats = _resolve_runtime_budget_splats(renderer, scene_state, perf_settings);
+	if (desired_runtime_splats > 0 && streaming_state.memory_stream.is_valid()) {
+		const uint32_t current_memory_capacity = streaming_state.memory_stream->get_max_gaussians();
+		const uint32_t current_runtime_capacity = streaming_state.current_streaming_system.is_valid()
+				? streaming_state.current_streaming_system->get_buffer_capacity_splats()
+				: 0u;
+		if (desired_runtime_splats > current_memory_capacity || desired_runtime_splats > current_runtime_capacity) {
+			RenderingDevice *rd = state_view.get_rendering_device();
+			if (!rd) {
+				const StreamingReadinessState readiness_state = StreamingReadinessState::RUNTIME_BOOTSTRAP_PENDING;
+				publish_not_ready_route(readiness_state);
+				Dictionary streaming_metrics = performance_state.metrics.streaming_state;
+				_apply_streaming_render_readiness_diagnostics(streaming_metrics, readiness_state,
+						"rendering_device unavailable for streaming capacity rebuild");
+				performance_state.metrics.streaming_state = streaming_metrics;
+				return false;
+			}
+
+			const bool async_upload_enabled = streaming_state.memory_stream->get_async_upload();
+			streaming_state.current_streaming_system.unref();
+			streaming_state.memory_stream->shutdown();
+			const Error resize_err = streaming_state.memory_stream->initialize(rd, desired_runtime_splats, 64);
+			if (resize_err != OK) {
+				const StreamingReadinessState readiness_state = StreamingReadinessState::RUNTIME_BOOTSTRAP_PENDING;
+				publish_not_ready_route(readiness_state);
+				Dictionary streaming_metrics = performance_state.metrics.streaming_state;
+				_apply_streaming_render_readiness_diagnostics(streaming_metrics, readiness_state,
+						vformat("streaming capacity rebuild failed: %d", resize_err));
+				performance_state.metrics.streaming_state = streaming_metrics;
+				return false;
+			}
+			streaming_state.memory_stream->set_async_upload(async_upload_enabled);
+			streaming_state.current_stream_gpu_buffer = RID();
+			streaming_state.streaming_gpu_splat_count = 0;
+			streaming_state.streaming_gpu_total_capacity = 0;
+			streaming_state.streamed_indices_generation = 0;
+			streaming_state.streamed_indices_are_local = false;
+			streaming_state.cached_streamed_indices_valid = false;
+			streaming_state.cached_streamed_gaussians.clear();
+			streaming_state.cached_streamed_indices.clear();
+			streaming_state.cached_streamed_source_indices.clear();
+			streaming_state.cached_streamed_sh_limits.clear();
+			streaming_state.cached_streamed_index_lookup.clear();
+			(renderer->*runtime_ports.clear_instance_pipeline_buffers)();
+			if (!ensure_instance_streaming_system()) {
+				const StreamingReadinessState readiness_state = StreamingReadinessState::RUNTIME_BOOTSTRAP_PENDING;
+				publish_not_ready_route(readiness_state);
+				Dictionary streaming_metrics = performance_state.metrics.streaming_state;
+				_apply_streaming_render_readiness_diagnostics(streaming_metrics, readiness_state,
+						"streaming system rebuild after capacity resize failed");
+				performance_state.metrics.streaming_state = streaming_metrics;
+				return false;
+			}
+		}
+	}
 	auto log_streaming_reset = [&](const char *p_reason) {
 		const uint64_t system_id = streaming_state.current_streaming_system.is_valid()
 				? uint64_t(reinterpret_cast<uintptr_t>(streaming_state.current_streaming_system.ptr()))
@@ -1402,8 +1554,8 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 			buffers.chunk_meta_buffer = atlas_state.chunk_meta_buffer;
 			buffers.asset_chunk_index_buffer = atlas_state.asset_chunk_index_buffer;
 			static int instance_buffer_diag_counter = 0;
-			if (++instance_buffer_diag_counter <= 20) {
-				print_line(vformat("[Streaming DIAG] instance buffer handoff: chunk_meta_rid=%d asset_meta_rid=%d chunk_index_rid=%d atlas_gen=%d",
+			if (trace_enabled && ++instance_buffer_diag_counter <= 20) {
+				GS_LOG_STREAMING_DEBUG(vformat("[Streaming] instance buffer handoff: chunk_meta_rid=%d asset_meta_rid=%d chunk_index_rid=%d atlas_gen=%d",
 						buffers.chunk_meta_buffer.get_id(),
 						buffers.asset_meta_buffer.get_id(),
 						buffers.asset_chunk_index_buffer.get_id(),
@@ -1419,9 +1571,8 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 		buffers.max_chunk_splats = streaming_system->get_max_chunk_splats();
 		instance_pipeline_max_chunk_splats = buffers.max_chunk_splats;
 
-		const PerformanceSettings &perf_settings = renderer->get_performance_settings();
-		uint64_t max_visible_splats_u64 = perf_settings.max_splats > 0
-				? uint64_t(perf_settings.max_splats)
+		uint64_t max_visible_splats_u64 = desired_runtime_splats > 0
+				? uint64_t(desired_runtime_splats)
 				: uint64_t(atlas_state.atlas_gaussian_count);
 
 		// Recompute the budget every frame from current scene state.

--- a/modules/gaussian_splatting/renderer/render_types/render_state_types.h
+++ b/modules/gaussian_splatting/renderer/render_types/render_state_types.h
@@ -66,6 +66,7 @@ struct CullStageOutput {
 struct SortStageSummary {
 	uint32_t sorted_count = 0;
 	float sort_time_ms = 0.0f;
+	bool did_execute = false;
 	IndexDomain input_domain = IndexDomain::UNKNOWN;
 	IndexDomain output_domain = IndexDomain::UNKNOWN;
 };

--- a/modules/gaussian_splatting/renderer/sort_fallback_policy.h
+++ b/modules/gaussian_splatting/renderer/sort_fallback_policy.h
@@ -29,9 +29,13 @@ struct SortFallbackPolicyDecision {
 	bool cpu_sort_forced = false;
 };
 
+static inline bool allow_unsorted_fallback_publication(bool p_strict_global_sort) {
+	return !p_strict_global_sort;
+}
+
 // Keep fallback behavior deterministic across force_cpu and GPU failure paths.
 static inline SortFallbackPolicyDecision build_sort_fallback_policy(
-		SortFallbackScenario p_scenario, bool p_instance_pipeline_active) {
+		SortFallbackScenario p_scenario, bool p_instance_pipeline_active, bool p_strict_global_sort = false) {
 	SortFallbackPolicyDecision decision;
 	auto push_action = [&](SortFallbackAction p_action) {
 		if (decision.action_count < 4) {
@@ -42,8 +46,10 @@ static inline SortFallbackPolicyDecision build_sort_fallback_policy(
 	switch (p_scenario) {
 		case SortFallbackScenario::FORCE_CPU_OVERRIDE: {
 			if (p_instance_pipeline_active) {
-				push_action(SortFallbackAction::PUBLISH_INSTANCE_IDENTITY);
 				push_action(SortFallbackAction::REUSE_PREVIOUS_SORT);
+				if (allow_unsorted_fallback_publication(p_strict_global_sort)) {
+					push_action(SortFallbackAction::PUBLISH_INSTANCE_IDENTITY);
+				}
 				push_action(SortFallbackAction::FAIL);
 			} else {
 				decision.cpu_sort_forced = true;
@@ -55,7 +61,9 @@ static inline SortFallbackPolicyDecision build_sort_fallback_policy(
 		case SortFallbackScenario::GPU_SORT_FAILED: {
 			push_action(SortFallbackAction::REUSE_PREVIOUS_SORT);
 			if (p_instance_pipeline_active) {
-				push_action(SortFallbackAction::PUBLISH_INSTANCE_IDENTITY);
+				if (allow_unsorted_fallback_publication(p_strict_global_sort)) {
+					push_action(SortFallbackAction::PUBLISH_INSTANCE_IDENTITY);
+				}
 			} else {
 				push_action(SortFallbackAction::RUN_CPU_SORT);
 			}

--- a/modules/gaussian_splatting/tests/test_gaussian_splatting.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splatting.h
@@ -36,6 +36,8 @@
 #include "test_synthetic_cloud_generator.h"
 #include "test_synthetic_mandelbrot_generator.h"
 #include "test_synthetic_bml_traffic_generator.h"
+#include "test_node_bootstrap.h"
+#include "test_shadow_instance_subset.h"
 
 namespace TestGaussianSplatting {
 

--- a/modules/gaussian_splatting/tests/test_node_bootstrap.h
+++ b/modules/gaussian_splatting/tests/test_node_bootstrap.h
@@ -1,0 +1,127 @@
+/**
+ * @file test_node_bootstrap.h
+ * @brief Regression test: GaussianSplatNode3D must bootstrap primary
+ *        gaussian_data on the shared renderer so the resident fallback
+ *        path can render during streaming warmup.
+ */
+
+#pragma once
+
+#include "tests/test_macros.h"
+
+#include "../core/gaussian_data.h"
+#include "../core/gaussian_splat_asset.h"
+#include "../core/gaussian_splat_scene_director.h"
+#include "../nodes/gaussian_splat_node_3d.h"
+#include "../renderer/gaussian_splat_renderer.h"
+#include "scene/main/scene_tree.h"
+#include "scene/main/window.h"
+
+namespace {
+
+/// Minimal single-splat asset used only by the bootstrap regression test.
+static Ref<GaussianSplatAsset> _make_bootstrap_test_asset() {
+	Ref<GaussianSplatAsset> asset;
+	asset.instantiate();
+	asset->set_splat_count(1);
+
+	PackedFloat32Array positions;
+	positions.resize(3);
+	{
+		float *ptr = positions.ptrw();
+		ptr[0] = 0.0f;
+		ptr[1] = 0.0f;
+		ptr[2] = 0.0f;
+	}
+	asset->set_positions(positions);
+
+	PackedFloat32Array scales;
+	scales.resize(3);
+	{
+		float *ptr = scales.ptrw();
+		ptr[0] = 1.0f;
+		ptr[1] = 1.0f;
+		ptr[2] = 1.0f;
+	}
+	asset->set_scales(scales);
+
+	PackedFloat32Array rotations;
+	rotations.resize(4);
+	{
+		float *ptr = rotations.ptrw();
+		ptr[0] = 1.0f; // w
+		ptr[1] = 0.0f;
+		ptr[2] = 0.0f;
+		ptr[3] = 0.0f;
+	}
+	asset->set_rotations(rotations);
+
+	PackedFloat32Array sh_dc;
+	sh_dc.resize(3);
+	{
+		float *ptr = sh_dc.ptrw();
+		ptr[0] = 1.0f;
+		ptr[1] = 1.0f;
+		ptr[2] = 1.0f;
+	}
+	asset->set_sh_dc_coefficients(sh_dc);
+
+	PackedFloat32Array opacity_logits;
+	opacity_logits.resize(1);
+	opacity_logits.set(0, 10.0f);
+	asset->set_opacity_logits(opacity_logits);
+
+	return asset;
+}
+
+} // anonymous namespace
+
+// [SceneTree] tag ensures the test harness creates a SceneTree before running.
+TEST_CASE("[GaussianSplatting][SceneTree] Asset-based node bootstraps primary gaussian_data on renderer") {
+	// Regression test for invisible-PLY-on-drag-drop bug:
+	// GaussianSplatNode3D must populate scene_state.gaussian_data on the
+	// shared renderer so the resident fallback path can render while the
+	// streaming instance pipeline warms up.
+
+	SceneTree *tree = SceneTree::get_singleton();
+	REQUIRE_MESSAGE(tree != nullptr, "SceneTree must exist (provided by [SceneTree] tag)");
+
+	Window *root = tree->get_root();
+	REQUIRE_MESSAGE(root != nullptr, "SceneTree root window must exist");
+
+	Ref<GaussianSplatAsset> asset = _make_bootstrap_test_asset();
+	CHECK(asset.is_valid());
+	CHECK(asset->get_splat_count() > 0);
+
+	GaussianSplatNode3D *node = memnew(GaussianSplatNode3D);
+	node->set_splat_asset(asset);
+
+	root->add_child(node);
+	tree->process(0.0);
+
+	Ref<GaussianSplatRenderer> renderer = node->get_renderer();
+
+	// In headless mode (no RenderingServer), the renderer won't be created.
+	// The full bootstrap path is only exercisable with a GPU device.
+	if (!renderer.is_valid()) {
+		MESSAGE("Renderer unavailable (headless mode) — skipping renderer state checks");
+	}
+	if (renderer.is_valid()) {
+		const auto &scene_state = renderer->get_scene_state();
+		CHECK_MESSAGE(scene_state.gaussian_data.is_valid(),
+				"Renderer scene_state.gaussian_data must be set by GaussianSplatNode3D bootstrap");
+		if (scene_state.gaussian_data.is_valid()) {
+			CHECK(scene_state.gaussian_data->get_count() > 0);
+		}
+
+		GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
+		if (director) {
+			LocalVector<InstanceDataGPU> instance_buffer;
+			director->build_instance_buffer_for_renderer(renderer.ptr(), instance_buffer);
+			CHECK(instance_buffer.size() >= 1);
+		}
+	}
+
+	root->remove_child(node);
+	memdelete(node);
+}

--- a/modules/gaussian_splatting/tests/test_shadow_instance_subset.h
+++ b/modules/gaussian_splatting/tests/test_shadow_instance_subset.h
@@ -1,0 +1,136 @@
+#pragma once
+
+#include "tests/test_macros.h"
+
+#include "../core/gaussian_splat_asset.h"
+#include "../core/gaussian_splat_scene_director.h"
+#include "../nodes/gaussian_splat_node_3d.h"
+#include "../renderer/gaussian_gpu_layout.h"
+#include "../renderer/gaussian_splat_renderer.h"
+#include "scene/main/scene_tree.h"
+#include "scene/main/window.h"
+
+namespace {
+
+static Ref<GaussianSplatAsset> _make_shadow_subset_test_asset(float p_x_offset) {
+	Ref<GaussianSplatAsset> asset;
+	asset.instantiate();
+	asset->set_splat_count(1);
+
+	PackedFloat32Array positions;
+	positions.resize(3);
+	{
+		float *ptr = positions.ptrw();
+		ptr[0] = p_x_offset;
+		ptr[1] = 0.0f;
+		ptr[2] = 0.0f;
+	}
+	asset->set_positions(positions);
+
+	PackedFloat32Array scales;
+	scales.resize(3);
+	{
+		float *ptr = scales.ptrw();
+		ptr[0] = 1.0f;
+		ptr[1] = 1.0f;
+		ptr[2] = 1.0f;
+	}
+	asset->set_scales(scales);
+
+	PackedFloat32Array rotations;
+	rotations.resize(4);
+	{
+		float *ptr = rotations.ptrw();
+		ptr[0] = 1.0f;
+		ptr[1] = 0.0f;
+		ptr[2] = 0.0f;
+		ptr[3] = 0.0f;
+	}
+	asset->set_rotations(rotations);
+
+	PackedFloat32Array sh_dc;
+	sh_dc.resize(3);
+	{
+		float *ptr = sh_dc.ptrw();
+		ptr[0] = 1.0f;
+		ptr[1] = 1.0f;
+		ptr[2] = 1.0f;
+	}
+	asset->set_sh_dc_coefficients(sh_dc);
+
+	PackedFloat32Array opacity_logits;
+	opacity_logits.resize(1);
+	opacity_logits.set(0, 10.0f);
+	asset->set_opacity_logits(opacity_logits);
+
+	return asset;
+}
+
+} // namespace
+
+TEST_CASE("[GaussianSplatting][SceneTree] Shared renderer shadow subset follows per-instance cast_shadow state") {
+	SceneTree *tree = SceneTree::get_singleton();
+	REQUIRE_MESSAGE(tree != nullptr, "SceneTree must exist (provided by [SceneTree] tag)");
+
+	Window *root = tree->get_root();
+	REQUIRE_MESSAGE(root != nullptr, "SceneTree root window must exist");
+
+	GaussianSplatNode3D *node_a = memnew(GaussianSplatNode3D);
+	GaussianSplatNode3D *node_b = memnew(GaussianSplatNode3D);
+	node_a->set_splat_asset(_make_shadow_subset_test_asset(0.0f));
+	node_b->set_splat_asset(_make_shadow_subset_test_asset(10.0f));
+	node_b->set_cast_shadow(true);
+
+	root->add_child(node_a);
+	root->add_child(node_b);
+	tree->process(0.0);
+
+	Ref<GaussianSplatRenderer> renderer_a = node_a->get_renderer();
+	Ref<GaussianSplatRenderer> renderer_b = node_b->get_renderer();
+	if (!renderer_a.is_valid() || !renderer_b.is_valid()) {
+		MESSAGE("Shared renderer unavailable (headless/no RenderingDevice) — skipping shadow subset checks");
+		root->remove_child(node_b);
+		root->remove_child(node_a);
+		memdelete(node_b);
+		memdelete(node_a);
+		return;
+	}
+	REQUIRE(renderer_a == renderer_b);
+
+	GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
+	REQUIRE(director != nullptr);
+
+	LocalVector<InstanceDataGPU> all_instances;
+	LocalVector<InstanceDataGPU> shadow_instances;
+	LocalVector<InstanceAssetRegistration> all_assets;
+	LocalVector<InstanceAssetRegistration> shadow_assets;
+
+	director->build_instance_buffer_for_renderer(renderer_a.ptr(), all_instances);
+	director->build_instance_buffer_for_renderer(renderer_a.ptr(), shadow_instances, true);
+	director->collect_instance_assets_for_renderer(renderer_a.ptr(), all_assets);
+	director->collect_instance_assets_for_renderer(renderer_a.ptr(), shadow_assets, true);
+
+	CHECK_EQ(all_instances.size(), 2);
+	CHECK_EQ(shadow_instances.size(), 1);
+	CHECK_EQ(all_assets.size(), 2);
+	CHECK_EQ(shadow_assets.size(), 1);
+
+	node_b->set_cast_shadow(false);
+	tree->process(0.0);
+	director->build_instance_buffer_for_renderer(renderer_a.ptr(), shadow_instances, true);
+	director->collect_instance_assets_for_renderer(renderer_a.ptr(), shadow_assets, true);
+	CHECK_EQ(shadow_instances.size(), 0);
+	CHECK_EQ(shadow_assets.size(), 0);
+
+	node_a->set_cast_shadow(true);
+	tree->process(0.0);
+	director->build_instance_buffer_for_renderer(renderer_a.ptr(), shadow_instances, true);
+	director->collect_instance_assets_for_renderer(renderer_a.ptr(), shadow_assets, true);
+	CHECK_EQ(shadow_instances.size(), 1);
+	CHECK_EQ(shadow_assets.size(), 1);
+
+	root->remove_child(node_b);
+	root->remove_child(node_a);
+	memdelete(node_b);
+	memdelete(node_a);
+}

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -239,7 +239,7 @@ static void _gaussian_shadow_dispatch(const RenderDataRD *p_render_data, const L
 			continue;
 		}
 
-		_gaussian_shadow_submit(p_render_data->gaussian_splat_renderers, dispatch);
+		_gaussian_shadow_submit(p_render_data->gaussian_shadow_renderers, dispatch);
 		p_finalize_func(shadow, light_instance, base_light, light_type, dispatch);
 	}
 }
@@ -1735,7 +1735,7 @@ void RenderForwardClustered::_pre_opaque_render(RenderDataRD *p_render_data, boo
 	if (render_shadows) {
 		_render_shadow_end();
 #ifdef MODULE_GAUSSIAN_SPLATTING_ENABLED
-		if (!p_render_data->gaussian_splat_renderers.is_empty()) {
+		if (!p_render_data->gaussian_shadow_renderers.is_empty()) {
 			if (p_render_data->directional_shadows.size()) {
 				const RID directional_fb = light_storage->direction_shadow_get_fb();
 				if (directional_fb.is_valid()) {

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -87,6 +87,7 @@ void RendererSceneRenderRD::commit_gaussian_splats(RenderDataRD &p_render_data) 
 		renderer->commit_to_render_buffers(&p_render_data);
 	}
 	p_render_data.gaussian_splat_renderers.clear();
+	p_render_data.gaussian_shadow_renderers.clear();
 }
 #endif
 #include "servers/rendering/renderer_rd/shaders/decal_data_inc.glsl.gen.h"
@@ -1486,6 +1487,7 @@ void RendererSceneRenderRD::render_scene(const Ref<RenderSceneBuffers> &p_render
 
 #ifdef MODULE_GAUSSIAN_SPLATTING_ENABLED
 		render_data.gaussian_splat_renderers.clear();
+		render_data.gaussian_shadow_renderers.clear();
 		RendererRD::GaussianSplatStorage *gaussian_storage = RendererRD::GaussianSplatStorage::get_singleton();
 
 		if (gaussian_storage != nullptr && render_data.gaussian_splats != nullptr) {
@@ -1493,7 +1495,9 @@ void RendererSceneRenderRD::render_scene(const Ref<RenderSceneBuffers> &p_render
 				// print_line(vformat("[Forward+] Found %d gaussian splat RIDs to process", render_data.gaussian_splats->size()));
 			}
 			HashSet<ObjectID> seen_renderers;
+			HashSet<ObjectID> seen_shadow_renderers;
 			seen_renderers.reserve(render_data.gaussian_splats->size());
+			seen_shadow_renderers.reserve(render_data.gaussian_splats->size());
 			for (uint64_t i = 0; i < render_data.gaussian_splats->size(); i++) {
 			const RID &gaussian_rid = (*render_data.gaussian_splats)[i];
 				if (!gaussian_rid.is_valid()) {
@@ -1509,6 +1513,11 @@ void RendererSceneRenderRD::render_scene(const Ref<RenderSceneBuffers> &p_render
 				}
 
 				ObjectID renderer_id = gaussian_renderer->get_instance_id();
+				const bool casts_shadow = gaussian_storage->gaussian_get_casts_shadow(gaussian_rid);
+				if (casts_shadow && !seen_shadow_renderers.has(renderer_id)) {
+					seen_shadow_renderers.insert(renderer_id);
+					render_data.gaussian_shadow_renderers.push_back(gaussian_renderer);
+				}
 				if (seen_renderers.has(renderer_id)) {
 					continue;
 				}

--- a/servers/rendering/renderer_rd/storage_rd/gaussian_splat_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/gaussian_splat_storage.cpp
@@ -87,8 +87,19 @@ void GaussianSplatStorage::gaussian_set_aabb(RID p_rid, const AABB &p_aabb) {
 }
 
 AABB GaussianSplatStorage::gaussian_get_aabb(RID p_rid) const {
-        const GaussianSplat *splat = gaussian_owner.get_or_null(p_rid);
-        ERR_FAIL_NULL_V(splat, AABB());
-        return splat->aabb;
+	const GaussianSplat *splat = gaussian_owner.get_or_null(p_rid);
+	ERR_FAIL_NULL_V(splat, AABB());
+	return splat->aabb;
 }
 
+void GaussianSplatStorage::gaussian_set_casts_shadow(RID p_rid, bool p_casts_shadow) {
+	GaussianSplat *splat = gaussian_owner.get_or_null(p_rid);
+	ERR_FAIL_NULL(splat);
+	splat->casts_shadow = p_casts_shadow;
+}
+
+bool GaussianSplatStorage::gaussian_get_casts_shadow(RID p_rid) const {
+	const GaussianSplat *splat = gaussian_owner.get_or_null(p_rid);
+	ERR_FAIL_NULL_V(splat, false);
+	return splat->casts_shadow;
+}

--- a/servers/rendering/renderer_rd/storage_rd/gaussian_splat_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/gaussian_splat_storage.h
@@ -42,12 +42,13 @@
 namespace RendererRD {
 
 class GaussianSplatStorage {
-        struct GaussianSplat {
+	struct GaussianSplat {
 #ifdef MODULE_GAUSSIAN_SPLATTING_ENABLED
-                Ref<GaussianSplatRenderer> renderer;
+		Ref<GaussianSplatRenderer> renderer;
 #endif
-                AABB aabb;
-        };
+		AABB aabb;
+		bool casts_shadow = false;
+	};
 
         static GaussianSplatStorage *singleton;
         mutable RID_Owner<GaussianSplat> gaussian_owner;
@@ -65,12 +66,13 @@ public:
         bool owns_gaussian(RID p_rid) const;
 
 #ifdef MODULE_GAUSSIAN_SPLATTING_ENABLED
-        void gaussian_set_renderer(RID p_rid, const Ref<GaussianSplatRenderer> &p_renderer);
-        Ref<GaussianSplatRenderer> gaussian_get_renderer(RID p_rid) const;
+	void gaussian_set_renderer(RID p_rid, const Ref<GaussianSplatRenderer> &p_renderer);
+	Ref<GaussianSplatRenderer> gaussian_get_renderer(RID p_rid) const;
 #endif
-        void gaussian_set_aabb(RID p_rid, const AABB &p_aabb);
-        AABB gaussian_get_aabb(RID p_rid) const;
+	void gaussian_set_aabb(RID p_rid, const AABB &p_aabb);
+	AABB gaussian_get_aabb(RID p_rid) const;
+	void gaussian_set_casts_shadow(RID p_rid, bool p_casts_shadow);
+	bool gaussian_get_casts_shadow(RID p_rid) const;
 };
 
 } // namespace RendererRD
-

--- a/servers/rendering/renderer_rd/storage_rd/render_data_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_data_rd.h
@@ -69,6 +69,7 @@ public:
         const PagedArray<RID> *gaussian_splats = nullptr;
 #ifdef MODULE_GAUSSIAN_SPLATTING_ENABLED
 	LocalVector<Ref<GaussianSplatRenderer>> gaussian_splat_renderers;
+	LocalVector<Ref<GaussianSplatRenderer>> gaussian_shadow_renderers;
 #endif
 	RID environment;
 	RID camera_attributes;


### PR DESCRIPTION
## Summary
- Plumbs per-instance `cast_shadow` through SceneDirector to engine shadow passes
- Propagates DC encoding metadata through asset populate and merge paths (GaussianDCEncoding enum, render_meta field, SH metadata packing)
- Fixes resource lifecycle ordering (forget_resource_owner before unregister_gaussian_buffer)
- Sort fallback strict mode with did_execute tracking
- Shared-renderer state preservation across multi-instance nodes
- GPU layout: static_assert offset verification for PackedGaussian
- Importer: stale .gsplatworld cleanup on decode failure
- Minimum regression tests: shadow instance subset + node bootstrap

**Dependency note:** Full regression validation is performed on stacked PR (test/infra-and-suite-split). This PR alone passes build + guards + the headless suite as available.

## Test plan
- [x] Build: `scons platform=windows target=editor dev_build=yes tests=yes -j14` — green
- [x] Guards: `python tests/ci/run_module_tests.py --guard-only` — green
- [x] Headless suite: 27 test cases, 0 failed assertions
- [ ] Full regression validation on stacked PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)