### PR TITLE
fix: route direct GaussianSplatNode3D scenes through resident backend

### DIFF
--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -1996,11 +1996,19 @@ void GaussianSplatNode3D::_register_instance_in_director() {
     if (!director) {
         return;
     }
+    // Direct single-asset nodes request the resident backend. The streaming
+    // backend is opt-in via GaussianSplatWorld3D (which publishes its own
+    // streaming hint). Without this, a direct-node-only scene with default
+    // project settings (route_policy=STREAMING) would fall into the streaming
+    // branch and rely on an unintended resident-fallback detour that emits a
+    // WARN_PRINT_ONCE on every cold start.
     director->register_instance(get_instance_id(), asset, get_global_transform(),
             opacity, lod_bias, _get_instance_flags(), cast_shadow,
             _get_instance_wind_intensity(), _get_instance_wind_mode(),
             _get_instance_wind_direction(), _get_instance_wind_frequency(),
-            parent_visible && visible_in_viewport && is_visible_in_tree());
+            parent_visible && visible_in_viewport && is_visible_in_tree(),
+            /*has_desired_residency_hint=*/true,
+            GaussianSplatSceneDirector::SUBMISSION_RESIDENCY_HINT_RESIDENT);
 }
 
 void GaussianSplatNode3D::_unregister_instance_in_director() {
@@ -2026,7 +2034,9 @@ void GaussianSplatNode3D::_update_instance_params_in_director() {
         director->update_instance_params(get_instance_id(), opacity, lod_bias, _get_instance_flags(), cast_shadow,
                 _get_instance_wind_intensity(), _get_instance_wind_mode(),
                 _get_instance_wind_direction(), _get_instance_wind_frequency(),
-                parent_visible && visible_in_viewport && is_visible_in_tree());
+                parent_visible && visible_in_viewport && is_visible_in_tree(),
+                /*has_desired_residency_hint=*/true,
+                GaussianSplatSceneDirector::SUBMISSION_RESIDENCY_HINT_RESIDENT);
     }
     if (renderer.is_valid()) {
         renderer->invalidate_cached_render();


### PR DESCRIPTION
## Summary

`GaussianSplatNode3D` already registers with `GaussianSplatSceneDirector` but omits the residency-hint fields, leaving `has_desired_residency_hint=false`. With default project settings (`route_policy=STREAMING`), the renderer's `should_prefer_resident_backend` consults the director's aggregated hint — and with no active hint from any submission, it returns `false`. Direct-node-only scenes then take the streaming branch, rely on the primary-fallback-instance path to synthesize a contract from non-chunked in-memory data, and when that returns without publishing atlas inputs, fall back to resident and emit a `WARN_PRINT_ONCE` about streaming not being usable — on every cold start.

This patch populates the hint fields on both `register_instance` and `update_instance_params` calls so `GaussianSplatNode3D` instances request the resident backend. `GaussianSplatWorld3D` continues to publish its own streaming hint, so mixed scenes are unaffected (world submissions take precedence over instance hints).

## What changed

- `modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp`: pass `has_desired_residency_hint=true` + `SUBMISSION_RESIDENCY_HINT_RESIDENT` on the two director calls that previously relied on defaults.

## Verification

Empirical check on a 25-asset direct-node scene (`dream_memory.tscn` in an internal test project):

| Binary | `[DIAG-ROUTE]` first frame | Streaming fallback WARN | Splats visible |
|---|---|---|---|
| Before this PR | `prefer_resident=no streaming_req=YES` | emitted | yes (via detour + fallback) |
| After this PR  | `prefer_resident=YES streaming_req=YES` | not emitted | yes (direct resident path) |

No visible-output difference; this is a routing cleanup, not a rendering fix.

## Known related issue (not addressed here)

Even with correct routing, rendering the splats in a real scene currently requires `rendering/gaussian_splatting/composite/depth_test=false` in the consumer project. The compositor rejects splat pixels against Godot's opaque scene depth buffer for reasons that need further investigation (`interfaces/output_compositor.cpp` + `shaders/viewport_blit.glsl`). That's a separate PR; this one is the scoped routing fix.

## Test plan

- [x] Build clean on Windows MSVC x86_64 (dev_build=yes, target=editor).
- [x] Direct-node scene still renders (empirically verified in an internal project).
- [x] Mixed scene behavior unchanged — world submissions take precedence.
- [ ] Reviewer spot-check: no doctest suite for `GaussianSplatSceneDirector` hint aggregation explicitly covers single-asset direct-node scenes; could add one in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)