### PR TITLE
fix: remove global DC decode overrides

### DIFF
--- a/modules/gaussian_splatting/core/gaussian_streaming.cpp
+++ b/modules/gaussian_splatting/core/gaussian_streaming.cpp
@@ -51,6 +51,20 @@ uint32_t _streaming_addressable_chunk_limit() {
     return static_cast<uint32_t>(MIN<uint64_t>(uint64_t(UINT32_MAX) / slot_bytes, uint64_t(UINT32_MAX)));
 }
 
+bool _data_has_uniform_dc_encoding(const Ref<GaussianData> &p_data) {
+    if (p_data.is_null() || p_data->get_count() <= 1) {
+        return true;
+    }
+
+    const GaussianDCEncoding first_encoding = gaussian_get_dc_encoding(p_data->get_gaussian(0).render_meta);
+    for (int i = 1; i < p_data->get_count(); i++) {
+        if (gaussian_get_dc_encoding(p_data->get_gaussian(i).render_meta) != first_encoding) {
+            return false;
+        }
+    }
+    return true;
+}
+
 struct StreamingTierCapPolicy {
     String tier_preset = "custom";
     bool active = false;
@@ -827,6 +841,7 @@ void GaussianStreamingSystem::initialize(Ref<::GaussianData> p_data) {
     scheduler.last_cpu_unattributed_ms = 0.0;
     source_data = p_data;
     if (source_data.is_null()) {
+        per_chunk_quantization_dc_compatible = true;
         GaussianSplatManager *manager = GaussianSplatManager::get_singleton();
         RenderingDevice *rd = primary_device_override ? primary_device_override
                 : (last_upload_device ? last_upload_device
@@ -849,6 +864,7 @@ void GaussianStreamingSystem::initialize(Ref<::GaussianData> p_data) {
         return;
     }
     _register_primary_asset();
+    _refresh_quantization_dc_compatibility();
 
     // Allocate persistent GPU buffer for maximum loaded chunks
     GaussianSplatManager *manager = GaussianSplatManager::get_singleton();
@@ -910,7 +926,7 @@ void GaussianStreamingSystem::initialize(Ref<::GaussianData> p_data) {
     _load_streaming_tuning_config_from_project_settings();
     _reload_debug_logging_config();
 
-    if (per_chunk_quantization_enabled) {
+    if (is_per_chunk_quantization_enabled()) {
         // Upload quantization buffer to GPU
         if (rd) {
             _upload_quantization_buffer(rd);
@@ -987,6 +1003,7 @@ void GaussianStreamingSystem::initialize_empty(RenderingDevice *p_device) {
     scheduler.last_cpu_total_attributed_ms = 0.0;
     scheduler.last_cpu_unattributed_ms = 0.0;
     source_data.unref();
+    per_chunk_quantization_dc_compatible = true;
     total_splat_count = 0;
     chunks.clear();
     asset_registry.primary_chunk_source_indices.clear();
@@ -1047,6 +1064,7 @@ void GaussianStreamingSystem::initialize_empty(RenderingDevice *p_device) {
     streaming_initialized = true;
 
     _load_quantization_config_from_project_settings();
+    _refresh_quantization_dc_compatibility();
     _load_streaming_tuning_config_from_project_settings();
     _reload_debug_logging_config();
 
@@ -1113,6 +1131,7 @@ void GaussianStreamingSystem::update_primary_asset_data(Ref<::GaussianData> p_da
         asset->metadata_dirty = true;
         asset->generation = _advance_asset_generation(PRIMARY_ASSET_ID);
     }
+    _refresh_quantization_dc_compatibility();
 
     visibility.clear_visible_state();
     scheduler.visible_scan_cursor = 0;
@@ -1124,7 +1143,7 @@ void GaussianStreamingSystem::update_primary_asset_data(Ref<::GaussianData> p_da
     scheduler.force_sync_fallback_due_to_async_stall = false;
     frame_data[current_frame_idx].visible_chunks.clear();
 
-    if (per_chunk_quantization_enabled) {
+    if (is_per_chunk_quantization_enabled()) {
         quantization_dirty = true;
     }
     quantization_cpu_cache_valid = false;
@@ -1379,6 +1398,7 @@ void GaussianStreamingSystem::register_asset(uint32_t asset_id, const Ref<Gaussi
         quantization_dirty = true;
     }
     quantization_cpu_cache_valid = false;
+    _refresh_quantization_dc_compatibility();
 
     global_atlas_registry.mark_asset_registry_dirty();
 }
@@ -1433,6 +1453,29 @@ void GaussianStreamingSystem::unregister_asset(uint32_t asset_id) {
     global_atlas_registry.mark_asset_registry_dirty();
     quantization_dirty = true;
     quantization_cpu_cache_valid = false;
+    _refresh_quantization_dc_compatibility();
+}
+
+void GaussianStreamingSystem::_refresh_quantization_dc_compatibility() {
+    bool compatible = true;
+    for (const KeyValue<uint32_t, AtlasAssetState> &E : asset_registry.atlas_assets) {
+        if (!_data_has_uniform_dc_encoding(E.value.data)) {
+            compatible = false;
+            break;
+        }
+    }
+
+    if (per_chunk_quantization_dc_compatible == compatible) {
+        return;
+    }
+
+    per_chunk_quantization_dc_compatible = compatible;
+    quantization_dirty = true;
+    quantization_cpu_cache_valid = false;
+    global_atlas_registry.mark_asset_registry_dirty();
+    if (!compatible) {
+        WARN_PRINT_ONCE("[Quantization] Disabled per-chunk quantization for mixed DC-encoding assets; using the non-quantized upload path.");
+    }
 }
 
 uint32_t GaussianStreamingSystem::get_dense_asset_id(uint32_t asset_id) const {

--- a/modules/gaussian_splatting/core/gaussian_streaming.h
+++ b/modules/gaussian_splatting/core/gaussian_streaming.h
@@ -134,6 +134,7 @@ private:
 
     // Per-chunk quantization (Unity technique for 4x compression)
     bool per_chunk_quantization_enabled = false;
+    bool per_chunk_quantization_dc_compatible = true;
     RID quantization_buffer;  // GPU buffer for ChunkQuantizationGPU data
     uint32_t quantization_buffer_size = 0;
     LocalVector<ChunkQuantizationGPU> quantization_gpu_data;  // CPU-side copy for upload
@@ -248,7 +249,7 @@ public:
     bool is_asset_registered(uint32_t asset_id) const { return asset_registry.atlas_assets.has(asset_id); }
 
     // Per-chunk quantization (Unity technique for 4x compression)
-    bool is_per_chunk_quantization_enabled() const { return per_chunk_quantization_enabled; }
+    bool is_per_chunk_quantization_enabled() const { return per_chunk_quantization_enabled && per_chunk_quantization_dc_compatible; }
     RID get_quantization_buffer() const { return quantization_buffer; }
     uint32_t get_quantization_position_bits() const { return quantization_position_bits; }
     uint32_t get_quantization_scale_bits() const { return quantization_scale_bits; }
@@ -288,6 +289,7 @@ private:
     bool _resolve_primary_chunk_source_index(const StreamingChunk &chunk, uint32_t p_offset_in_chunk, uint32_t &r_source_index) const;
     void _refresh_primary_chunk_layout_metrics();
     void _register_primary_asset();
+    void _refresh_quantization_dc_compatibility();
     uint32_t _advance_asset_generation(uint32_t asset_id);
     uint32_t _alloc_dense_id(uint32_t asset_id);
     void _release_dense_id(uint32_t dense_id);

--- a/modules/gaussian_splatting/core/streaming_global_atlas_registry.cpp
+++ b/modules/gaussian_splatting/core/streaming_global_atlas_registry.cpp
@@ -36,6 +36,18 @@ void _clear_dirty_flags(LocalVector<uint8_t> &flags) {
 	}
 }
 
+GaussianDCEncoding _resolve_data_dc_encoding(const Ref<GaussianData> &p_data) {
+	if (p_data.is_null() || p_data->get_count() <= 0) {
+		return GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
+	}
+	return gaussian_get_dc_encoding(p_data->get_gaussian(0).render_meta);
+}
+
+uint32_t _pack_data_gpu_flags(const Ref<GaussianData> &p_data) {
+	const bool is_2d = p_data.is_valid() && p_data->get_2d_mode();
+	return gs_pack_asset_gpu_flags(is_2d, _resolve_data_dc_encoding(p_data));
+}
+
 bool _ensure_placeholder_buffer(RenderingDevice *p_rd, RID &r_buffer, uint32_t &r_logical_size, const char *p_name) {
 	ERR_FAIL_NULL_V(p_rd, false);
 
@@ -182,7 +194,7 @@ void StreamingGlobalAtlasRegistry::build_cpu_state(GaussianStreamingSystem &syst
 		AssetMetaGPU asset_meta = {};
 		asset_meta.lod_count = MAX(uint32_t(1), asset->lod_count);
 		asset_meta.sh_degree = asset->sh_degree;
-		asset_meta.flags = 0;
+		asset_meta.flags = _pack_data_gpu_flags(asset->data);
 
 		Vector3 asset_center = asset->bounds.get_center();
 		Vector3 asset_half = asset->bounds.size * 0.5f;
@@ -194,8 +206,8 @@ void StreamingGlobalAtlasRegistry::build_cpu_state(GaussianStreamingSystem &syst
 
 		asset_meta.chunk_index_base = asset->chunk_index_base;
 		asset_meta.chunk_index_count = asset->chunk_index_count;
-		asset_meta.quant_chunk_base = system.per_chunk_quantization_enabled ? asset->quant_base : 0;
-		asset_meta.quant_chunk_count = system.per_chunk_quantization_enabled ? asset->quant_count : 0;
+		asset_meta.quant_chunk_base = system.is_per_chunk_quantization_enabled() ? asset->quant_base : 0;
+		asset_meta.quant_chunk_count = system.is_per_chunk_quantization_enabled() ? asset->quant_count : 0;
 		asset_meta.lod_ranges[0].base = asset->chunk_index_base;
 		asset_meta.lod_ranges[0].count = asset->chunk_index_count;
 
@@ -271,7 +283,7 @@ void StreamingGlobalAtlasRegistry::update_chunk_meta_entry(GaussianStreamingSyst
 		meta.atlas_base = 0;
 		meta.splat_count = 0;
 	}
-	if (system.per_chunk_quantization_enabled) {
+	if (system.is_per_chunk_quantization_enabled()) {
 		meta.quant_base = asset->quant_base + chunk_idx;
 		meta.quant_count = 1;
 	} else {
@@ -293,7 +305,7 @@ void StreamingGlobalAtlasRegistry::update_chunk_meta_entry(GaussianStreamingSyst
 
 	meta.asset_id = asset->dense_id;
 	meta.lod_level = chunk.current_lod_level;
-	meta.flags = 0;
+	meta.flags = _pack_data_gpu_flags(asset->data);
 	meta.sh_limit = sh_band_limit;
 
 	chunk_meta_cpu[global_idx] = meta;
@@ -334,18 +346,18 @@ void StreamingGlobalAtlasRegistry::mark_chunk_meta_dirty(GaussianStreamingSystem
 void StreamingGlobalAtlasRegistry::sync_to_gpu(GaussianStreamingSystem &system, RenderingDevice *p_rd) {
 	global_atlas_state.atlas_gaussian_buffer = system.persistent_buffer;
 	global_atlas_state.atlas_gaussian_count = system.get_buffer_capacity_splats();
-	global_atlas_state.quantization_buffer = system.per_chunk_quantization_enabled ? system.quantization_buffer : RID();
+	global_atlas_state.quantization_buffer = system.is_per_chunk_quantization_enabled() ? system.quantization_buffer : RID();
 
 	const bool quantization_rebuild = system.quantization_dirty;
 	const uint32_t quantization_expected_size = uint32_t(system.quantization_gpu_data.size()) * sizeof(ChunkQuantizationGPU);
 	bool atlas_dirty = quantization_rebuild || asset_registry_dirty || asset_meta_dirty ||
 			asset_chunk_index_dirty || chunk_meta_dirty_all || !chunk_meta_dirty_indices.is_empty();
-	if (system.per_chunk_quantization_enabled &&
+	if (system.is_per_chunk_quantization_enabled() &&
 			(system.quantization_dirty || !system.quantization_buffer.is_valid() || system.quantization_buffer_size != quantization_expected_size)) {
 		const bool quantization_resource_changed = system._upload_quantization_buffer(p_rd);
 		atlas_dirty = atlas_dirty || quantization_resource_changed;
 		global_atlas_state.quantization_buffer = system.quantization_buffer;
-	} else if (!system.per_chunk_quantization_enabled) {
+	} else if (!system.is_per_chunk_quantization_enabled()) {
 		if (system._release_quantization_buffer(p_rd, "_sync_global_atlas_state(disabled)", true)) {
 			atlas_dirty = true;
 		}

--- a/modules/gaussian_splatting/core/streaming_quantization.cpp
+++ b/modules/gaussian_splatting/core/streaming_quantization.cpp
@@ -392,12 +392,14 @@ ChunkQuantizationGPU GaussianStreamingSystem::_create_gpu_quantization_data(
 
 Dictionary GaussianStreamingSystem::get_quantization_stats() const {
     Dictionary stats;
-    stats["enabled"] = per_chunk_quantization_enabled;
+    stats["enabled"] = is_per_chunk_quantization_enabled();
+    stats["configured_enabled"] = per_chunk_quantization_enabled;
+    stats["dc_compatible"] = per_chunk_quantization_dc_compatible;
     stats["position_bits"] = quantization_position_bits;
     stats["scale_bits"] = quantization_scale_bits;
     stats["scales_quantized"] = quantization_scales_enabled;
 
-    if (per_chunk_quantization_enabled && !asset_registry.atlas_asset_order.is_empty()) {
+    if (is_per_chunk_quantization_enabled() && !asset_registry.atlas_asset_order.is_empty()) {
         // Calculate average and max errors across all chunks
         float total_pos_error = 0.0f;
         float max_pos_error = 0.0f;

--- a/modules/gaussian_splatting/renderer/gaussian_gpu_layout.h
+++ b/modules/gaussian_splatting/renderer/gaussian_gpu_layout.h
@@ -383,8 +383,7 @@ struct alignas(16) TileRenderParamsGPU {
     // x=sh_bands (0-3), y=amortization_divisor, z=amortization_phase, w=force_full_update
     // sh_bands: 0=DC only, 1=1st order, 2=2nd order, 3=3rd order (full)
     float sh_config[4];
-    // SH decode configuration:
-    // x=dc_logit (1.0=decode DC with sigmoid), yzw=reserved
+    // SH decode configuration is reserved; runtime decode now comes from per-gaussian metadata.
     float sh_decode_config[4];
     // Opacity-aware culling (FlashGS): x=enabled (bool), y=visibility_threshold (tau), z=reserved, w=reserved
     // When enabled, splat radii are calculated as: r = sqrt(2 * ln(alpha/tau) * lambda_max)

--- a/modules/gaussian_splatting/renderer/gaussian_gpu_layout.h
+++ b/modules/gaussian_splatting/renderer/gaussian_gpu_layout.h
@@ -16,6 +16,8 @@ static constexpr uint32_t GS_SH_METADATA_ENCODING_MASK = 0x7F000000u;
 static constexpr uint32_t GS_SH_METADATA_DC_ENCODING_MASK = 0x80000000u;
 static constexpr uint32_t GS_SH_ENCODING_RGB9E5 = 1u;
 static constexpr uint32_t GS_SH_ENCODING_F16 = 2u;
+static constexpr uint32_t GS_GPU_ASSET_FLAG_IS_2D = 1u << 0u;
+static constexpr uint32_t GS_GPU_ASSET_FLAG_DC_LINEAR_RGB = 1u << 1u;
 
 inline uint32_t gs_pack_sh_metadata(uint32_t p_stored_first, uint32_t p_stored_high, uint32_t p_encoded_total,
         GaussianDCEncoding p_dc_encoding, uint32_t p_sh_encoding) {
@@ -39,6 +41,14 @@ inline GaussianDCEncoding gs_get_dc_encoding(uint32_t p_metadata) {
     return (p_metadata & GS_SH_METADATA_DC_ENCODING_MASK) != 0u
             ? GAUSSIAN_DC_ENCODING_LINEAR_RGB
             : GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
+}
+
+inline uint32_t gs_pack_asset_gpu_flags(bool p_is_2d, GaussianDCEncoding p_dc_encoding) {
+    uint32_t flags = p_is_2d ? GS_GPU_ASSET_FLAG_IS_2D : 0u;
+    if (p_dc_encoding == GAUSSIAN_DC_ENCODING_LINEAR_RGB) {
+        flags |= GS_GPU_ASSET_FLAG_DC_LINEAR_RGB;
+    }
+    return flags;
 }
 
 // Instance pipeline only: uses SplatRef indirection and asset-local quantization.
@@ -98,7 +108,7 @@ static_assert(offsetof(AssetLodRangeGPU, count) == 4, "AssetLodRangeGPU.count of
 struct alignas(16) AssetMetaGPU {
     uint32_t lod_count;
     uint32_t sh_degree;          // max SH bands for asset
-    uint32_t flags;              // include is_2d bit
+    uint32_t flags;              // GS_GPU_ASSET_FLAG_* metadata shared with chunk flags
     uint32_t pad0;
 
     float bounds_center_local[3];

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
@@ -116,7 +116,6 @@ static void _initialize_lighting_project_settings_defaults() {
     static const StringName direct_light_scale_path("rendering/gaussian_splatting/lighting/direct_light_scale");
     static const StringName indirect_sh_scale_path("rendering/gaussian_splatting/lighting/indirect_sh_scale");
     static const StringName shadow_strength_path("rendering/gaussian_splatting/lighting/shadow_strength");
-    static const StringName sh_dc_logit_path("rendering/gaussian_splatting/lighting/dc_logit");
     static const StringName shadow_bias_scale_path("rendering/gaussian_splatting/lighting/shadow_receiver_bias_scale");
     static const StringName shadow_bias_min_path("rendering/gaussian_splatting/lighting/shadow_receiver_bias_min");
     static const StringName shadow_bias_max_path("rendering/gaussian_splatting/lighting/shadow_receiver_bias_max");
@@ -135,11 +134,6 @@ static void _initialize_lighting_project_settings_defaults() {
         ps->set_setting(shadow_strength_path, 1.0f); // GS_CI_ALLOW_RENDER_PATH_SETTING_MUTATION
     }
     ps->set_initial_value(shadow_strength_path, 1.0f);
-
-    if (!ps->has_setting(sh_dc_logit_path)) {
-        ps->set_setting(sh_dc_logit_path, false); // GS_CI_ALLOW_RENDER_PATH_SETTING_MUTATION
-    }
-    ps->set_initial_value(sh_dc_logit_path, false);
 
     if (!ps->has_setting(shadow_bias_scale_path)) {
         ps->set_setting(shadow_bias_scale_path, 0.2f); // GS_CI_ALLOW_RENDER_PATH_SETTING_MUTATION

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -301,7 +301,6 @@ static uint64_t _compute_lighting_signature(const RenderDataRD *p_render_data, u
 	float direct_light_scale = 0.5f;
 	float indirect_sh_scale = 1.0f;
 	float shadow_strength = 1.0f;
-	bool sh_dc_logit = false;
 	float shadow_receiver_bias_scale = 0.2f;
 	float shadow_receiver_bias_min = 0.0f;
 	float shadow_receiver_bias_max = 0.0f;
@@ -322,7 +321,6 @@ static uint64_t _compute_lighting_signature(const RenderDataRD *p_render_data, u
 		static const StringName direct_path("rendering/gaussian_splatting/lighting/direct_light_scale");
 		static const StringName indirect_path("rendering/gaussian_splatting/lighting/indirect_sh_scale");
 		static const StringName shadow_path("rendering/gaussian_splatting/lighting/shadow_strength");
-		static const StringName sh_dc_logit_path("rendering/gaussian_splatting/lighting/dc_logit");
 		static const StringName shadow_bias_scale_path("rendering/gaussian_splatting/lighting/shadow_receiver_bias_scale");
 		static const StringName shadow_bias_min_path("rendering/gaussian_splatting/lighting/shadow_receiver_bias_min");
 		static const StringName shadow_bias_max_path("rendering/gaussian_splatting/lighting/shadow_receiver_bias_max");
@@ -347,7 +345,6 @@ static uint64_t _compute_lighting_signature(const RenderDataRD *p_render_data, u
 		direct_light_scale = _get_float_setting(ps, direct_path, direct_light_scale);
 		indirect_sh_scale = _get_float_setting(ps, indirect_path, indirect_sh_scale);
 		shadow_strength = _get_float_setting(ps, shadow_path, shadow_strength);
-		sh_dc_logit = _get_bool_setting(ps, sh_dc_logit_path, sh_dc_logit);
 		shadow_receiver_bias_scale = _get_float_setting(ps, shadow_bias_scale_path, shadow_receiver_bias_scale);
 		shadow_receiver_bias_min = _get_float_setting(ps, shadow_bias_min_path, shadow_receiver_bias_min);
 		shadow_receiver_bias_max = _get_float_setting(ps, shadow_bias_max_path, shadow_receiver_bias_max);
@@ -374,7 +371,6 @@ static uint64_t _compute_lighting_signature(const RenderDataRD *p_render_data, u
 	seed = _hash_float_bits(direct_light_scale, seed);
 	seed = _hash_float_bits(indirect_sh_scale, seed);
 	seed = _hash_float_bits(shadow_strength, seed);
-	seed = _hash_bool(sh_dc_logit, seed);
 	seed = _hash_float_bits(shadow_receiver_bias_scale, seed);
 	seed = _hash_float_bits(shadow_receiver_bias_min, seed);
 	seed = _hash_float_bits(shadow_receiver_bias_max, seed);
@@ -1661,7 +1657,6 @@ Error RenderPipelineStages::RasterStage::render_tile_fallback(const Size2i &p_vi
 	float direct_light_scale = 0.5f;
 	float indirect_sh_scale = 1.0f;
 	float shadow_strength = 1.0f;
-	bool sh_dc_logit = false;
 	float shadow_receiver_bias_scale = 0.2f;
 	float shadow_receiver_bias_min = 0.0f;
 	float shadow_receiver_bias_max = 0.0f;
@@ -1682,7 +1677,6 @@ Error RenderPipelineStages::RasterStage::render_tile_fallback(const Size2i &p_vi
 		static const StringName direct_path("rendering/gaussian_splatting/lighting/direct_light_scale");
 		static const StringName indirect_path("rendering/gaussian_splatting/lighting/indirect_sh_scale");
 		static const StringName shadow_path("rendering/gaussian_splatting/lighting/shadow_strength");
-		static const StringName sh_dc_logit_path("rendering/gaussian_splatting/lighting/dc_logit");
 		static const StringName shadow_bias_scale_path("rendering/gaussian_splatting/lighting/shadow_receiver_bias_scale");
 		static const StringName shadow_bias_min_path("rendering/gaussian_splatting/lighting/shadow_receiver_bias_min");
 		static const StringName shadow_bias_max_path("rendering/gaussian_splatting/lighting/shadow_receiver_bias_max");
@@ -1707,7 +1701,6 @@ Error RenderPipelineStages::RasterStage::render_tile_fallback(const Size2i &p_vi
 		direct_light_scale = _get_float_setting(ps, direct_path, direct_light_scale);
 		indirect_sh_scale = _get_float_setting(ps, indirect_path, indirect_sh_scale);
 		shadow_strength = _get_float_setting(ps, shadow_path, shadow_strength);
-		sh_dc_logit = _get_bool_setting(ps, sh_dc_logit_path, sh_dc_logit);
 		shadow_receiver_bias_scale = _get_float_setting(ps, shadow_bias_scale_path, shadow_receiver_bias_scale);
 		shadow_receiver_bias_min = _get_float_setting(ps, shadow_bias_min_path, shadow_receiver_bias_min);
 		shadow_receiver_bias_max = _get_float_setting(ps, shadow_bias_max_path, shadow_receiver_bias_max);
@@ -1732,7 +1725,6 @@ Error RenderPipelineStages::RasterStage::render_tile_fallback(const Size2i &p_vi
 	render_params.direct_light_scale = CLAMP(direct_light_scale, 0.0f, 4.0f);
 	render_params.indirect_sh_scale = CLAMP(indirect_sh_scale, 0.0f, 4.0f);
 	render_params.shadow_strength = CLAMP(shadow_strength, 0.0f, 1.0f);
-	render_params.sh_dc_logit = sh_dc_logit;
 	render_params.shadow_receiver_bias_scale = MAX(0.0f, shadow_receiver_bias_scale);
 	render_params.shadow_receiver_bias_min = MAX(0.0f, shadow_receiver_bias_min);
 	render_params.shadow_receiver_bias_max = MAX(0.0f, shadow_receiver_bias_max);

--- a/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
+++ b/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
@@ -63,6 +63,13 @@ static AABB _compute_contiguous_chunk_bounds(const LocalVector<Gaussian> &p_gaus
 	return AABB(min_pos, size);
 }
 
+static GaussianDCEncoding _resolve_data_dc_encoding(const Ref<GaussianData> &p_data) {
+	if (p_data.is_null() || p_data->get_count() <= 0) {
+		return GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
+	}
+	return gaussian_get_dc_encoding(p_data->get_gaussian(0).render_meta);
+}
+
 template <typename T>
 static bool _upload_typed_storage_buffer(GaussianSplatRenderer *p_renderer, RenderingDevice *p_rd, RID &r_buffer,
 		uint32_t &r_buffer_size, const char *p_label, const Vector<T> &p_data) {
@@ -281,7 +288,7 @@ bool publish(GaussianSplatRenderer *p_renderer, bool p_allow_primary_fallback_in
 		AssetMetaGPU asset_meta = {};
 		asset_meta.lod_count = 1;
 		asset_meta.sh_degree = asset.data->get_sh_degree();
-		asset_meta.flags = asset.data->get_2d_mode() ? GS_INSTANCE_FLAG_IS_2D : 0u;
+		asset_meta.flags = gs_pack_asset_gpu_flags(asset.data->get_2d_mode(), _resolve_data_dc_encoding(asset.data));
 		const AABB asset_bounds = asset.data->get_aabb();
 		const Vector3 asset_center = asset_bounds.get_center();
 		const Vector3 asset_half = asset_bounds.size * 0.5f;

--- a/modules/gaussian_splatting/renderer/sh_config.cpp
+++ b/modules/gaussian_splatting/renderer/sh_config.cpp
@@ -8,7 +8,6 @@
 
 // Project settings paths
 const String SHConfig::BANDS_PATH = SH_CONFIG_BANDS_PATH;
-const String SHConfig::DC_LOGIT_PATH = SH_CONFIG_DC_LOGIT_PATH;
 const String SHConfig::PROGRESSIVE_PATH = SH_CONFIG_PROGRESSIVE_PATH;
 
 // Global instance
@@ -44,9 +43,6 @@ void SHConfig::load_from_project_settings() {
     // Load progressive loading setting
     progressive_load = ps->get_setting(PROGRESSIVE_PATH, false);
 
-    // Load DC encoding mode
-    dc_is_logit = ps->get_setting(DC_LOGIT_PATH, false);
-
     if (GS_LOG_ENABLED(gs_logger::Category::STREAMING, gs_logger::Level::INFO)) {
         print_config_summary();
     }
@@ -59,7 +55,6 @@ void SHConfig::save_to_project_settings() const {
     }
 
     ps->set_setting(BANDS_PATH, static_cast<int>(sh_bands));
-    ps->set_setting(DC_LOGIT_PATH, dc_is_logit);
     ps->set_setting(PROGRESSIVE_PATH, progressive_load);
 
     ps->save();
@@ -70,7 +65,6 @@ void SHConfig::save_to_project_settings() const {
 void SHConfig::reset_to_defaults() {
     sh_bands = SH_BAND_3;
     progressive_load = false;
-    dc_is_logit = false;
 
     GS_LOG_STREAMING_INFO(String("[SH Config] Reset to default configuration (SH3, progressive disabled)"));
 }
@@ -125,8 +119,6 @@ void SHConfig::print_config_summary() const {
             get_memory_multiplier(sh_bands) * 100.0f));
     GS_LOG_STREAMING_INFO(vformat("[SH Config] Progressive Loading: %s",
             progressive_load ? "enabled (SH0 first, then higher bands)" : "disabled"));
-    GS_LOG_STREAMING_INFO(vformat("[SH Config] DC Logit Decode: %s",
-            dc_is_logit ? "enabled (sigmoid)" : "disabled (linear)"));
     GS_LOG_STREAMING_INFO(String("[SH Config] ================================================"));
 }
 
@@ -160,18 +152,6 @@ void initialize_sh_config() {
         SHConfig::BANDS_PATH,
         PROPERTY_HINT_ENUM,
         "Auto (Tier Default):-1,SH0 (DC Only):0,SH1 (1st Order):1,SH2 (2nd Order):2,SH3 (3rd Order):3"
-    ));
-
-    // DC logit decode toggle
-    if (!ps->has_setting(SHConfig::DC_LOGIT_PATH)) {
-        ps->set_setting(SHConfig::DC_LOGIT_PATH, false);
-    }
-    ps->set_initial_value(SHConfig::DC_LOGIT_PATH, false);
-    ps->set_custom_property_info(PropertyInfo(
-        Variant::BOOL,
-        SHConfig::DC_LOGIT_PATH,
-        PROPERTY_HINT_NONE,
-        ""
     ));
 
     // Progressive loading setting

--- a/modules/gaussian_splatting/renderer/sh_config.h
+++ b/modules/gaussian_splatting/renderer/sh_config.h
@@ -24,7 +24,6 @@
 // Project settings paths
 #define SH_CONFIG_SECTION "rendering/gaussian_splatting/rendering/"
 #define SH_CONFIG_BANDS_PATH SH_CONFIG_SECTION "sh_bands"
-#define SH_CONFIG_DC_LOGIT_PATH SH_CONFIG_SECTION "dc_is_logit"
 #define SH_CONFIG_PROGRESSIVE_PATH "rendering/gaussian_splatting/streaming/sh_progressive_load"
 
 /**
@@ -50,9 +49,6 @@ struct SHConfig {
     // Enable progressive SH loading (SH0 first, then higher bands)
     bool progressive_load = false;
 
-    // Treat DC as logit and apply sigmoid (legacy compatibility)
-    bool dc_is_logit = false;
-
     // Project settings integration
     void load_from_project_settings();
     void save_to_project_settings() const;
@@ -74,7 +70,6 @@ struct SHConfig {
 
     // Constants for project settings paths
     static const String BANDS_PATH;
-    static const String DC_LOGIT_PATH;
     static const String PROGRESSIVE_PATH;
 
     String sh_bands_source = "code_default";

--- a/modules/gaussian_splatting/renderer/shader_compilation_helper.cpp
+++ b/modules/gaussian_splatting/renderer/shader_compilation_helper.cpp
@@ -331,7 +331,10 @@ Error ShaderCompilationManager::compile_all_shaders(RenderingDevice *p_device_hi
 	// Legacy per-tile sort pipeline removed; global composite sort is the only supported path.
 	owner.shader_resources.shader_device = device;
 	owner.shader_resources.shader_device_instance = device->get_device_instance_id();
-	owner.shader_resources.quantized_storage_enabled = g_quantization_config.per_chunk_quantization;
+	// Keep the cached compile mode aligned with the effective runtime quantization
+	// state. Mixed-encoding fallback can disable per-chunk quantization even when
+	// the project setting remains enabled.
+	owner.shader_resources.quantized_storage_enabled = owner.instance_pipeline_buffers.quantization_required;
 	owner.shader_resources.shader_defines_hash = owner._compute_shader_defines_hash();
 	owner.config_state.effective_splat_capacity = TileRenderer::MAX_SPLATS_PER_TILE;
 

--- a/modules/gaussian_splatting/renderer/tile_render_binning.cpp
+++ b/modules/gaussian_splatting/renderer/tile_render_binning.cpp
@@ -220,7 +220,7 @@ RID TileRenderer::TileBinningStage::acquire_binning_buffer_uniform_set(Rendering
 		ERR_FAIL_COND_V(!owner.global_sort_resources.indirect_dispatch_buffer.is_valid(), RID());
 	}
 
-	const bool quantization_required = g_quantization_config.per_chunk_quantization;
+		const bool quantization_required = owner.instance_pipeline_buffers.quantization_required;
 	ERR_FAIL_COND_V(!owner.instance_pipeline_buffers.splat_ref_buffer.is_valid(), RID());
 	ERR_FAIL_COND_V(!owner.instance_pipeline_buffers.instance_buffer.is_valid(), RID());
 	ERR_FAIL_COND_V(!owner.instance_pipeline_buffers.indirect_count_buffer.is_valid(), RID());
@@ -424,7 +424,7 @@ RID TileRenderer::TileBinningStage::acquire_binning_count_uniform_set(RenderingD
 	ERR_FAIL_COND_V(!owner.subpixel_history_buffers.subpixel_history_buffer.is_valid(), RID());
 	ERR_FAIL_COND_V(!owner.subpixel_visibility_buffers.subpixel_visibility_buffer.is_valid(), RID());
 
-	const bool quantization_required = g_quantization_config.per_chunk_quantization;
+		const bool quantization_required = owner.instance_pipeline_buffers.quantization_required;
 	ERR_FAIL_COND_V(!owner.instance_pipeline_buffers.splat_ref_buffer.is_valid(), RID());
 	ERR_FAIL_COND_V(!owner.instance_pipeline_buffers.instance_buffer.is_valid(), RID());
 	ERR_FAIL_COND_V(!owner.instance_pipeline_buffers.indirect_count_buffer.is_valid(), RID());

--- a/modules/gaussian_splatting/renderer/tile_render_stages.cpp
+++ b/modules/gaussian_splatting/renderer/tile_render_stages.cpp
@@ -203,9 +203,8 @@ TileRenderParamsGPU TileRenderer::TileRenderParamsBuilder::build_params(const Re
 	params.sh_config[1] = static_cast<float>(sh_divisor);
 	params.sh_config[2] = static_cast<float>(sh_phase);
 	params.sh_config[3] = owner.sh_cache_needs_full_update ? 1.0f : 0.0f;
-	// SH decode configuration:
-	// x=dc_logit (1.0 = decode DC with sigmoid), yzw=reserved
-	params.sh_decode_config[0] = p_params.sh_dc_logit ? 1.0f : 0.0f;
+	// SH decode configuration is reserved; decode now comes from per-gaussian metadata.
+	params.sh_decode_config[0] = 0.0f;
 	params.sh_decode_config[1] = 0.0f;
 	params.sh_decode_config[2] = 0.0f;
 	params.sh_decode_config[3] = 0.0f;

--- a/modules/gaussian_splatting/renderer/tile_render_types.h
+++ b/modules/gaussian_splatting/renderer/tile_render_types.h
@@ -338,7 +338,6 @@ struct TileRenderParams {
 	float direct_light_scale = 0.5f;
 	float indirect_sh_scale = 1.0f;
 	float shadow_strength = 1.0f;
-	bool sh_dc_logit = false;
 	float shadow_receiver_bias_scale = 0.2f;
 	float shadow_receiver_bias_min = 0.0f;
 	float shadow_receiver_bias_max = 0.0f;

--- a/modules/gaussian_splatting/renderer/tile_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/tile_renderer.cpp
@@ -1205,7 +1205,6 @@ GaussianSplatting::TileRenderParams::TileRenderParams() {
 	direct_light_scale = 0.5f;
 	indirect_sh_scale = 1.0f;
 	shadow_strength = 1.0f;
-	sh_dc_logit = false;
 	shadow_receiver_bias_scale = 0.2f;
 	shadow_receiver_bias_min = 0.0f;
 	shadow_receiver_bias_max = 0.0f;
@@ -1803,9 +1802,6 @@ Vector<String> TileRenderer::_build_common_shader_defines(bool p_include_dispatc
 	}
 	if (g_quantization_config.per_chunk_quantization) {
 		defines.push_back("#define USE_QUANTIZED_GAUSSIANS 1\n");
-	}
-	if (g_sh_config.dc_is_logit) {
-		defines.push_back("#define GS_DC_LOGIT 1\n");
 	}
 	RendererRD::LightStorage *light_storage = RendererRD::LightStorage::get_singleton();
 	uint32_t max_directional_lights = light_storage ? light_storage->get_max_directional_lights() : 1u;

--- a/modules/gaussian_splatting/renderer/tile_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/tile_renderer.cpp
@@ -343,15 +343,16 @@ private:
 
 		renderer.instance_pipeline_buffers.instance_buffer = params.instance_buffer;
 		renderer.instance_pipeline_buffers.splat_ref_buffer = params.splat_ref_buffer;
-		renderer.instance_pipeline_buffers.chunk_meta_buffer = params.chunk_meta_buffer;
-		renderer.instance_pipeline_buffers.quantization_buffer = params.quantization_buffer;
-		renderer.instance_pipeline_buffers.indirect_count_buffer = params.instance_indirect_count_buffer;
-		renderer.instance_pipeline_buffers.indirect_dispatch_buffer = params.instance_indirect_dispatch_buffer;
+			renderer.instance_pipeline_buffers.chunk_meta_buffer = params.chunk_meta_buffer;
+			renderer.instance_pipeline_buffers.quantization_buffer = params.quantization_buffer;
+			renderer.instance_pipeline_buffers.quantization_required = params.quantization_buffer.is_valid();
+			renderer.instance_pipeline_buffers.indirect_count_buffer = params.instance_indirect_count_buffer;
+			renderer.instance_pipeline_buffers.indirect_dispatch_buffer = params.instance_indirect_dispatch_buffer;
 
-		const bool quantization_required = g_quantization_config.per_chunk_quantization;
-		const GaussianSplatting::InstancePipelineContract::InvariantViolationReason invariant_reason =
-				GaussianSplatting::InstancePipelineContract::first_tile_runtime_violation(
-						renderer.instance_pipeline_buffers.instance_buffer,
+			const bool quantization_required = renderer.instance_pipeline_buffers.quantization_required;
+			const GaussianSplatting::InstancePipelineContract::InvariantViolationReason invariant_reason =
+					GaussianSplatting::InstancePipelineContract::first_tile_runtime_violation(
+							renderer.instance_pipeline_buffers.instance_buffer,
 						renderer.instance_pipeline_buffers.splat_ref_buffer,
 						renderer.instance_pipeline_buffers.indirect_count_buffer,
 						renderer.instance_pipeline_buffers.indirect_dispatch_buffer,
@@ -1800,9 +1801,9 @@ Vector<String> TileRenderer::_build_common_shader_defines(bool p_include_dispatc
 	if (render_settings.enable_sh_amortization) {
 		defines.push_back("#define GS_SH_AMORTIZATION 1\n");
 	}
-	if (g_quantization_config.per_chunk_quantization) {
-		defines.push_back("#define USE_QUANTIZED_GAUSSIANS 1\n");
-	}
+		if (instance_pipeline_buffers.quantization_required) {
+			defines.push_back("#define USE_QUANTIZED_GAUSSIANS 1\n");
+		}
 	RendererRD::LightStorage *light_storage = RendererRD::LightStorage::get_singleton();
 	uint32_t max_directional_lights = light_storage ? light_storage->get_max_directional_lights() : 1u;
 	if (max_directional_lights == 0u) {
@@ -1955,7 +1956,7 @@ bool TileRenderer::_check_pipeline_validity(RenderingDevice *p_device, bool p_wa
 	if (p_want_compute_raster) {
 		pipelines_valid = pipelines_valid && shader_resources.tile_raster_compute_shader.is_valid() && shader_resources.tile_raster_compute_pipeline.is_valid();
 	}
-	pipelines_valid = pipelines_valid && shader_resources.quantized_storage_enabled == g_quantization_config.per_chunk_quantization;
+		pipelines_valid = pipelines_valid && shader_resources.quantized_storage_enabled == instance_pipeline_buffers.quantization_required;
 	pipelines_valid = pipelines_valid && shader_resources.shader_defines_hash == _compute_shader_defines_hash();
 	return pipelines_valid;
 }

--- a/modules/gaussian_splatting/shaders/includes/gs_instance_layout.glsl
+++ b/modules/gaussian_splatting/shaders/includes/gs_instance_layout.glsl
@@ -24,6 +24,10 @@ const uint GS_INSTANCE_FLAG_ROTATION_IDENTITY = 1u << 1u;
 const uint GS_INSTANCE_FLAG_SCALE_IDENTITY = 1u << 2u;
 const uint GS_INSTANCE_FLAG_TRANSLATION_ZERO = 1u << 3u;
 
+// Asset/chunk metadata flags.
+const uint GS_ASSET_FLAG_IS_2D = 1u << 0u;
+const uint GS_ASSET_FLAG_DC_LINEAR_RGB = 1u << 1u;
+
 // Instance wind override modes (params.w).
 #ifndef GS_INSTANCE_WIND_MODE_INHERIT
 #define GS_INSTANCE_WIND_MODE_INHERIT 0u
@@ -40,7 +44,7 @@ struct AssetLodRangeGPU {
 struct AssetMetaGPU {
     uint lod_count;
     uint sh_degree;          // max SH bands for asset
-    uint flags;              // include is_2d bit
+    uint flags;              // GS_ASSET_FLAG_* metadata shared with chunk flags
     uint pad0;
 
     vec3 bounds_center_local;

--- a/modules/gaussian_splatting/shaders/includes/gs_render_params.glsl
+++ b/modules/gaussian_splatting/shaders/includes/gs_render_params.glsl
@@ -40,8 +40,7 @@ layout(set = 1, binding = 0, std140) uniform RenderParams {
     // x=sh_bands (0-3), y=amortization_divisor, z=amortization_phase, w=force_full_update
     // sh_bands: 0=DC only, 1=1st order, 2=2nd order, 3=3rd order (full)
     vec4 sh_config;
-    // SH decode configuration:
-    // x=dc_logit (1.0=decode DC with sigmoid), yzw=reserved
+    // SH decode configuration (reserved for legacy/debug; runtime decode now comes from per-gaussian metadata).
     vec4 sh_decode_config;
     // Opacity-aware culling (FlashGS optimization):
     // x=enabled (1.0=true), y=visibility_threshold (tau), z=reserved, w=reserved
@@ -123,11 +122,6 @@ bool gs_is_sh_amortization_enabled() {
 // Return whether SH amortization should force an update this frame.
 bool gs_get_sh_amortization_force_update() {
     return params.sh_config.w > 0.5;
-}
-
-// Return whether DC logit decoding is enabled.
-bool gs_is_dc_logit_enabled() {
-    return params.sh_decode_config.x > 0.5;
 }
 
 // Helper to check if opacity-aware culling is enabled

--- a/modules/gaussian_splatting/shaders/includes/gs_sh_binning.glsl
+++ b/modules/gaussian_splatting/shaders/includes/gs_sh_binning.glsl
@@ -33,6 +33,10 @@ uint gaussian_get_sh_encoding(uint meta) {
     return (meta & SH_METADATA_ENCODING_MASK) >> 24u;
 }
 
+bool gaussian_get_dc_is_linear_rgb(uint meta) {
+    return (meta & SH_METADATA_DC_ENCODING_MASK) != 0u;
+}
+
 // Decode one RGB9E5-packed SH coefficient triplet to linear RGB.
 vec3 decode_rgb9e5(uint packed) {
     uint exponent = (packed >> 27u) & 0x1Fu;

--- a/modules/gaussian_splatting/shaders/includes/gs_sh_binning.glsl
+++ b/modules/gaussian_splatting/shaders/includes/gs_sh_binning.glsl
@@ -1,6 +1,6 @@
 // gs_sh_binning.glsl — Spherical harmonics evaluation for tile binning.
 //
-// Requires: Gaussian struct, gs_is_dc_logit_enabled() (from gs_render_params.glsl)
+// Requires: Gaussian struct
 // to be defined before inclusion.
 
 #ifndef GS_SH_BINNING_GLSL_INCLUDED
@@ -131,7 +131,7 @@ void compute_sh_basis_1st_order(vec3 dir, out float basis[4]) {
 vec3 evaluate_sh_with_bands(Gaussian g, vec3 view_dir, uint sh_band_level) {
     // Decode DC term. Some datasets store DC in logit space (original 3DGS),
     // others store linear coefficients (SPZ/converted assets).
-    bool dc_logit = gs_is_dc_logit_enabled();
+    bool dc_logit = !gaussian_get_dc_is_linear_rgb(g.sh_metadata);
     vec3 color;
     if (dc_logit) {
         vec3 dc_logit_val = g.sh_dc.rgb;

--- a/modules/gaussian_splatting/shaders/tile_binning.glsl
+++ b/modules/gaussian_splatting/shaders/tile_binning.glsl
@@ -363,10 +363,14 @@ bool gs_tile_intersects_projected_ellipse(vec2 center, vec3 conic, float sigma2,
 #include "includes/gs_culling_utils.glsl"
 
 // Pack quantized spherical-harmonic metadata for the renderer.
-uint gs_build_quantized_sh_metadata(uint encoded_total) {
+uint gs_build_quantized_sh_metadata(uint encoded_total, bool dc_linear_rgb) {
     uint first_count = min(encoded_total, 3u);
     uint high_count = encoded_total > first_count ? (encoded_total - first_count) : 0u;
-    return first_count | (high_count << 8u) | (encoded_total << 16u) | (SH_ENCODING_RGB9E5 << 24u);
+    uint metadata = first_count | (high_count << 8u) | (encoded_total << 16u) | (SH_ENCODING_RGB9E5 << 24u);
+    if (dc_linear_rgb) {
+        metadata |= SH_METADATA_DC_ENCODING_MASK;
+    }
+    return metadata;
 }
 
 // Project a Gaussian into screen space and derive its 2D covariance.
@@ -627,7 +631,8 @@ void main() {
     GaussianQuantized src = atlas_gaussian_buffer.gaussians[gaussian_idx];
     uint quant_id = extract_chunk_id(src.position_chunk);
     ChunkQuantization quant = quantization_buffer.chunks[quant_id];
-    chunk_sh_limit = min(chunk_meta_buffer.chunk_meta[quant_id].sh_limit, 3u);
+    ChunkMetaGPU chunk_meta = chunk_meta_buffer.chunk_meta[quant_id];
+    chunk_sh_limit = min(chunk_meta.sh_limit, 3u);
     vec3 local_position = dequantize_position(extract_quantized_position(src.position_chunk), quant);
     vec3 local_scale = LOAD_SCALE_QUANTIZED(src, quant);
     vec4 local_rotation = extract_rotation(src.rotation_lo, src.rotation_hi);
@@ -635,7 +640,7 @@ void main() {
     Gaussian g;
     g.opacity = src.opacity;
     g.sh_dc = src.sh_dc;
-    g.sh_metadata = gs_build_quantized_sh_metadata(6u);
+    g.sh_metadata = gs_build_quantized_sh_metadata(6u, (chunk_meta.flags & GS_ASSET_FLAG_DC_LINEAR_RGB) != 0u);
     for (int i = 0; i < 12; ++i) {
         g.sh_encoded[i] = 0.0;
     }

--- a/modules/gaussian_splatting/tests/test_gaussian_importer.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_importer.h
@@ -1122,6 +1122,24 @@ TEST_CASE("[GaussianSplatting][Renderer] Shader SH metadata masks match host DC 
     CHECK(binning_source.contains("const uint SH_METADATA_DC_ENCODING_MASK = 0x80000000u;"));
 }
 
+TEST_CASE("[GaussianSplatting][Renderer] Quantized SH metadata preserves DC encoding through asset flags") {
+    const uint32_t legacy_flags = gs_pack_asset_gpu_flags(false, GAUSSIAN_DC_ENCODING_LEGACY_BIAS);
+    const uint32_t linear_flags = gs_pack_asset_gpu_flags(false, GAUSSIAN_DC_ENCODING_LINEAR_RGB);
+    const uint32_t is_2d_linear_flags = gs_pack_asset_gpu_flags(true, GAUSSIAN_DC_ENCODING_LINEAR_RGB);
+    CHECK((legacy_flags & GS_GPU_ASSET_FLAG_DC_LINEAR_RGB) == 0u);
+    CHECK((linear_flags & GS_GPU_ASSET_FLAG_DC_LINEAR_RGB) != 0u);
+    CHECK((is_2d_linear_flags & GS_GPU_ASSET_FLAG_IS_2D) != 0u);
+
+    const String instance_layout_source = _load_text_fixture_or_empty("res://modules/gaussian_splatting/shaders/includes/gs_instance_layout.glsl");
+    REQUIRE_MESSAGE(!instance_layout_source.is_empty(), "gs_instance_layout.glsl must be readable in test environment");
+    CHECK(instance_layout_source.contains("const uint GS_ASSET_FLAG_DC_LINEAR_RGB = 1u << 1u;"));
+
+    const String tile_binning_source = _load_text_fixture_or_empty("res://modules/gaussian_splatting/shaders/tile_binning.glsl");
+    REQUIRE_MESSAGE(!tile_binning_source.is_empty(), "tile_binning.glsl must be readable in test environment");
+    CHECK(tile_binning_source.contains("uint gs_build_quantized_sh_metadata(uint encoded_total, bool dc_linear_rgb)"));
+    CHECK(tile_binning_source.contains("chunk_meta.flags & GS_ASSET_FLAG_DC_LINEAR_RGB"));
+}
+
 TEST_CASE("[GaussianSplatting][Importer] populate_from_asset preserves DC encoding metadata") {
     Ref<GaussianSplatAsset> asset = _make_thumbnail_fixture_asset(1);
     REQUIRE_MESSAGE(asset.is_valid(), "Fixture asset must be created");

--- a/modules/gaussian_splatting/tests/test_gpu_streaming.cpp
+++ b/modules/gaussian_splatting/tests/test_gpu_streaming.cpp
@@ -1376,6 +1376,46 @@ TEST_CASE("[Streaming Pipeline] Atlas generation bumps on quantization buffer re
     g_quantization_config = saved_quantization_config;
 }
 
+TEST_CASE("[Streaming Pipeline] Mixed DC encoding disables per-chunk quantization fallback") {
+    RenderingServer *rs = RenderingServer::get_singleton();
+    if (!rs) {
+        MESSAGE("Skipping - Rendering server unavailable");
+        return;
+    }
+
+    RenderingDevice *rd = RenderingDevice::get_singleton();
+    if (!rd) {
+        rd = rs->create_local_rendering_device();
+    }
+    if (!rd) {
+        MESSAGE("Skipping - Rendering device unavailable");
+        return;
+    }
+
+    const QuantizationConfig saved_quantization_config = g_quantization_config;
+    g_quantization_config.per_chunk_quantization = true;
+    g_quantization_config.position_bits = 16;
+    g_quantization_config.scale_bits = 12;
+    g_quantization_config.quantize_scales = false;
+
+    Ref<::GaussianData> mixed_data = create_test_gaussian_data(GaussianStreamingSystem::CHUNK_SIZE);
+    REQUIRE(mixed_data.is_valid());
+    Gaussian linear = mixed_data->get_gaussian(0);
+    linear.render_meta = gaussian_set_dc_encoding(linear.render_meta, GAUSSIAN_DC_ENCODING_LINEAR_RGB);
+    mixed_data->set_gaussian(0, linear);
+
+    Ref<GaussianStreamingSystem> system;
+    system.instantiate();
+    system->initialize_empty(rd);
+
+    const uint32_t asset_id = 23;
+    system->register_asset(asset_id, mixed_data);
+    CHECK_FALSE(system->is_per_chunk_quantization_enabled());
+    CHECK_FALSE(system->get_atlas_quantization_buffer().is_valid());
+
+    g_quantization_config = saved_quantization_config;
+}
+
 TEST_CASE("[Streaming Pipeline] IO layout hints clamp chunk size to CHUNK_SIZE") {
     RenderingServer *rs = RenderingServer::get_singleton();
     if (!rs) {


### PR DESCRIPTION
## Summary
- remove active global DC decode override usage and rely on per-asset/per-gaussian metadata
- harden quantized handling so uniform assets preserve DC mode and mixed-encoding assets fall back to the non-quantized path
- report the effective quantization state in streaming diagnostics

## Validation
- `git diff --check`
- `python3 tests/ci/run_module_tests.py --guard-only`

Closes #164.