### PR TITLE
fix: use proper bounding sphere radius in cluster builder

### DIFF
--- a/modules/gaussian_splatting/lod/cluster_builder.cpp
+++ b/modules/gaussian_splatting/lod/cluster_builder.cpp
@@ -170,7 +170,7 @@ ClusterBuildResult ClusterBuilder::build_clusters(
         cluster.bounds = compute_cluster_bounds(p_gaussians, result.sorted_splat_order, splat_offset, count, max_radius);
         cluster.max_splat_radius = max_radius;
         cluster.center = cluster.bounds.get_center();
-        cluster.radius = cluster.bounds.get_longest_axis_size() * 0.5f;
+        cluster.radius = (cluster.bounds.size * 0.5f).length();
 
         // Compute importance sum
         if (p_params.compute_importance) {
@@ -266,7 +266,7 @@ ClusterBuildResult ClusterBuilder::update_clusters_incremental(
         );
         cluster.max_splat_radius = max_radius;
         cluster.center = cluster.bounds.get_center();
-        cluster.radius = cluster.bounds.get_longest_axis_size() * 0.5f;
+        cluster.radius = (cluster.bounds.size * 0.5f).length();
 
         // Recompute importance
         cluster.importance_sum = 0.0f;


### PR DESCRIPTION
## Summary
- Fixes incorrect bounding sphere radius computation in `cluster_builder.cpp`
- Was using `get_longest_axis_size() * 0.5f` (half longest axis) instead of `(bounds.size * 0.5f).length()` (actual bounding sphere)
- This under-estimates the radius for non-cubic bounds, causing incorrect cluster culling

Cherry-picked from `develop` branch.

## Test plan
- [ ] Verify cluster culling correctness with non-uniform bounds
- [ ] GPU QA tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)