### PR TITLE
perf: speed up splat rendering hot path (resident + raster)

### DIFF
--- a/docs/reports/timestamp_monitor_investigation.md
+++ b/docs/reports/timestamp_monitor_investigation.md
@@ -1,0 +1,65 @@
+# Timestamp Monitor Investigation — `gpu_time_raster_ms` reads 0
+
+**Status**: open, partial fix applied (commit removing one of the per-frame syncronous readbacks).
+**Date**: 2026-04-15
+**Branch context**: investigated on `test/tier2-pr232-plus-235` (≈ master + tier-2 + #232).
+
+## Symptom
+
+`Performance.get_custom_monitor("gaussian_splatting/gpu_time_raster_ms")` reads `0.000` on direct-node scenes (GaussianSplatNode3D, no streaming world). `gpu_time_binning_ms`, `gpu_time_prefix_ms`, `gpu_time_resolve_ms` likely also zero (only raster was probed).
+
+`gpu_time_sort_ms` and `gpu_time_cull_ms` work — those use a different timing source (sort pipeline / culler), not the tile-renderer timestamp pool.
+
+## What is confirmed
+
+Verified via temporary `print_line()` diagnostics (since reverted):
+
+| Check | Result |
+|---|---|
+| `TileRenderer::resolve_gpu_timestamps_async()` called every frame | yes |
+| `gpu_timestamp_capture_enabled` | true (default) |
+| `_get_submission_device()` returns a valid device | yes |
+| `device->get_captured_timestamps_count()` at resolve time | **0 every frame** |
+
+Function exits at the early-return at `tile_renderer.cpp:2384` (`if (available == 0) return;`) before ever entering `_compute_stage_durations()`.
+
+## What is mechanically true in the code
+
+- Raster stage emits `capture_timestamp("TileRaster_<serial>_Begin/_End")` at `tile_render_rasterizer_stage.cpp:86/114` (compute path) and `:149/227` (graphics path).
+- The capture device is `submission_device` = `_acquire_submission_device()` = `_get_submission_device()` — same device the resolve queries. Not a device-mismatch bug.
+- `_reset_timestamp_tracking()` at `tile_renderer.cpp:2175-2193` keeps previous values when `gpu_timestamp_capture_enabled=true`, so stale values would persist if any capture had succeeded — they haven't.
+- The code itself flags the cause at `tile_renderer.cpp:495-497`:
+  > "GaussianSplat_Begin/End timestamps are NOT captured because buffer_get_data() in the prefix sum forces a flush that resets the timestamp buffer. Only TileOverlapCount markers (pre-flush) can be read."
+
+## What was tried and ruled out
+
+- **`active_renderer` registration**: `GaussianSplattingPerformanceMonitors::register_renderer(TileRenderer*)` is never called in production code (only in tests at `tests/test_diagnostics.h`). So the monitor's "direct" path (`active_renderer->get_last_gpu_raster_time_ms()`) is always 0 and the monitor depends entirely on the snapshot fallback. **Not the root cause** — fallback chain is wired correctly.
+- **Calling `resolve_gpu_timestamps_async()` from the monitor getter**: tried and reverted. Caused per-poll GPU sync, halving FPS. Do not repeat.
+- **Removing per-frame `sorted_indices_preview` readback** (`render_diagnostics_orchestrator.cpp:1002`): committed as a separate perf win. Did **not** restore raster_ms — there's at least one more in-frame flush wiping the timestamp buffer.
+- **Prefix-scan policy-gated readbacks** (`tile_render_prefix_scan.cpp:230/418/65/558/579/603`): all default-off and not overridden in the GH project. Not the source.
+
+## Hypotheses still open
+
+1. Some other in-frame `buffer_get_data()` or device-flushing operation between raster `capture_timestamp()` and end-of-frame `resolve_gpu_timestamps_async()` query. Need to enumerate every device-touching call on the per-frame path post-raster.
+2. Multi-context boundary: the local compute device may not actually share the timestamp buffer with whatever device returns from `_get_submission_device()` at resolve time, even though the pointers compare equal in our diagnostic. Worth checking whether device pointer identity → timestamp pool identity in Godot's RD layer.
+3. Timestamp buffer is reset by Godot at frame boundaries before our resolve runs — possible if `update_gpu_pass_metrics_from_tile_renderer()` runs in a phase where the previous frame's captures have already been wiped.
+
+## Why this matters
+
+Without `raster_ms` (and the other tile-renderer monitors), all subsequent GPU-side optimization work is blind. The dream scene runs at ~60 FPS with 227k visible splats, and we need to know whether the bulk of the 16ms is in raster, in CPU setup, or in something else entirely. Codex audits identified candidate wins (per-pixel SSBO chain, 40KB shared-memory occupancy throttle, cross-device sort sync, resident contract republish), but we can't quantify their impact without the monitor.
+
+## Next investigation steps
+
+- **Enumerate all per-frame device-touching calls** on the tile_renderer path after raster capture. Targets: `buffer_get_data`, `safe_sync`, `safe_submit_and_sync`, `_flush_pending_submission(true)`, `compute_list_add_barrier` of full-barrier type, `submit`, `sync`. Categorize: which fire by default, which only on debug/sync paths.
+- **Cross-check device identity** between capture site and resolve site: log `submission_device` pointer at both call sites; if they're different objects despite both coming from `_get_submission_device()`, that's the bug.
+- **Try a synthetic capture-then-immediately-query** to isolate whether timestamps survive AT ALL on this path, independent of the raster pipeline. If a degenerate `capture("test_Begin"); capture("test_End"); get_count()` returns 0, the timestamp pool is being wiped by something further upstream than we think.
+
+## Related codex audit findings (not the monitor itself, but in the same area)
+
+- `gpu_sorting_pipeline.cpp:2604-2609` — `safe_submit_and_sync(compute_rd)` before `sort_async()` on cross-device sort. Per-frame full sync. Likely candidate for "what wipes the timestamp buffer" if cross-device path is active.
+- `tile_render_resolve.cpp:1243-1249` — `safe_sync()` after resolve dispatch on non-main RD. Another flush.
+- `tile_render_prefix_scan.cpp:417/499/603` — sync readbacks on policy-gated paths.
+
+## Workaround until fixed
+
+Use frame-time variance (`Engine.get_frames_per_second()` over a sample window) and CPU-side timing markers (e.g. `Time.get_ticks_usec()` around code regions) to estimate where time goes. Imprecise, but the only signal we have on this path right now.

--- a/modules/gaussian_splatting/core/gaussian_data.cpp
+++ b/modules/gaussian_splatting/core/gaussian_data.cpp
@@ -231,6 +231,7 @@ void GaussianData::_on_gaussian_storage_changed_locked() {
     if (animation_state_machine.is_valid()) {
         animation_state_machine->set_splat_count(gaussians.size());
     }
+    _bump_content_revision();
 }
 
 void GaussianData::set_gaussians(const LocalVector<Gaussian> &p_gaussians) {
@@ -301,6 +302,7 @@ void GaussianData::set_gaussian_payload(const LocalVector<Gaussian> &p_gaussians
     if (animation_state_machine.is_valid()) {
         animation_state_machine->set_splat_count(gaussians.size());
     }
+    _bump_content_revision();
 }
 
 const Gaussian *GaussianData::get_gaussians() const {
@@ -362,6 +364,7 @@ void GaussianData::set_gaussian(int p_index, const Gaussian &p_gaussian) {
         MutexLock anim_lock(animation_cache_mutex);
         animation_cache_dirty = true;
     }
+    _bump_content_revision();
 }
 
 Gaussian GaussianData::get_gaussian(int p_index) const {
@@ -531,6 +534,7 @@ void GaussianData::set_positions(const PackedVector3Array &p_positions) {
     for (uint32_t i = 0; i < gaussians.size(); i++) {
         gaussians[i].position = p_positions[i];
     }
+    _bump_content_revision();
 }
 
 void GaussianData::set_scales(const PackedVector3Array &p_scales) {
@@ -539,6 +543,7 @@ void GaussianData::set_scales(const PackedVector3Array &p_scales) {
     for (uint32_t i = 0; i < gaussians.size(); i++) {
         gaussians[i].scale = p_scales[i];
     }
+    _bump_content_revision();
 }
 
 void GaussianData::set_rotations(const TypedArray<Quaternion> &p_rotations) {
@@ -547,6 +552,7 @@ void GaussianData::set_rotations(const TypedArray<Quaternion> &p_rotations) {
     for (uint32_t i = 0; i < gaussians.size(); i++) {
         gaussians[i].rotation = p_rotations[i];
     }
+    _bump_content_revision();
 }
 
 void GaussianData::set_opacities(const PackedFloat32Array &p_opacities) {
@@ -555,6 +561,7 @@ void GaussianData::set_opacities(const PackedFloat32Array &p_opacities) {
     for (uint32_t i = 0; i < gaussians.size(); i++) {
         gaussians[i].opacity = p_opacities[i];
     }
+    _bump_content_revision();
 }
 
 void GaussianData::set_spherical_harmonics(const PackedFloat32Array &p_sh_data) {
@@ -583,6 +590,7 @@ void GaussianData::set_spherical_harmonics(const PackedFloat32Array &p_sh_data) 
     for (uint32_t i = 0; i < gaussian_count; i++) {
         _set_spherical_harmonics_locked(i, data_ptr + i * floats_per_gaussian, floats_per_gaussian);
     }
+    _bump_content_revision();
 }
 
 void GaussianData::set_palette_ids(const PackedInt32Array &p_palette_ids) {
@@ -594,6 +602,7 @@ void GaussianData::set_palette_ids(const PackedInt32Array &p_palette_ids) {
         Gaussian &g = gaussians[i];
         g.painterly_meta = gaussian_set_palette_id(g.painterly_meta, (uint16_t)value);
     }
+    _bump_content_revision();
 }
 
 void GaussianData::set_painterly_flags(const PackedInt32Array &p_flags) {
@@ -605,6 +614,7 @@ void GaussianData::set_painterly_flags(const PackedInt32Array &p_flags) {
         Gaussian &g = gaussians[i];
         g.painterly_meta = gaussian_set_painterly_flags(g.painterly_meta, (uint16_t)value);
     }
+    _bump_content_revision();
 }
 
 PackedInt32Array GaussianData::get_brush_override_ids() const {
@@ -791,6 +801,7 @@ void GaussianData::_set_spherical_harmonics_locked(int p_index, const float *p_c
 void GaussianData::set_spherical_harmonics(int p_index, const float *p_coeffs, int p_count) {
     RWLockWrite lock(data_rwlock);
     _set_spherical_harmonics_locked(p_index, p_coeffs, p_count);
+    _bump_content_revision();
 }
 
 void GaussianData::set_brush_axes(const PackedVector2Array &p_brush_axes) {
@@ -799,6 +810,7 @@ void GaussianData::set_brush_axes(const PackedVector2Array &p_brush_axes) {
     for (uint32_t i = 0; i < gaussians.size(); i++) {
         gaussians[i].brush_axes = p_brush_axes[i];
     }
+    _bump_content_revision();
 }
 
 void GaussianData::set_stroke_ages(const PackedFloat32Array &p_stroke_ages) {
@@ -807,11 +819,13 @@ void GaussianData::set_stroke_ages(const PackedFloat32Array &p_stroke_ages) {
     for (uint32_t i = 0; i < gaussians.size(); i++) {
         gaussians[i].stroke_age = p_stroke_ages[i];
     }
+    _bump_content_revision();
 }
 
 void GaussianData::set_2d_mode(bool p_enabled) {
     RWLockWrite lock(data_rwlock);
     is_2d_mode = p_enabled;
+    _bump_content_revision();
 }
 
 void GaussianData::set_normals(const PackedVector3Array &p_normals) {
@@ -820,6 +834,7 @@ void GaussianData::set_normals(const PackedVector3Array &p_normals) {
     for (uint32_t i = 0; i < gaussians.size(); i++) {
         gaussians[i].normal = p_normals[i];
     }
+    _bump_content_revision();
 }
 
 

--- a/modules/gaussian_splatting/core/gaussian_data.h
+++ b/modules/gaussian_splatting/core/gaussian_data.h
@@ -11,6 +11,7 @@
 #ifndef GAUSSIAN_DATA_H
 #define GAUSSIAN_DATA_H
 
+#include <atomic>
 #include <cstddef>
 
 #include "core/io/resource.h"
@@ -272,6 +273,7 @@ class GaussianData : public Resource {
 
 private:
     LocalVector<Gaussian> gaussians;
+    std::atomic<uint64_t> content_revision{0};
     uint32_t sh_degree = 0;
     uint32_t sh_first_order_count = 0;
     uint32_t sh_high_order_count = 0;
@@ -347,6 +349,7 @@ private:
     void _subdivide_octree_node(uint32_t node_idx, int max_depth, uint32_t min_gaussians = 32);
     void _on_gaussian_storage_changed();
     void _on_gaussian_storage_changed_locked();
+    void _bump_content_revision() { content_revision.fetch_add(1, std::memory_order_relaxed); }
     void _set_spherical_harmonics_locked(int p_index, const float *p_coeffs, int p_count);
     bool _clear_runtime_modifications_locked();
     void _clear_brush_strokes_locked();
@@ -639,6 +642,8 @@ public:
 
     /** @brief Returns the number of Gaussians in this resource. */
     int get_count() const { return gaussians.size(); }
+
+    uint64_t get_content_revision() const { return content_revision.load(std::memory_order_relaxed); }
 
     /** @brief Returns the axis-aligned bounding box of all Gaussians. */
     AABB get_aabb() const;

--- a/modules/gaussian_splatting/core/gaussian_data_animation.cpp
+++ b/modules/gaussian_splatting/core/gaussian_data_animation.cpp
@@ -155,6 +155,10 @@ void GaussianData::apply_animation_at_time(float p_time) {
             gaussians[i].opacity = animated_opacities_cache[i];
         }
     }
+
+    if (animate_positions || animate_colors || animate_opacities) {
+        _bump_content_revision();
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/gaussian_splatting/core/gaussian_data_edits.cpp
+++ b/modules/gaussian_splatting/core/gaussian_data_edits.cpp
@@ -222,6 +222,7 @@ void GaussianData::commit_runtime_changes() {
                 MutexLock anim_lock(animation_cache_mutex);
                 animation_cache_dirty = true;
             }
+            _bump_content_revision();
         }
     }
 

--- a/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.cpp
@@ -999,30 +999,6 @@ Dictionary RenderDiagnosticsOrchestrator::build_render_stats() const {
 			}
 		}
 	}
-	if (sorted_preview.is_empty() && sorting_pipeline) {
-		const uint32_t sorted_count = sorting_state.sorted_splat_count;
-		const int preview_count = MIN((int)sorted_count, 32);
-		if (preview_count > 0) {
-			RID sort_indices_buffer = sorting_pipeline->get_sort_indices_buffer();
-			RenderingDevice *fallback_device = rendering_device;
-			RenderingDevice *owner = (renderer->*runtime_ports.resolve_resource_owner)(sort_indices_buffer, fallback_device);
-			if (!owner) {
-				owner = fallback_device;
-			}
-			if (owner && sort_indices_buffer.is_valid()) {
-				Vector<uint8_t> preview_bytes = owner->buffer_get_data(sort_indices_buffer, 0,
-						uint32_t(preview_count) * uint32_t(sizeof(uint32_t)));
-				const int expected_bytes = preview_count * int(sizeof(uint32_t));
-				if (preview_bytes.size() >= expected_bytes) {
-					sorted_preview.resize(preview_count);
-					const uint32_t *preview_indices = reinterpret_cast<const uint32_t *>(preview_bytes.ptr());
-					for (int i = 0; i < preview_count; i++) {
-						sorted_preview.set(i, int(preview_indices[i]));
-					}
-				}
-			}
-		}
-	}
 	stats["sorted_indices_preview"] = sorted_preview;
 
 	// GPU sorter state and metrics

--- a/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
+++ b/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
@@ -247,6 +247,9 @@ bool publish(GaussianSplatRenderer *p_renderer, bool p_allow_primary_fallback_in
 	{
 		const GaussianSplatRenderer::ResourceState &resource_state = p_renderer->get_resource_state();
 		const GaussianRenderPipeline::InstancePipelineBuffers &published_buffers = p_renderer->get_instance_pipeline_buffers();
+		auto owner_ok = [&](const RID &p_rid) {
+			return !p_rid.is_valid() || p_renderer->get_resource_owner(p_rid, rd) == rd;
+		};
 		if (p_renderer->get_instance_backend_policy() == GaussianRenderPipeline::InstanceBackendPolicy::RESIDENT &&
 				p_renderer->has_instance_pipeline_buffers() &&
 				p_renderer->has_instance_asset_remap() &&
@@ -255,7 +258,13 @@ bool publish(GaussianSplatRenderer *p_renderer, bool p_allow_primary_fallback_in
 				GaussianSplatting::InstancePipelineContract::has_atlas_buffers(published_buffers) &&
 				GaussianSplatting::InstancePipelineContract::has_cull_buffers(published_buffers) &&
 				GaussianSplatting::InstancePipelineContract::has_sort_buffers(published_buffers) &&
-				GaussianSplatting::InstancePipelineContract::has_raster_buffers(published_buffers)) {
+				GaussianSplatting::InstancePipelineContract::has_raster_buffers(published_buffers) &&
+				owner_ok(resource_state.instance_visible_chunk_buffer) &&
+				owner_ok(resource_state.instance_splat_ref_buffer) &&
+				owner_ok(resource_state.instance_counter_buffer) &&
+				owner_ok(resource_state.instance_chunk_dispatch_buffer) &&
+				owner_ok(resource_state.instance_indirect_count_buffer) &&
+				owner_ok(resource_state.instance_count_buffer)) {
 			return true;
 		}
 	}

--- a/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
+++ b/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
@@ -226,6 +226,38 @@ bool publish(GaussianSplatRenderer *p_renderer, bool p_allow_primary_fallback_in
 		assets.push_back(asset);
 	}
 
+	uint64_t source_generation = 0x6a09e667f3bcc909ULL;
+	source_generation = _mix_generation(source_generation, has_primary_data ? uint64_t(primary_data->get_instance_id()) : 0ULL);
+	const Ref<GPUCuller> &gpu_culler = p_renderer->get_subsystem_state().gpu_culler;
+	source_generation = _mix_generation(source_generation,
+			gpu_culler.is_valid() ? gpu_culler->get_state().static_chunks_revision : 0ULL);
+	if (director != nullptr) {
+		source_generation = _mix_generation(source_generation, director->get_instance_generation_for_renderer(p_renderer));
+	}
+	source_generation = _mix_generation(source_generation, p_renderer->is_shadow_instance_filter_enabled() ? 1ULL : 0ULL);
+	source_generation = _mix_generation(source_generation, p_allow_primary_fallback_instance ? 1ULL : 0ULL);
+	source_generation = _mix_generation(source_generation, uint64_t(p_renderer->get_performance_settings().max_splats));
+	for (const ResidentAssetDescriptor &asset : assets) {
+		source_generation = _mix_generation(source_generation, asset.submission_asset_id);
+		source_generation = _mix_generation(source_generation, asset.data.is_valid() ? uint64_t(asset.data->get_instance_id()) : 0ULL);
+	}
+
+	{
+		const GaussianSplatRenderer::ResourceState &resource_state = p_renderer->get_resource_state();
+		const GaussianRenderPipeline::InstancePipelineBuffers &published_buffers = p_renderer->get_instance_pipeline_buffers();
+		if (p_renderer->get_instance_backend_policy() == GaussianRenderPipeline::InstanceBackendPolicy::RESIDENT &&
+				p_renderer->has_instance_pipeline_buffers() &&
+				p_renderer->has_instance_asset_remap() &&
+				resource_state.instance_pipeline_contract_generation == source_generation &&
+				resource_state.instance_pipeline_upload_generation == source_generation &&
+				GaussianSplatting::InstancePipelineContract::has_atlas_buffers(published_buffers) &&
+				GaussianSplatting::InstancePipelineContract::has_cull_buffers(published_buffers) &&
+				GaussianSplatting::InstancePipelineContract::has_sort_buffers(published_buffers) &&
+				GaussianSplatting::InstancePipelineContract::has_raster_buffers(published_buffers)) {
+			return true;
+		}
+	}
+
 	LocalVector<InstanceDataGPU> instances;
 	if (director != nullptr) {
 		director->build_instance_buffer_for_renderer(p_renderer, instances,
@@ -287,18 +319,10 @@ bool publish(GaussianSplatRenderer *p_renderer, bool p_allow_primary_fallback_in
 
 	uint32_t max_chunk_count_per_asset = 0;
 	uint32_t max_chunk_splats = 0;
-	uint64_t source_generation = 0x6a09e667f3bcc909ULL;
-	source_generation = _mix_generation(source_generation, has_primary_data ? uint64_t(primary_data->get_instance_id()) : 0ULL);
-	source_generation = _mix_generation(source_generation, uint64_t(p_renderer->get_static_chunks().size()));
-	if (director != nullptr) {
-		source_generation = _mix_generation(source_generation, director->get_instance_generation_for_renderer(p_renderer));
-	}
 
 	for (uint32_t asset_index = 0; asset_index < assets.size(); asset_index++) {
 		const ResidentAssetDescriptor &asset = assets[asset_index];
 		asset_meta_cpu.write[asset.dense_asset_id] = AssetMetaGPU();
-		source_generation = _mix_generation(source_generation, asset.submission_asset_id);
-		source_generation = _mix_generation(source_generation, asset.data.is_valid() ? uint64_t(asset.data->get_instance_id()) : 0ULL);
 
 		if (asset.data.is_null() || asset.data->get_count() <= 0) {
 			continue;

--- a/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
+++ b/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
@@ -228,6 +228,7 @@ bool publish(GaussianSplatRenderer *p_renderer, bool p_allow_primary_fallback_in
 
 	uint64_t source_generation = 0x6a09e667f3bcc909ULL;
 	source_generation = _mix_generation(source_generation, has_primary_data ? uint64_t(primary_data->get_instance_id()) : 0ULL);
+	source_generation = _mix_generation(source_generation, has_primary_data ? primary_data->get_content_revision() : 0ULL);
 	const Ref<GPUCuller> &gpu_culler = p_renderer->get_subsystem_state().gpu_culler;
 	source_generation = _mix_generation(source_generation,
 			gpu_culler.is_valid() ? gpu_culler->get_state().static_chunks_revision : 0ULL);
@@ -240,6 +241,7 @@ bool publish(GaussianSplatRenderer *p_renderer, bool p_allow_primary_fallback_in
 	for (const ResidentAssetDescriptor &asset : assets) {
 		source_generation = _mix_generation(source_generation, asset.submission_asset_id);
 		source_generation = _mix_generation(source_generation, asset.data.is_valid() ? uint64_t(asset.data->get_instance_id()) : 0ULL);
+		source_generation = _mix_generation(source_generation, asset.data.is_valid() ? asset.data->get_content_revision() : 0ULL);
 	}
 
 	{

--- a/modules/gaussian_splatting/shaders/includes/tile_raster_common.glsl
+++ b/modules/gaussian_splatting/shaders/includes/tile_raster_common.glsl
@@ -37,6 +37,7 @@ layout(set = 0, binding = 15, std430) readonly buffer InstanceIndirectDispatch {
 // For R8G8B8A8_UNORM (8-bit per channel), 1 LSB = 1/255
 // Use slightly more than 1 LSB for effective banding reduction
 const float GS_DITHER_AMPLITUDE = 1.0 / 255.0;
+const float GS_RASTER_ALPHA_REJECT_Q = 18.41;
 
 // Simple hash-based noise for dithering (spatially varying)
 // Uses fragment position to generate pseudo-random value in [-0.5, 0.5]
@@ -154,15 +155,6 @@ bool gs_rasterize_splat_batch(
             continue;
         }
 
-        uint splat_ref_idx = sorted_indices.indices[sorted_idx];
-        if (splat_ref_idx >= gs_get_visible_gaussian_count()) {
-            continue;
-        }
-        uint gaussian_idx = splat_ref_buffer.splat_refs[splat_ref_idx].atlas_index;
-        if (gaussian_idx >= params.total_gaussians) {
-            continue;
-        }
-
 #ifdef GS_TILE_RASTER_SHARED_PAYLOAD
         ProjectedGaussian payload = gs_shared_projected_gaussians[i];
 #else
@@ -184,10 +176,16 @@ bool gs_rasterize_splat_batch(
         if (base_opacity <= 0.0) {
             continue;
         }
+        if (base_opacity * lod_blend <= 1e-4) {
+            continue;
+        }
 
         vec2 diff = pixel_center - screen_px;
         float quadratic = conic.x * diff.x * diff.x + 2.0 * conic.y * diff.x * diff.y + conic.z * diff.y * diff.y;
         quadratic = max(quadratic, 0.0);
+        if (quadratic > GS_RASTER_ALPHA_REJECT_Q) {
+            continue;
+        }
         float weight = gs_exp_fast(-0.5 * quadratic);
         if (weight <= 0.0) {
             continue;
@@ -350,25 +348,6 @@ void gs_rasterize_pixel(vec2 frag_coord, uint range_start, uint splat_count, uin
             continue;
         }
 
-        uint splat_ref_idx = sorted_indices.indices[sorted_idx];
-        if (splat_ref_idx >= gs_get_visible_gaussian_count()) {
-#ifdef GS_COLLECT_RASTER_STATS
-            if (sample_raster_stats) {
-                local_reject_gaussian++;
-            }
-#endif
-            continue;
-        }
-        uint gaussian_idx = splat_ref_buffer.splat_refs[splat_ref_idx].atlas_index;
-        if (gaussian_idx >= params.total_gaussians) {
-#ifdef GS_COLLECT_RASTER_STATS
-            if (sample_raster_stats) {
-                local_reject_gaussian++;
-            }
-#endif
-            continue;
-        }
-
         ProjectedGaussian payload = gs_read_projected_gaussian(i, sorted_idx);
 
         // Unpack the 24-byte packed format
@@ -415,6 +394,9 @@ void gs_rasterize_pixel(vec2 frag_coord, uint range_start, uint splat_count, uin
             }
             continue;
         }
+        if (base_opacity * lod_blend <= 1e-4) {
+            continue;
+        }
 
         // PERF-8 (#679): NaN/Inf validation moved to tile_binning.glsl projection stage
         // This eliminates per-pixel * per-splat validation overhead.
@@ -436,6 +418,9 @@ void gs_rasterize_pixel(vec2 frag_coord, uint range_start, uint splat_count, uin
         float dy = diff.y;
         float quadratic = conic.x * dx * dx + 2.0 * conic.y * dx * dy + conic.z * dy * dy;
         quadratic = max(quadratic, 0.0);
+        if (quadratic > GS_RASTER_ALPHA_REJECT_Q) {
+            continue;
+        }
 
         float weight = gs_exp_fast(-0.5 * quadratic);
         // PERF-8 (#679): Simplified weight check - with conic validated upstream and


### PR DESCRIPTION
## Summary

Stack of four perf fixes and one followup-doc commit targeting the resident render path and the tile-raster inner loop on direct-node Gaussian Splat scenes. Measured on `dream_memory.tscn` (≈44 PLY assets, 9k–400k visible splats), median FPS rose from **65.8 → 71** uncapped (with peaks to 87), and the original post-refactor stuttery baseline of **43.5 median** is recovered and surpassed.

- `perf: drop per-frame sync readback for sorted_indices_preview` — `build_render_stats()` did a synchronous `buffer_get_data()` on `sort_indices_buffer` every frame for a diagnostic-only preview. Removed; preview now only populates from already-available CPU culler data.
- `perf: skip resident instance contract republish when content unchanged` — the resident publish path rebuilt the full instance contract every frame for static scenes. Added an early-out gated on a `source_generation` hash covering primary data id, `static_chunks_revision`, director instance generation, shadow filter, fallback flag, `max_splats`, and per-asset ids. Skip only when the cached contract and all published buffers remain valid.
- `perf: tighten raster inner loop (drop redundant chain, add support reject)` — two compounding shader changes in `tile_raster_common.glsl`:
  - Drop the per-pixel `sorted_indices → splat_ref_buffer → atlas_index` chain — the bounds check it fed is structurally redundant (`tile_binning.glsl:616-626` already validates before payload write).
  - Add two cheap rejects before `gs_exp_fast()`: `base_opacity * lod_blend <= 1e-4` and `quadratic > 18.41` (derived from the 0.99 peak-alpha clamp; guarantees `alpha < 1e-4` below threshold).
- `fix: include GaussianData content revision in resident cache key` — addresses a review concern that in-place GaussianData mutations preserving object identity could leave the resident contract stale. Adds a `content_revision` counter bumped by every in-place mutator and mixes it into the cache key.
- `docs: add timestamp monitor investigation followup` — captures the state of the broken `gpu_time_raster_ms` monitor (tracked for a separate PR; `resolve_gpu_timestamps_async` is called but `get_captured_timestamps_count()` returns 0 every frame due to at least one more in-frame flush we haven't identified).

## Test plan

- [x] Build clean on Windows MSVC dev editor (`scons platform=windows target=editor dev_build=yes ...`)
- [x] Dream scene renders correctly — visible splat count tracks camera (9k–411k range), sort/cull timings stable, no Vulkan errors
- [x] Post-fix FPS benchmark on `dream_memory.tscn` (30 samples, vsync off): min=26, median=71, mean=66, max=87 vs. pre-fix median=65.8
- [x] Code review (Codex + Claude Explore, independent static analysis): both APPROVE; one finding (in-place GaussianData mutation) addressed in commit 5
- [ ] Human visual pass for shader artifacts on a known-good scene (support-threshold fringing, index-validation correctness) — **recommended before merge**
- [ ] Runtime verification that resident cache early-out correctly invalidates on asset hot-reload and in-place data mutation
- [ ] Broader scene coverage — dream_memory is splat-heavy but only 170k median visible; shader wins should compound on scenes with 500k+ sustained visible

## Known followup (not in this PR)

`gpu_time_raster_ms` and other tile-renderer-derived monitors still read 0 on direct-node scenes. See `docs/reports/timestamp_monitor_investigation.md` for what's been traced. Fixing it unlocks further targeted optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)