### PR TITLE
gaussian_splatting: audit editor workflow and fix color grading leak

### DIFF
--- a/modules/gaussian_splatting/docs/GAUSSIAN_EDITOR_UX_REDESIGN_CHECKLIST.md
+++ b/modules/gaussian_splatting/docs/GAUSSIAN_EDITOR_UX_REDESIGN_CHECKLIST.md
@@ -49,16 +49,22 @@ The Gaussian bottom panel is no longer part of the normal editor flow.
 - [x] Preserved asset metadata summary and `Reimport...` action in the asset inspector.
 - [x] Added safe fallback behavior when the interactive preview cannot be shown.
 - [x] Kept preview generation anchored in existing thumbnail infrastructure for filesystem previews.
-- [x] Enabled 3D viewport drag-and-drop acceptance for `GaussianSplatAsset`.
-- [x] Added `GaussianSplatNode3D` instantiation on viewport drop with undo/redo integration.
+- [ ] ~~Enabled 3D viewport drag-and-drop acceptance for `GaussianSplatAsset`.~~ **Audit 2026-04-03: NOT implemented.** No `forward_3d_gui_input` or viewport-level drop handler exists in `GaussianEditorPlugin`. Only on-node `_drop_data_fw` exists (drops onto an existing node, not into empty viewport).
+- [ ] ~~Added `GaussianSplatNode3D` instantiation on viewport drop with undo/redo integration.~~ **Audit 2026-04-03: NOT implemented.** No code creates a new node on viewport drop.
 - [x] Removed the Gaussian bottom panel from `GaussianEditorPlugin` primary workflow.
+- [x] Gated painterly brush tools UI behind `painterly/enabled` and valid data. Brush UI no longer appears unconditionally for every node.
+- [x] Broadened shared-renderer color grading guard to cover both multi-instance and active world submissions. Renamed `_is_multi_instance_shared_renderer_active` to `_is_renderer_shared_with_other_content` and added `has_world_submission_for_renderer` check. Shared-renderer mode no longer leaks one node's grading to others or to world content.
+- [x] Added disabled states to bake/restore color grading buttons (disabled when no data, no grading, or wrong bake state).
+- [x] Added 4 color grading tests: single-node push, enter/exit tree survival, signal propagation, and world submission blocking node grading push with recovery.
 
-### Follow-up optional improvements
+### Follow-up improvements
 
-- [ ] Verify direct raw `.ply`/`.spz` drag semantics in the viewport and decide whether to support them explicitly.
+- [ ] Implement viewport-level drag-and-drop for `GaussianSplatAsset` (create node on drop with undo/redo).
+- [ ] Verify direct raw `.ply`/`.spz` drag semantics in the viewport and decide whether to support them explicitly. Currently falls back to `ply_file_path` if asset load fails.
 - [ ] Replace the proxy inspector preview with a deeper renderer-backed preview if coupling stays manageable.
 - [ ] Tighten asset inspector layout and styling once the workflow is stable.
 - [ ] Add automated tests or scripted editor QA for preview and reimport behavior.
+- [ ] Add per-instance color grading support in the instance pipeline (currently renderer-level only, hidden in multi-instance mode).
 
 ## Manual QA Checklist
 
@@ -74,18 +80,25 @@ Run these steps in the editor on a clean project copy:
 8. Select an asset state that cannot build the interactive preview and confirm the fallback thumbnail or empty state appears safely.
 9. Press `Reimport...` from the asset inspector and confirm the import settings dialog opens with the saved configuration.
 10. Reimport the asset and confirm the metadata/thumbnail state refreshes.
-11. Drag the imported Gaussian asset into the 3D viewport.
-12. Confirm the drop creates a `GaussianSplatNode3D`.
-13. Verify the created node has the expected asset assigned.
-14. Use undo after the drop and confirm the node creation is reverted.
-15. Use redo after undo and confirm the node is restored.
-16. Modify the asset, reimport it, and confirm existing scene instances pick up the change or refresh as expected.
-17. Trigger any hot-reload path available on this branch and confirm the editor does not lose the asset link or crash.
+11. ~~Drag the imported Gaussian asset into the 3D viewport.~~ **Blocked: viewport drop not implemented.**
+12. ~~Confirm the drop creates a `GaussianSplatNode3D`.~~ **Blocked: viewport drop not implemented.**
+13. ~~Verify the created node has the expected asset assigned.~~ **Blocked: viewport drop not implemented.**
+14. ~~Use undo after the drop and confirm the node creation is reverted.~~ **Blocked: viewport drop not implemented.**
+15. ~~Use redo after undo and confirm the node is restored.~~ **Blocked: viewport drop not implemented.**
+16. Instead: manually add a `GaussianSplatNode3D`, assign the imported asset via the inspector, and confirm it loads and renders.
+17. Drag a `.ply` file onto an existing `GaussianSplatNode3D` and confirm asset-first load (not `ply_file_path` fallback if already imported).
+18. Modify the asset, reimport it, and confirm existing scene instances pick up the change or refresh as expected.
+19. Trigger any hot-reload path available on this branch and confirm the editor does not lose the asset link or crash.
+20. Add two `GaussianSplatNode3D` instances sharing one renderer. Confirm color grading property is hidden on both nodes.
+21. Remove one node. Confirm color grading reappears on the remaining node and reaches the renderer.
+22. Confirm brush tools UI does not appear when `painterly/enabled` is false.
+23. Enable `painterly/enabled` on a node with valid data. Confirm brush tools appear.
+24. Confirm bake button is disabled when no `ColorGradingResource` is assigned. Assign one and confirm bake becomes enabled.
 
 ## Risk Notes
 
 - The current asset preview is a proxy visualization plus thumbnail fallback, not full renderer-viewport parity yet.
-- Drag-and-drop currently targets imported `GaussianSplatAsset` flow in the viewport path; direct raw file-drop semantics should be tested explicitly on this branch.
+- **Viewport-level drag-and-drop is not implemented.** Only on-node drops (onto an existing `GaussianSplatNode3D`) work. On-node drops try asset-first load, then fall back to `ply_file_path`. Direct raw file-drop semantics should be tested explicitly once viewport drop is implemented.
 - Any future move from proxy preview to renderer-backed preview should be treated as a coupling risk and validated against editor stability.
 - Bottom-panel removal should be sequenced after drag/drop and node-inspector behavior are fully stable.
 

--- a/modules/gaussian_splatting/editor/gaussian_inspector_plugins.cpp
+++ b/modules/gaussian_splatting/editor/gaussian_inspector_plugins.cpp
@@ -628,185 +628,190 @@ void GaussianSplatNodeInspectorPlugin::parse_begin(Object *p_object) {
     root->add_child(runtime_row);
 #endif
 
-    HSeparator *paint_separator = memnew(HSeparator);
-    root->add_child(paint_separator);
+    // Painterly Brush Tools: only shown when painterly is enabled and valid data is loaded.
+    {
+        Ref<GaussianSplatRenderer> brush_renderer = node->get_renderer();
+        Ref<::GaussianData> brush_data = brush_renderer.is_valid() ? brush_renderer->get_gaussian_data() : Ref<::GaussianData>();
+        const bool has_valid_data = brush_data.is_valid() && brush_data->get_count() > 0;
 
-    Label *paint_label = memnew(Label);
-    paint_label->set_text(TTR("Painterly Brush Tools"));
-    root->add_child(paint_label);
+        if (node->is_painterly_enabled() && has_valid_data) {
+            HSeparator *paint_separator = memnew(HSeparator);
+            root->add_child(paint_separator);
 
-    Label *paint_hint = memnew(Label);
-    paint_hint->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
-    paint_hint->set_text(TTR("Session-only brush controls: values persist while the editor stays open and are not saved to scenes or resources."));
-    root->add_child(paint_hint);
+            Label *paint_label = memnew(Label);
+            paint_label->set_text(TTR("Painterly Brush Tools"));
+            root->add_child(paint_label);
 
-    GridContainer *paint_grid = memnew(GridContainer);
-    paint_grid->set_columns(2);
-    paint_grid->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+            Label *paint_hint = memnew(Label);
+            paint_hint->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
+            paint_hint->set_text(TTR("Session-only brush controls: values persist while the editor stays open and are not saved to scenes or resources."));
+            root->add_child(paint_hint);
 
-    Vector3 node_position = node->get_global_position();
-    if (!brush_session_state.has_center) {
-        brush_session_state.center = node_position;
-        brush_session_state.has_center = true;
+            GridContainer *paint_grid = memnew(GridContainer);
+            paint_grid->set_columns(2);
+            paint_grid->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+
+            Vector3 node_position = node->get_global_position();
+            if (!brush_session_state.has_center) {
+                brush_session_state.center = node_position;
+                brush_session_state.has_center = true;
+            }
+
+            Label *center_label = memnew(Label);
+            center_label->set_text(TTR("Center X"));
+            paint_grid->add_child(center_label);
+            SpinBox *center_x = memnew(SpinBox);
+            center_x->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+            center_x->set_min(-10000.0);
+            center_x->set_max(10000.0);
+            center_x->set_step(0.1);
+            center_x->set_value(brush_session_state.center.x);
+            center_x->connect("value_changed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_brush_center_changed).bind(0));
+            paint_grid->add_child(center_x);
+
+            Label *center_y_label = memnew(Label);
+            center_y_label->set_text(TTR("Center Y"));
+            paint_grid->add_child(center_y_label);
+            SpinBox *center_y = memnew(SpinBox);
+            center_y->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+            center_y->set_min(-10000.0);
+            center_y->set_max(10000.0);
+            center_y->set_step(0.1);
+            center_y->set_value(brush_session_state.center.y);
+            center_y->connect("value_changed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_brush_center_changed).bind(1));
+            paint_grid->add_child(center_y);
+
+            Label *center_z_label = memnew(Label);
+            center_z_label->set_text(TTR("Center Z"));
+            paint_grid->add_child(center_z_label);
+            SpinBox *center_z = memnew(SpinBox);
+            center_z->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+            center_z->set_min(-10000.0);
+            center_z->set_max(10000.0);
+            center_z->set_step(0.1);
+            center_z->set_value(brush_session_state.center.z);
+            center_z->connect("value_changed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_brush_center_changed).bind(2));
+            paint_grid->add_child(center_z);
+
+            Label *radius_label = memnew(Label);
+            radius_label->set_text(TTR("Radius"));
+            paint_grid->add_child(radius_label);
+            SpinBox *radius_spin = memnew(SpinBox);
+            radius_spin->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+            radius_spin->set_min(0.01);
+            radius_spin->set_max(250.0);
+            radius_spin->set_step(0.05);
+            radius_spin->set_value(brush_session_state.radius);
+            radius_spin->connect("value_changed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_brush_radius_changed));
+            paint_grid->add_child(radius_spin);
+
+            Label *strength_label = memnew(Label);
+            strength_label->set_text(TTR("Strength"));
+            paint_grid->add_child(strength_label);
+            SpinBox *strength_spin = memnew(SpinBox);
+            strength_spin->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+            strength_spin->set_min(0.0);
+            strength_spin->set_max(1.0);
+            strength_spin->set_step(0.01);
+            strength_spin->set_value(brush_session_state.strength);
+            strength_spin->connect("value_changed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_brush_strength_changed));
+            paint_grid->add_child(strength_spin);
+
+            Label *hardness_label = memnew(Label);
+            hardness_label->set_text(TTR("Hardness"));
+            paint_grid->add_child(hardness_label);
+            SpinBox *hardness_spin = memnew(SpinBox);
+            hardness_spin->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+            hardness_spin->set_min(0.1);
+            hardness_spin->set_max(8.0);
+            hardness_spin->set_step(0.05);
+            hardness_spin->set_value(brush_session_state.hardness);
+            hardness_spin->connect("value_changed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_brush_hardness_changed));
+            paint_grid->add_child(hardness_spin);
+
+            Label *color_label = memnew(Label);
+            color_label->set_text(TTR("Color"));
+            paint_grid->add_child(color_label);
+            ColorPickerButton *color_button = memnew(ColorPickerButton);
+            color_button->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+            color_button->set_custom_minimum_size(Size2(80, 0));
+            color_button->set_pick_color(brush_session_state.color);
+            color_button->connect("color_changed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_brush_color_changed));
+            paint_grid->add_child(color_button);
+
+            root->add_child(paint_grid);
+
+            HFlowContainer *paint_actions = memnew(HFlowContainer);
+            paint_actions->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+
+            Button *apply_brush = memnew(Button);
+            apply_brush->set_text(TTR("Apply Brush"));
+            apply_brush->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+            apply_brush->connect("pressed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_apply_brush_pressed).bind(node->get_instance_id(), center_x, center_y, center_z, radius_spin, strength_spin, hardness_spin, color_button));
+            paint_actions->add_child(apply_brush);
+
+            Button *commit_brush = memnew(Button);
+            commit_brush->set_text(TTR("Commit"));
+            commit_brush->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+            commit_brush->connect("pressed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_commit_brush_pressed).bind(node->get_instance_id()));
+            paint_actions->add_child(commit_brush);
+
+            Button *revert_brush = memnew(Button);
+            revert_brush->set_text(TTR("Revert"));
+            revert_brush->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+            revert_brush->connect("pressed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_revert_brush_pressed).bind(node->get_instance_id()));
+            paint_actions->add_child(revert_brush);
+
+            root->add_child(paint_actions);
+        }
     }
 
-    Label *center_label = memnew(Label);
-    center_label->set_text(TTR("Center X"));
-    paint_grid->add_child(center_label);
-    SpinBox *center_x = memnew(SpinBox);
-    center_x->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-    center_x->set_min(-10000.0);
-    center_x->set_max(10000.0);
-    center_x->set_step(0.1);
-    center_x->set_value(brush_session_state.center.x);
-    center_x->connect("value_changed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_brush_center_changed).bind(0));
-    paint_grid->add_child(center_x);
+    // Color Grading section: only shown when the node has valid GaussianData.
+    {
+        Ref<GaussianSplatRenderer> cg_renderer = node->get_renderer();
+        Ref<::GaussianData> cg_data = cg_renderer.is_valid() ? cg_renderer->get_gaussian_data() : Ref<::GaussianData>();
+        const bool cg_has_valid_data = cg_data.is_valid() && cg_data->get_count() > 0;
 
-    Label *center_y_label = memnew(Label);
-    center_y_label->set_text(TTR("Center Y"));
-    paint_grid->add_child(center_y_label);
-    SpinBox *center_y = memnew(SpinBox);
-    center_y->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-    center_y->set_min(-10000.0);
-    center_y->set_max(10000.0);
-    center_y->set_step(0.1);
-    center_y->set_value(brush_session_state.center.y);
-    center_y->connect("value_changed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_brush_center_changed).bind(1));
-    paint_grid->add_child(center_y);
+        if (cg_has_valid_data) {
+            HSeparator *color_grading_separator = memnew(HSeparator);
+            root->add_child(color_grading_separator);
 
-    Label *center_z_label = memnew(Label);
-    center_z_label->set_text(TTR("Center Z"));
-    paint_grid->add_child(center_z_label);
-    SpinBox *center_z = memnew(SpinBox);
-    center_z->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-    center_z->set_min(-10000.0);
-    center_z->set_max(10000.0);
-    center_z->set_step(0.1);
-    center_z->set_value(brush_session_state.center.z);
-    center_z->connect("value_changed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_brush_center_changed).bind(2));
-    paint_grid->add_child(center_z);
+            Label *color_grading_label = memnew(Label);
+            color_grading_label->set_text(TTR("Color Grading"));
+            root->add_child(color_grading_label);
 
-    Label *radius_label = memnew(Label);
-    radius_label->set_text(TTR("Radius"));
-    paint_grid->add_child(radius_label);
-    SpinBox *radius_spin = memnew(SpinBox);
-    radius_spin->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-    radius_spin->set_min(0.01);
-    radius_spin->set_max(250.0);
-    radius_spin->set_step(0.05);
-    radius_spin->set_value(brush_session_state.radius);
-    radius_spin->connect("value_changed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_brush_radius_changed));
-    paint_grid->add_child(radius_spin);
+            HFlowContainer *color_grading_actions = memnew(HFlowContainer);
+            color_grading_actions->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 
-    Label *strength_label = memnew(Label);
-    strength_label->set_text(TTR("Strength"));
-    paint_grid->add_child(strength_label);
-    SpinBox *strength_spin = memnew(SpinBox);
-    strength_spin->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-    strength_spin->set_min(0.0);
-    strength_spin->set_max(1.0);
-    strength_spin->set_step(0.01);
-    strength_spin->set_value(brush_session_state.strength);
-    strength_spin->connect("value_changed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_brush_strength_changed));
-    paint_grid->add_child(strength_spin);
+            const bool is_baked = node->is_color_grading_baked();
+            const bool has_color_grading = node->get_color_grading().is_valid();
 
-    Label *hardness_label = memnew(Label);
-    hardness_label->set_text(TTR("Hardness"));
-    paint_grid->add_child(hardness_label);
-    SpinBox *hardness_spin = memnew(SpinBox);
-    hardness_spin->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-    hardness_spin->set_min(0.1);
-    hardness_spin->set_max(8.0);
-    hardness_spin->set_step(0.05);
-    hardness_spin->set_value(brush_session_state.hardness);
-    hardness_spin->connect("value_changed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_brush_hardness_changed));
-    paint_grid->add_child(hardness_spin);
+            Button *bake_button = memnew(Button);
+            bake_button->set_text(TTR("Bake Color Grading"));
+            bake_button->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+            bake_button->set_tooltip_text(TTR("Permanently applies color grading to splat colors (zero runtime cost)"));
+            bake_button->set_disabled(is_baked || !has_color_grading);
+            bake_button->connect("pressed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_bake_color_grading_pressed).bind(node->get_instance_id()));
+            color_grading_actions->add_child(bake_button);
 
-    Label *color_label = memnew(Label);
-    color_label->set_text(TTR("Color"));
-    paint_grid->add_child(color_label);
-    ColorPickerButton *color_button = memnew(ColorPickerButton);
-    color_button->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-    color_button->set_custom_minimum_size(Size2(80, 0));
-    color_button->set_pick_color(brush_session_state.color);
-    color_button->connect("color_changed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_brush_color_changed));
-    paint_grid->add_child(color_button);
+            Button *restore_button = memnew(Button);
+            restore_button->set_text(TTR("Restore Original"));
+            restore_button->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+            restore_button->set_tooltip_text(TTR("Restores original colors before baking"));
+            restore_button->set_disabled(!is_baked);
+            restore_button->connect("pressed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_restore_color_grading_pressed).bind(node->get_instance_id()));
+            color_grading_actions->add_child(restore_button);
 
-    root->add_child(paint_grid);
+            root->add_child(color_grading_actions);
 
-    HFlowContainer *paint_actions = memnew(HFlowContainer);
-    paint_actions->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-
-    Ref<GaussianSplatRenderer> node_renderer = node->get_renderer();
-    Ref<::GaussianData> node_data = node_renderer.is_valid() ? node_renderer->get_gaussian_data() : Ref<::GaussianData>();
-    const bool brush_actions_available = node_data.is_valid() && node_data->get_count() > 0;
-    const String brush_disabled_tooltip = TTR("Load a Gaussian asset before using brush actions.");
-
-    Button *apply_brush = memnew(Button);
-    apply_brush->set_text(TTR("Apply Brush"));
-    apply_brush->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-    apply_brush->set_disabled(!brush_actions_available);
-    if (!brush_actions_available) {
-        apply_brush->set_tooltip_text(brush_disabled_tooltip);
-    }
-    apply_brush->connect("pressed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_apply_brush_pressed).bind(node->get_instance_id(), center_x, center_y, center_z, radius_spin, strength_spin, hardness_spin, color_button));
-    paint_actions->add_child(apply_brush);
-
-    Button *commit_brush = memnew(Button);
-    commit_brush->set_text(TTR("Commit"));
-    commit_brush->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-    commit_brush->set_disabled(!brush_actions_available);
-    if (!brush_actions_available) {
-        commit_brush->set_tooltip_text(brush_disabled_tooltip);
-    }
-    commit_brush->connect("pressed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_commit_brush_pressed).bind(node->get_instance_id()));
-    paint_actions->add_child(commit_brush);
-
-    Button *revert_brush = memnew(Button);
-    revert_brush->set_text(TTR("Revert"));
-    revert_brush->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-    revert_brush->set_disabled(!brush_actions_available);
-    if (!brush_actions_available) {
-        revert_brush->set_tooltip_text(brush_disabled_tooltip);
-    }
-    revert_brush->connect("pressed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_revert_brush_pressed).bind(node->get_instance_id()));
-    paint_actions->add_child(revert_brush);
-
-    root->add_child(paint_actions);
-
-    // Color Grading section
-    HSeparator *color_grading_separator = memnew(HSeparator);
-    root->add_child(color_grading_separator);
-
-    Label *color_grading_label = memnew(Label);
-    color_grading_label->set_text(TTR("Color Grading"));
-    root->add_child(color_grading_label);
-
-    HFlowContainer *color_grading_actions = memnew(HFlowContainer);
-    color_grading_actions->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-
-    Button *bake_button = memnew(Button);
-    bake_button->set_text(TTR("Bake Color Grading"));
-    bake_button->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-    bake_button->set_tooltip_text(TTR("Permanently applies color grading to splat colors (zero runtime cost)"));
-    bake_button->connect("pressed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_bake_color_grading_pressed).bind(node->get_instance_id()));
-    color_grading_actions->add_child(bake_button);
-
-    Button *restore_button = memnew(Button);
-    restore_button->set_text(TTR("Restore Original"));
-    restore_button->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-    restore_button->set_tooltip_text(TTR("Restores original colors before baking"));
-    restore_button->connect("pressed", callable_mp(this, &GaussianSplatNodeInspectorPlugin::_on_restore_color_grading_pressed).bind(node->get_instance_id()));
-    color_grading_actions->add_child(restore_button);
-
-    root->add_child(color_grading_actions);
-
-    // Display bake status
-    if (node->is_color_grading_baked()) {
-        Label *bake_status = memnew(Label);
-        bake_status->set_text(TTR("Status: Color grading is baked"));
-        bake_status->add_theme_color_override("font_color", Color(0.4, 1.0, 0.4));
-        root->add_child(bake_status);
+            // Display bake status
+            if (is_baked) {
+                Label *bake_status = memnew(Label);
+                bake_status->set_text(TTR("Status: Color grading is baked"));
+                bake_status->add_theme_color_override("font_color", Color(0.4, 1.0, 0.4));
+                root->add_child(bake_status);
+            }
+        }
     }
 
     add_custom_control(root);

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -37,12 +37,23 @@
 namespace {
 static bool _is_frame_log_enabled() { return gs::settings::is_frame_log_enabled(); }
 
-static bool _is_multi_instance_shared_renderer_active(const Ref<GaussianSplatRenderer> &p_renderer) {
+static bool _is_renderer_shared_with_other_content(const Ref<GaussianSplatRenderer> &p_renderer) {
     if (!p_renderer.is_valid()) {
         return false;
     }
     GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
-    return director && director->get_instance_count_for_renderer(p_renderer.ptr()) > 1u;
+    if (!director) {
+        return false;
+    }
+    // Shared if multiple instances use this renderer...
+    if (director->get_instance_count_for_renderer(p_renderer.ptr()) > 1u) {
+        return true;
+    }
+    // ...or if a world submission is active on this renderer.
+    if (director->has_world_submission_for_renderer(p_renderer.ptr())) {
+        return true;
+    }
+    return false;
 }
 } // namespace
 
@@ -431,7 +442,7 @@ void GaussianSplatNode3D::_notification(int p_what) {
 }
 
 void GaussianSplatNode3D::_validate_property(PropertyInfo &p_property) const {
-    if (_is_multi_instance_shared_renderer_active(renderer)) {
+    if (_is_renderer_shared_with_other_content(renderer)) {
         if (p_property.name.begins_with("painterly/") || p_property.name == "rendering/color_grading") {
             p_property.usage = PROPERTY_USAGE_NO_EDITOR;
             return;
@@ -870,7 +881,7 @@ void GaussianSplatNode3D::set_enable_painterly(bool p_enabled) {
 }
 
 void GaussianSplatNode3D::set_edge_threshold(float p_threshold) {
-    if (_is_multi_instance_shared_renderer_active(renderer)) {
+    if (_is_renderer_shared_with_other_content(renderer)) {
         return;
     }
     edge_threshold = CLAMP(p_threshold, 0.0f, 1.0f);
@@ -883,7 +894,7 @@ void GaussianSplatNode3D::set_edge_threshold(float p_threshold) {
 }
 
 void GaussianSplatNode3D::set_stroke_opacity(float p_opacity) {
-    if (_is_multi_instance_shared_renderer_active(renderer)) {
+    if (_is_renderer_shared_with_other_content(renderer)) {
         return;
     }
     stroke_opacity = CLAMP(p_opacity, 0.0f, 1.0f);
@@ -895,7 +906,7 @@ void GaussianSplatNode3D::set_stroke_opacity(float p_opacity) {
 }
 
 void GaussianSplatNode3D::set_stroke_width(float p_width) {
-    if (_is_multi_instance_shared_renderer_active(renderer)) {
+    if (_is_renderer_shared_with_other_content(renderer)) {
         return;
     }
     stroke_width = CLAMP(p_width, 0.1f, 5.0f);
@@ -912,7 +923,7 @@ void GaussianSplatNode3D::set_color_variation(float p_variation) {
 }
 
 void GaussianSplatNode3D::set_temporal_blend(float p_blend) {
-    if (_is_multi_instance_shared_renderer_active(renderer)) {
+    if (_is_renderer_shared_with_other_content(renderer)) {
         return;
     }
     temporal_blend = CLAMP(p_blend, 0.01f, 1.0f);
@@ -925,7 +936,7 @@ void GaussianSplatNode3D::set_temporal_blend(float p_blend) {
 }
 
 void GaussianSplatNode3D::set_painterly_seed(uint32_t p_seed) {
-    if (_is_multi_instance_shared_renderer_active(renderer)) {
+    if (_is_renderer_shared_with_other_content(renderer)) {
         return;
     }
     painterly_seed = MIN(p_seed, (uint32_t)65535);
@@ -1379,7 +1390,7 @@ void GaussianSplatNode3D::process_gaussian_render() {
     _update_visibility();
 
     if (renderer.is_valid()) {
-        const bool shared_renderer_multi_instance = _is_multi_instance_shared_renderer_active(renderer);
+        const bool shared_renderer_multi_instance = _is_renderer_shared_with_other_content(renderer);
         if (shared_renderer_multi_instance_state != shared_renderer_multi_instance) {
             shared_renderer_multi_instance_state = shared_renderer_multi_instance;
             _apply_renderer_settings();
@@ -2050,7 +2061,7 @@ void GaussianSplatNode3D::_on_asset_changed() {
 
 void GaussianSplatNode3D::_on_color_grading_changed() {
     if (renderer.is_valid()) {
-        if (_is_multi_instance_shared_renderer_active(renderer)) {
+        if (_is_renderer_shared_with_other_content(renderer)) {
             renderer->set_color_grading(Ref<ColorGradingResource>());
         } else {
             renderer->set_color_grading(color_grading);
@@ -2123,7 +2134,7 @@ void GaussianSplatNode3D::set_color_grading(const Ref<ColorGradingResource> &p_g
     }
 
     if (renderer.is_valid()) {
-        if (_is_multi_instance_shared_renderer_active(renderer)) {
+        if (_is_renderer_shared_with_other_content(renderer)) {
             renderer->set_color_grading(Ref<ColorGradingResource>());
         } else {
             renderer->set_color_grading(color_grading);

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
@@ -1392,7 +1392,19 @@ void GaussianSplatNodeRendererHelper::apply_renderer_settings() {
     owner.renderer->set_painterly_stroke_length(owner.stroke_width);
     owner.renderer->set_painterly_gamma(MAX(owner.temporal_blend, 0.01f));
     owner.renderer->set_opacity_multiplier(owner.opacity);
-    owner.renderer->set_color_grading(owner.color_grading);
+    {
+        bool renderer_shared = false;
+        GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
+        if (director) {
+            renderer_shared = director->get_instance_count_for_renderer(owner.renderer.ptr()) > 1u ||
+                    director->has_world_submission_for_renderer(owner.renderer.ptr());
+        }
+        if (renderer_shared) {
+            owner.renderer->set_color_grading(Ref<ColorGradingResource>());
+        } else {
+            owner.renderer->set_color_grading(owner.color_grading);
+        }
+    }
     {
         GaussianStreamingSystem::ConfigOverrides overrides;
 

--- a/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
@@ -1180,15 +1180,90 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer hid
     Ref<GaussianSplatRenderer> renderer = node_a->get_renderer();
     if (!renderer.is_valid()) {
         MESSAGE("Skipping shared-renderer property check - renderer unavailable (headless mode)");
-    } else {
-        CHECK_FALSE(is_property_editor_exposed(node_a, StringName("rendering/color_grading")));
-        CHECK_FALSE(is_property_editor_exposed(node_b, StringName("rendering/color_grading")));
+        root->remove_child(node_b);
+        root->remove_child(node_a);
+        memdelete(node_b);
+        memdelete(node_a);
+        return;
     }
 
+    CHECK_FALSE(is_property_editor_exposed(node_a, StringName("rendering/color_grading")));
+    CHECK_FALSE(is_property_editor_exposed(node_b, StringName("rendering/color_grading")));
+
+    // Remove the second node — shared renderer collapses to single-instance.
+    // Color grading property should become editor-visible again on the remaining node.
     root->remove_child(node_b);
+    tree->process(0.0);
+    CHECK(is_property_editor_exposed(node_a, StringName("rendering/color_grading")));
+
     root->remove_child(node_a);
     memdelete(node_b);
     memdelete(node_a);
+}
+
+TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] World submission blocks node color grading push to renderer") {
+    SceneTree *tree = SceneTree::get_singleton();
+    REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");
+
+    Window *root = tree->get_root();
+    REQUIRE_MESSAGE(root != nullptr, "SceneTree root window required");
+
+    // Set up a world node with active submission.
+    Ref<GaussianSplatWorld> world_res;
+    world_res.instantiate();
+    Ref<GaussianData> world_data = make_test_gaussian_data(4, 500.0f);
+    world_res->set_gaussian_data(world_data);
+
+    GaussianSplatWorld3D *world_node = memnew(GaussianSplatWorld3D);
+    world_node->set_world(world_res);
+    root->add_child(world_node);
+    tree->process(0.0);
+    world_node->apply_world();
+
+    // Set up a splat node that shares the same renderer.
+    GaussianSplatNode3D *graded_node = memnew(GaussianSplatNode3D);
+    graded_node->set_splat_asset(make_single_splat_asset(9400.0f));
+    root->add_child(graded_node);
+    tree->process(0.0);
+
+    Ref<GaussianSplatRenderer> renderer = graded_node->get_renderer();
+    if (!renderer.is_valid()) {
+        MESSAGE("Skipping test - renderer unavailable (headless mode)");
+        root->remove_child(graded_node);
+        root->remove_child(world_node);
+        memdelete(graded_node);
+        memdelete(world_node);
+        return;
+    }
+
+    // Assign color grading to the splat node.
+    Ref<ColorGradingResource> grading = make_color_grading_resource();
+    graded_node->set_color_grading(grading);
+
+    // The renderer is shared with an active world submission, so color
+    // grading must NOT leak to the renderer.
+    CHECK_MESSAGE(graded_node->get_color_grading() == grading,
+            "Node retains its local color grading");
+    CHECK_MESSAGE(!renderer->get_color_grading().is_valid(),
+            "Renderer color grading must be null when world submission is active");
+
+    // Color grading property should be hidden in the inspector.
+    CHECK_FALSE(is_property_editor_exposed(graded_node, StringName("rendering/color_grading")));
+
+    // Remove the world node — renderer is no longer shared with world content.
+    world_node->clear_world();
+    root->remove_child(world_node);
+    tree->process(0.0);
+
+    // Now the splat node is the sole user. Re-push grading and verify it reaches the renderer.
+    graded_node->set_color_grading(grading);
+    CHECK_MESSAGE(renderer->get_color_grading() == grading,
+            "Color grading should reach renderer after world submission is removed");
+    CHECK(is_property_editor_exposed(graded_node, StringName("rendering/color_grading")));
+
+    root->remove_child(graded_node);
+    memdelete(graded_node);
+    memdelete(world_node);
 }
 
 TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer preserves local painterly and color grading state") {
@@ -1256,6 +1331,146 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer pre
     root->remove_child(node_a);
     memdelete(node_b);
     memdelete(node_a);
+}
+
+TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Single node color grading reaches renderer") {
+    SceneTree *tree = SceneTree::get_singleton();
+    REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");
+
+    Window *root = tree->get_root();
+    REQUIRE_MESSAGE(root != nullptr, "SceneTree root window required");
+
+    GaussianSplatNode3D *node = memnew(GaussianSplatNode3D);
+    node->set_splat_asset(make_single_splat_asset(9100.0f));
+
+    root->add_child(node);
+    tree->process(0.0);
+
+    Ref<GaussianSplatRenderer> renderer = node->get_renderer();
+    if (!renderer.is_valid()) {
+        MESSAGE("Skipping test - renderer unavailable (headless mode)");
+        root->remove_child(node);
+        memdelete(node);
+        return;
+    }
+
+    // Renderer should start with no color grading.
+    CHECK(renderer->get_color_grading().is_null());
+
+    Ref<ColorGradingResource> grading = make_color_grading_resource();
+    CHECK(grading.is_valid());
+
+    node->set_color_grading(grading);
+    tree->process(0.0);
+
+    // Single node owns the renderer exclusively, so color grading must propagate.
+    CHECK(node->get_color_grading() == grading);
+    CHECK(renderer->get_color_grading() == grading);
+
+    root->remove_child(node);
+    memdelete(node);
+}
+
+TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Color grading survives exit and re-enter tree") {
+    SceneTree *tree = SceneTree::get_singleton();
+    REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");
+
+    Window *root = tree->get_root();
+    REQUIRE_MESSAGE(root != nullptr, "SceneTree root window required");
+
+    GaussianSplatNode3D *node = memnew(GaussianSplatNode3D);
+    node->set_splat_asset(make_single_splat_asset(9200.0f));
+
+    Ref<ColorGradingResource> grading = make_color_grading_resource();
+    CHECK(grading.is_valid());
+
+    // Set color grading before entering tree.
+    node->set_color_grading(grading);
+    CHECK(node->get_color_grading() == grading);
+
+    // Enter tree.
+    root->add_child(node);
+    tree->process(0.0);
+
+    Ref<GaussianSplatRenderer> renderer = node->get_renderer();
+    if (!renderer.is_valid()) {
+        MESSAGE("Skipping test - renderer unavailable (headless mode)");
+        root->remove_child(node);
+        memdelete(node);
+        return;
+    }
+
+    CHECK(renderer->get_color_grading() == grading);
+
+    // Exit tree.
+    root->remove_child(node);
+    tree->process(0.0);
+
+    // Node should retain its color grading while detached.
+    CHECK(node->get_color_grading() == grading);
+
+    // Re-enter tree.
+    root->add_child(node);
+    tree->process(0.0);
+
+    Ref<GaussianSplatRenderer> renderer_after = node->get_renderer();
+    if (!renderer_after.is_valid()) {
+        MESSAGE("Skipping re-enter check - renderer unavailable after re-add");
+        root->remove_child(node);
+        memdelete(node);
+        return;
+    }
+
+    // Color grading must still be on the node and pushed to the (possibly new) renderer.
+    CHECK(node->get_color_grading() == grading);
+    CHECK(renderer_after->get_color_grading() == grading);
+
+    root->remove_child(node);
+    memdelete(node);
+}
+
+TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Color grading signal propagation updates renderer") {
+    SceneTree *tree = SceneTree::get_singleton();
+    REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");
+
+    Window *root = tree->get_root();
+    REQUIRE_MESSAGE(root != nullptr, "SceneTree root window required");
+
+    GaussianSplatNode3D *node = memnew(GaussianSplatNode3D);
+    node->set_splat_asset(make_single_splat_asset(9300.0f));
+
+    root->add_child(node);
+    tree->process(0.0);
+
+    Ref<GaussianSplatRenderer> renderer = node->get_renderer();
+    if (!renderer.is_valid()) {
+        MESSAGE("Skipping test - renderer unavailable (headless mode)");
+        root->remove_child(node);
+        memdelete(node);
+        return;
+    }
+
+    Ref<ColorGradingResource> grading = make_color_grading_resource();
+    CHECK(grading.is_valid());
+
+    node->set_color_grading(grading);
+    tree->process(0.0);
+
+    CHECK(renderer->get_color_grading() == grading);
+
+    // Mutate a property on the resource — the "changed" signal should propagate
+    // through _on_color_grading_changed and keep the renderer in sync.
+    const float original_exposure = grading->get_exposure();
+    grading->set_exposure(2.5f);
+    CHECK(grading->get_exposure() != doctest::Approx(original_exposure));
+
+    // The renderer should still reference the same resource (signal updates
+    // the renderer in-place, it does not swap the Ref).
+    CHECK(renderer->get_color_grading() == grading);
+    CHECK(renderer->get_color_grading()->get_exposure() == doctest::Approx(2.5f));
+
+    root->remove_child(node);
+    memdelete(node);
 }
 
 TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer full-fidelity override only follows attached assets") {


### PR DESCRIPTION
## Summary
- fix shared-renderer color grading leakage so node grading no longer reaches other shared content, including active world submissions
- gate painterly brush tools and bake/restore actions behind valid editor/runtime state
- add editor/workflow regressions for shared-property visibility recovery and world-submission color grading blocking
- correct the UX checklist to reflect that viewport-level drag-and-drop is still not implemented

## Notes
- shared-mode per-instance color grading is still deferred; the property remains hidden while the renderer is shared
- viewport-level drag-and-drop is still not implemented in this slice

## Validation
- targeted node/editor regression coverage added in modules/gaussian_splatting/tests/test_gaussian_splat_node.h
- manual QA checklist updated in modules/gaussian_splatting/docs/GAUSSIAN_EDITOR_UX_REDESIGN_CHECKLIST.md
