### PR TITLE
fix: detach import settings inspector before teardown

### DIFF
--- a/modules/gaussian_splatting/editor/gaussian_import_settings_dialog.cpp
+++ b/modules/gaussian_splatting/editor/gaussian_import_settings_dialog.cpp
@@ -281,7 +281,13 @@ GaussianImportSettingsDialog::GaussianImportSettingsDialog() {
 
 GaussianImportSettingsDialog::~GaussianImportSettingsDialog() {
 	singleton = nullptr;
+	if (inspector) {
+		inspector->edit(nullptr);
+	}
+	_clear_viewport_scene();
+	loaded_asset.unref();
 	memdelete(settings_data);
+	settings_data = nullptr;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- clear the import settings inspector edited object before dialog destruction
- tear down preview state before freeing the backing settings object
- harden the advanced import-settings dialog against the current Windows runtime-harness crash

## Context
The current production gate on `master` is crashing in `[GaussianSplatting][Editor] Advanced import settings reimport refreshes inspector, preview, and stats`. This slice is the smallest safe lifecycle hardening patch based on the failing path.

## Validation
- `git diff --check origin/master...HEAD`
- `python3 tests/ci/run_module_tests.py --guard-only`