### PR TITLE
cleanup: downgrade startup-info log lines from WARN to INFO

### DIFF
--- a/modules/gaussian_splatting/interfaces/gpu_culler.cpp
+++ b/modules/gaussian_splatting/interfaces/gpu_culler.cpp
@@ -360,7 +360,7 @@ void GPUCuller::_ensure_shader(RenderingDevice *p_device) {
                 // Enable subgroup-optimized variant
                 state.source.enable_group(SHADER_GROUP_SUBGROUPS);
                 state.enabled_group = SHADER_GROUP_SUBGROUPS;
-                GS_LOG_WARN_DEFAULT("[GPUCuller] Subgroup operations available - using optimized ballot/shuffle path");
+                GS_LOG_INFO_DEFAULT("[GPUCuller] Subgroup operations available - using optimized ballot/shuffle path");
             } else {
                 // Enable standard variant with atomicAdd fallback
                 state.source.enable_group(SHADER_GROUP_STANDARD);
@@ -407,7 +407,7 @@ void GPUCuller::_ensure_shader(RenderingDevice *p_device) {
     }
 
     resource_device = p_device;
-    GS_LOG_WARN_DEFAULT(vformat("[GPUCuller] Shader initialized successfully (subgroups=%s)",
+    GS_LOG_INFO_DEFAULT(vformat("[GPUCuller] Shader initialized successfully (subgroups=%s)",
             subgroups_available ? "enabled" : "disabled"));
 }
 

--- a/modules/gaussian_splatting/renderer/batched_async_readback.cpp
+++ b/modules/gaussian_splatting/renderer/batched_async_readback.cpp
@@ -45,7 +45,7 @@ Error BatchedAsyncReadback::initialize(RenderingDevice *p_rd, uint32_t p_staging
 	rd->set_resource_name(staging_buffer, "GS_BatchedReadbackStaging");
 
 	initialized = true;
-	GS_LOG_WARN_DEFAULT(vformat("[BatchedAsyncReadback] Initialized with %d KB staging buffer", staging_buffer_size / 1024));
+	GS_LOG_INFO_DEFAULT(vformat("[BatchedAsyncReadback] Initialized with %d KB staging buffer", staging_buffer_size / 1024));
 	return OK;
 }
 

--- a/modules/gaussian_splatting/renderer/tile_render_resources.cpp
+++ b/modules/gaussian_splatting/renderer/tile_render_resources.cpp
@@ -1204,7 +1204,7 @@ void TileGlobalSortResources::ensure_resources(uint32_t p_visible_count) {
 					key_config = desired_key_config;
 					capacity = sorter->get_max_elements();
 					sorter_available = true;
-					WARN_PRINT_ONCE(vformat("[TileRenderer] Global sort capacity initialized: %d (config max_overlap_records=%d)",
+					GS_LOG_INFO_DEFAULT(vformat("[TileRenderer] Global sort capacity initialized: %d (config max_overlap_records=%d)",
 						int(capacity), int(g_gpu_sorting_config.max_overlap_records)));
 					if (capacity < attempt_elements) {
 						WARN_PRINT_ONCE(vformat("[TileRenderer] Global sort capacity capped (requested=%d, actual=%d)",

--- a/modules/gaussian_splatting/renderer/tile_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/tile_renderer.cpp
@@ -1955,7 +1955,7 @@ void TileRenderer::_detect_subgroup_support(RenderingDevice *p_device) {
 
 	if (GaussianSplatting::is_debug_frame_logging_enabled()) {
 		if (shader_resources.subgroups_available) {
-			GS_LOG_WARN_DEFAULT(vformat("[TileRenderer] Subgroup operations available (basic=%d, ballot=%d, shuffle=%d, vote=%d, compute=%d, fragment=%d) - using optimized path",
+			GS_LOG_INFO_DEFAULT(vformat("[TileRenderer] Subgroup operations available (basic=%d, ballot=%d, shuffle=%d, vote=%d, compute=%d, fragment=%d) - using optimized path",
 					(int)has_basic, (int)has_ballot, (int)has_shuffle, (int)has_vote, (int)has_compute, (int)has_fragment));
 		} else {
 			GS_LOG_WARN_DEFAULT(vformat("[TileRenderer] Subgroup operations unavailable (basic=%d, ballot=%d, shuffle=%d, vote=%d, compute=%d, fragment=%d) - using atomicAdd fallback",


### PR DESCRIPTION
## Summary

Five routine startup messages were emitted at `WARN` level, polluting error scanners and misleading log readers. All five are feature-detection-success or one-shot init-capacity reports, not anomalies.

| File:line | Message |
|---|---|
| `tile_renderer.cpp:1958` | \"Subgroup operations available … - using optimized path\" |
| `interfaces/gpu_culler.cpp:363` | \"Subgroup operations available - using optimized ballot/shuffle path\" |
| `interfaces/gpu_culler.cpp:410` | \"Shader initialized successfully (subgroups=…)\" |
| `renderer/batched_async_readback.cpp:48` | \"Initialized with … KB staging buffer\" |
| `renderer/tile_render_resources.cpp:1207` | \"Global sort capacity initialized: …\" |

Moved them to `GS_LOG_INFO_DEFAULT`. The matching `tile_renderer.cpp:1961` fallback branch (subgroup unavailable → atomicAdd path) stays at WARN because that really is a legitimate slower-path warning.

## Test plan

- [x] Clean Windows build (dev_build=yes, target=editor, 33 s).
- [ ] `grep -c 'WARN' clean-startup-log` for the five messages above should drop from 5 to 0 in a clean run; they should now appear at `[INFO]` in dev builds and be suppressed in production where `GS_LOG_MAX_LEVEL=ERROR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)