### PR TITLE
fix: resolve critical GPU buffer state machine races and rendering edge cases

### DIFF
--- a/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
@@ -38,7 +38,7 @@ static Dictionary _build_runtime_load_timing(const String &p_stage,
 
 } // namespace
 
-uint32_t GaussianSplatAsset::instance_count = 0;
+std::atomic<uint32_t> GaussianSplatAsset::instance_count{ 0 };
 
 void GaussianSplatAsset::_bind_methods() {
     ClassDB::bind_method(D_METHOD("set_asset_type", "type"), &GaussianSplatAsset::set_asset_type);

--- a/modules/gaussian_splatting/core/gaussian_splat_asset.h
+++ b/modules/gaussian_splatting/core/gaussian_splat_asset.h
@@ -9,6 +9,8 @@
 #include "core/math/vector3.h"
 #include "core/variant/typed_array.h"
 
+#include <atomic>
+
 class GaussianData;
 
 class GaussianSplatAsset : public Resource {
@@ -55,7 +57,7 @@ private:
     bool has_sh_dc_coefficients = false;
     mutable Ref<::GaussianData> gaussian_data_cache;
 
-    static uint32_t instance_count;
+    static std::atomic<uint32_t> instance_count;
 
     void _recalculate_sh_component_counts();
     void _ensure_buffer_sizes();
@@ -124,7 +126,7 @@ public:
     void set_stroke_ages(const PackedFloat32Array &p_stroke_ages);
     void set_sh_component_terms(uint32_t p_first_order_terms, uint32_t p_high_order_terms);
 
-    static uint32_t get_instance_count() { return instance_count; }
+    static uint32_t get_instance_count() { return instance_count.load(); }
 
     void set_import_metadata(const Dictionary &p_metadata);
     Dictionary get_import_metadata() const { return import_metadata; }

--- a/modules/gaussian_splatting/core/gaussian_splat_quality_config.h
+++ b/modules/gaussian_splatting/core/gaussian_splat_quality_config.h
@@ -51,6 +51,14 @@ struct GaussianSplatStreamingConfig {
 	float painterly_hold_strength = 0.2f;
 
 	uint32_t stream_budget_ms = 2;
+	// WARNING: enable_async_loading is currently dead config. It is written by
+	// GaussianSplatNodeQualityHelper::apply_streaming_config_values() but never
+	// read by any production code path. StreamingPipeline::start_streaming(),
+	// which would consume this flag, is only called from tests. The production
+	// render path drives GPU uploads via explicit per-frame calls through
+	// RenderDataOrchestrator and streaming_config_overrides, which do not
+	// consult this flag. Do not rely on this field until it is wired into the
+	// production streaming path. See gpu_memory_stream.h StreamingPipeline.
 	bool enable_async_loading = true;
 	bool enable_compression = true;
 };

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
@@ -1077,6 +1077,11 @@ void GaussianSplatNodeQualityHelper::apply_streaming_config_values(int effective
     owner.streaming_config.painterly_hold_strength = owner.edge_threshold;
     owner.streaming_config.stream_budget_ms = effective_stream_budget_ms;
     owner.streaming_config.enable_async_loading = async_loading;
+    if (!async_loading) {
+        WARN_PRINT_ONCE("GaussianSplat: enable_async_loading is set to false, but this flag is not currently "
+                "wired to any production code path. Streaming behavior will not change. "
+                "See gaussian_splat_quality_config.h for details.");
+    }
     owner.streaming_config.enable_compression = compression;
 }
 

--- a/modules/gaussian_splatting/renderer/gpu_memory_stream.cpp
+++ b/modules/gaussian_splatting/renderer/gpu_memory_stream.cpp
@@ -745,11 +745,16 @@ RID GaussianMemoryStream::get_current_gpu_buffer() {
         _wait_for_buffer_complete(idx, false);
         BufferState expected = BUFFER_READY;
         if (!buffers[idx].state.compare_exchange_strong(expected, BUFFER_RENDERING)) {
-            if (expected != BUFFER_RENDERING) {
-                buffers[idx].state.store(BUFFER_RENDERING);
+            if (expected == BUFFER_RENDERING) {
+                // Already being rendered - still safe to return
+                active_rendering_index.store(idx);
+                return buffers[idx].gpu_buffer;
             }
+            // Buffer is in unexpected state (FREE/UPLOADING) - fall through to linear scan
+        } else {
+            active_rendering_index.store(idx);
+            return buffers[idx].gpu_buffer;
         }
-        return buffers[idx].gpu_buffer;
     }
 
     for (int i = 0; i < BUFFER_COUNT; i++) {
@@ -763,11 +768,14 @@ RID GaussianMemoryStream::get_current_gpu_buffer() {
             if (state == BUFFER_READY) {
                 BufferState expected2 = BUFFER_READY;
                 if (!buffers[i].state.compare_exchange_strong(expected2, BUFFER_RENDERING)) {
-                    if (expected2 != BUFFER_RENDERING) {
-                        buffers[i].state.store(BUFFER_RENDERING);
+                    if (expected2 == BUFFER_RENDERING) {
+                        active_rendering_index.store(i);
+                        return buffers[i].gpu_buffer;
                     }
+                    continue;  // State changed unexpectedly, try next buffer
                 }
             }
+            active_rendering_index.store(i);
             return buffers[i].gpu_buffer;
         }
     }
@@ -776,11 +784,14 @@ RID GaussianMemoryStream::get_current_gpu_buffer() {
 }
 
 void GaussianMemoryStream::swap_buffers() {
-    int current_idx = read_index % BUFFER_COUNT;
-    if (buffers[current_idx].state == BUFFER_RENDERING) {
-        buffers[current_idx].state = BUFFER_FREE;
-        buffers[current_idx].frame_last_used = current_frame;
+    int current_idx = active_rendering_index.load();
+    if (current_idx >= 0 && current_idx < BUFFER_COUNT) {
+        BufferState expected = BUFFER_RENDERING;
+        if (buffers[current_idx].state.compare_exchange_strong(expected, BUFFER_FREE)) {
+            buffers[current_idx].frame_last_used = current_frame;
+        }
     }
+    active_rendering_index.store(-1);
 
     read_index = (read_index + 1) % BUFFER_COUNT;
 }

--- a/modules/gaussian_splatting/renderer/gpu_memory_stream.h
+++ b/modules/gaussian_splatting/renderer/gpu_memory_stream.h
@@ -100,6 +100,7 @@ private:
     std::atomic<int> write_index{0};
     std::atomic<int> read_index{0};
     std::atomic<int> upload_index{0};
+    std::atomic<int> active_rendering_index{-1};
 
     // Upload fence tracking
     std::atomic<uint64_t> upload_timeline{0};

--- a/modules/gaussian_splatting/renderer/tile_render_prefix_scan.cpp
+++ b/modules/gaussian_splatting/renderer/tile_render_prefix_scan.cpp
@@ -278,8 +278,13 @@ bool TileRenderer::TilePrefixScanStage::update_global_tile_ranges(const RID &p_g
         RenderingDevice *p_device,
 		uint32_t &r_record_count, uint32_t &r_raw_record_count, bool p_allow_sync_readback) {
 	RenderingDevice *device = p_device ? p_device : owner._get_resource_device();
-	if (!device || owner.grid_state.total_tiles == 0) {
+	if (!device) {
 		return false;
+	}
+	if (owner.grid_state.total_tiles == 0) {
+		r_record_count = 0u;
+		r_raw_record_count = 0u;
+		return true;
 	}
 	if (!owner.global_sort_resources.get_tile_counts_buffer().is_valid() || !owner.global_sort_resources.tile_ranges_buffer.is_valid() ||
 			!owner.global_sort_resources.wg_sums_buffer.is_valid() || !owner.global_sort_resources.wg_offsets_buffer.is_valid()) {


### PR DESCRIPTION
- Replace unsafe CAS fallback force-stores in get_current_gpu_buffer() with
  correct atomic logic: accept BUFFER_RENDERING state or skip buffer on
  unexpected state, never force-store past a failed compare-exchange
- Add explicit active_rendering_index tracking to swap_buffers() instead of
  fragile modulo-based index inference, using proper CAS for state transitions
- Handle zero-tile frames as valid no-op in update_global_tile_ranges(),
  matching run_cpu_prefix_fallback() behavior (return true with zeroed outputs)
- Make GaussianSplatAsset::instance_count thread-safe with std::atomic, fixing
  data race when threaded PLY/SPZ importers construct assets concurrently
- Document enable_async_loading as dead config with runtime WARN_PRINT_ONCE
  when explicitly disabled, since the flag is never read in production paths

https://claude.ai/code/session_017hvBoUqQZ6xxgJZeenr3Y6