### PR TITLE
fix: skip CPU distance/frustum culling in editor viewport

### DIFF
--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -1482,10 +1482,15 @@ void GaussianSplatNode3D::_update_visibility() {
                 new_visibility = true;
             } else {
                 new_visibility = true;
-                const Transform3D camera_to_world_transform = camera->get_camera_transform();
-                const Vector3 camera_position = camera_to_world_transform.origin;
-
-                if (max_render_distance > 0.0f) {
+                // In editor, viewport->get_camera_3d() returns a scene
+                // Camera3D node rather than the editor navigation camera,
+                // so CPU-side distance and frustum culling would use the
+                // wrong position.  Skip both checks in editor; the GPU
+                // cull shader uses the correct camera.
+                const bool is_editor = Engine::get_singleton()->is_editor_hint();
+                if (!is_editor && max_render_distance > 0.0f) {
+                    const Transform3D camera_to_world_transform = camera->get_camera_transform();
+                    const Vector3 camera_position = camera_to_world_transform.origin;
                     const Vector3 center = world_aabb.get_center();
                     const float radius = world_aabb.get_longest_axis_size() * 0.5f;
                     const float distance_to_center = camera_position.distance_to(center);
@@ -1495,7 +1500,7 @@ void GaussianSplatNode3D::_update_visibility() {
                     }
                 }
 
-                if (new_visibility && use_frustum_culling) {
+                if (new_visibility && use_frustum_culling && !is_editor) {
                     RendererSceneCull::Frustum frustum(camera->get_frustum());
                     RendererSceneCull::InstanceBounds bounds(world_aabb);
                     if (!bounds.in_frustum(frustum)) {
@@ -1507,6 +1512,7 @@ void GaussianSplatNode3D::_update_visibility() {
     }
 
     visible_in_viewport = new_visibility;
+
     if (render_instance.is_valid()) {
         if (RenderingServer *rs = RS::get_singleton()) {
             rs->instance_set_visible(render_instance, parent_visible && visible_in_viewport && is_visible_in_tree());


### PR DESCRIPTION
## Summary
- **Root cause**: In the editor, `viewport->get_camera_3d()` returns a scene `Camera3D` node (e.g. at origin) rather than the editor's navigation camera. CPU-side distance and frustum culling used this wrong camera position, rejecting `GaussianSplatNode3D` instances that were visible in the editor viewport but outside the scene camera's frustum.
- **Symptom**: Newly added splat nodes showed only debug/point preview but no actual Gaussian Splat rendering. Only the first node (near the scene camera) rendered correctly.
- **Fix**: Skip CPU distance and frustum culling when `Engine::is_editor_hint()` is true. The GPU cull shader already uses the correct editor camera and handles both checks on its own.

## Test plan
- [x] Open editor, load scene with multiple `GaussianSplatNode3D` instances at various positions
- [x] Verify all instances render Gaussian Splats (not just debug points)
- [x] Verify runtime rendering still works (CPU culling active at runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)