### PR TITLE
perf: prune marginal overlaps from hotspot tiles

### DIFF
--- a/modules/gaussian_splatting/interfaces/rasterizer_interfaces.h
+++ b/modules/gaussian_splatting/interfaces/rasterizer_interfaces.h
@@ -59,6 +59,17 @@ struct RasterParams {
     bool lod_blend_enabled = true;
     float lod_blend_factor = 1.0f;
     float lod_blend_distance = 5.0f;
+    // Hotspot-aware pre-raster cull (shared by COUNT and EMIT via tile_counts ping-pong).
+    // Prunes marginal (gaussian, tile) pairs from tiles whose previous-frame count
+    // exceeded hotspot_pressure_threshold. Conservative defaults: the per-tile gate
+    // is no-op unless last-frame tile count >4096 (normal scenes stay well below),
+    // and within a hot tile only well-sub-pixel minor-axis splats
+    // (raw_min_radius_px < 0.7) are pruned. The 0.7 floor was chosen after the
+    // initial 1.0 default pruned some contrib%-positive splats on the corridor
+    // proof; 0.7 keeps the bulk of the pruning benefit while preserving
+    // contributors with near-pixel-wide minor axes. Set either to 0 to disable.
+    uint32_t hotspot_pressure_threshold = 4096;
+    float hotspot_min_radius_px = 0.7f;
 
     // Compute raster selection (defaults to global config).
     GaussianSplatting::ComputeRasterPolicy compute_raster_policy = GaussianSplatting::ComputeRasterPolicy::Default;

--- a/modules/gaussian_splatting/interfaces/tile_rasterizer.cpp
+++ b/modules/gaussian_splatting/interfaces/tile_rasterizer.cpp
@@ -283,6 +283,8 @@ RasterResult TileRasterizer::render(const RasterParams &p_params) {
     render_params.lod_blend_enabled = p_params.lod_blend_enabled;
     render_params.lod_blend_factor = p_params.lod_blend_factor;
     render_params.lod_blend_distance = p_params.lod_blend_distance;
+    render_params.hotspot_pressure_threshold = p_params.hotspot_pressure_threshold;
+    render_params.hotspot_min_radius_px = p_params.hotspot_min_radius_px;
     render_params.frame_serial = p_params.frame_serial;
     // Instance rotation inverse for SH view direction correction
     render_params.instance_rotation_inverse = p_params.instance_rotation_inverse;

--- a/modules/gaussian_splatting/renderer/gaussian_gpu_layout.h
+++ b/modules/gaussian_splatting/renderer/gaussian_gpu_layout.h
@@ -7,7 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 
-static constexpr uint32_t GS_RENDER_PARAMS_LAYOUT_VERSION = 16; // Keep in sync with shaders/includes/gs_render_params.glsl
+static constexpr uint32_t GS_RENDER_PARAMS_LAYOUT_VERSION = 17; // Keep in sync with shaders/includes/gs_render_params.glsl
 static constexpr uint32_t GS_MAX_ASSET_LODS = 8;
 static constexpr uint32_t GS_SH_METADATA_FIRST_ORDER_MASK = 0x000000FFu;
 static constexpr uint32_t GS_SH_METADATA_HIGH_ORDER_MASK = 0x0000FF00u;
@@ -450,9 +450,16 @@ struct alignas(16) TileRenderParamsGPU {
     // effector_config: x=enabled (0/1), y=strength (meters), z=falloff exponent, w=reserved
     float effector_sphere[4];
     float effector_config[4];
+    // Hotspot-aware pre-raster cull (deterministic, shared by COUNT and EMIT):
+    // x = hotspot_pressure_threshold (absolute previous-frame tile count above which
+    //     the per-tile prune fires; 0 disables the cull entirely)
+    // y = hotspot_min_radius_px (raw minor-axis screen radius threshold; splats with
+    //     raw_min_radius_px below this are pruned from hot tiles)
+    // z,w = reserved
+    float hotspot_cull_config[4];
 };
 
-static_assert(sizeof(TileRenderParamsGPU) == 720, "TileRenderParamsGPU must match RenderParams std140 layout (720 bytes)");
+static_assert(sizeof(TileRenderParamsGPU) == 736, "TileRenderParamsGPU must match RenderParams std140 layout (736 bytes)");
 static_assert(alignof(TileRenderParamsGPU) == 16, "TileRenderParamsGPU must be 16-byte aligned");
 static_assert(offsetof(TileRenderParamsGPU, view_matrix) == 0, "TileRenderParamsGPU.view_matrix offset mismatch");
 static_assert(offsetof(TileRenderParamsGPU, inv_view_matrix) == 64, "TileRenderParamsGPU.inv_view_matrix offset mismatch");
@@ -499,6 +506,7 @@ static_assert(offsetof(TileRenderParamsGPU, wind_dir_strength) == 656, "TileRend
 static_assert(offsetof(TileRenderParamsGPU, wind_time_config) == 672, "TileRenderParamsGPU.wind_time_config offset mismatch");
 static_assert(offsetof(TileRenderParamsGPU, effector_sphere) == 688, "TileRenderParamsGPU.effector_sphere offset mismatch");
 static_assert(offsetof(TileRenderParamsGPU, effector_config) == 704, "TileRenderParamsGPU.effector_config offset mismatch");
+static_assert(offsetof(TileRenderParamsGPU, hotspot_cull_config) == 720, "TileRenderParamsGPU.hotspot_cull_config offset mismatch");
 
 struct alignas(16) FrustumCullParamsGPU {
     static constexpr uint32_t kFrustumPlaneCount = 6;

--- a/modules/gaussian_splatting/renderer/tile_render_binning.cpp
+++ b/modules/gaussian_splatting/renderer/tile_render_binning.cpp
@@ -341,6 +341,15 @@ RID TileRenderer::TileBinningStage::acquire_binning_buffer_uniform_set(Rendering
 		counts_uniform.append_id(owner.global_sort_resources.get_tile_counts_buffer());
 		uniforms.push_back(counts_uniform);
 
+		// Previous-frame tile counts (ping-pong pair slot). Used by the
+		// hotspot-aware pre-raster cull in COUNT and EMIT to prune marginal
+		// splats from tiles that were hot on the prior frame.
+		RD::Uniform prev_counts_uniform;
+		prev_counts_uniform.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+		prev_counts_uniform.binding = 19;
+		prev_counts_uniform.append_id(owner.global_sort_resources.get_previous_tile_counts_buffer());
+		uniforms.push_back(prev_counts_uniform);
+
 			RD::Uniform projection_uniform;
 			projection_uniform.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			projection_uniform.binding = 7;
@@ -531,6 +540,15 @@ RID TileRenderer::TileBinningStage::acquire_binning_count_uniform_set(RenderingD
 	counts_uniform.binding = 5;
 	counts_uniform.append_id(owner.global_sort_resources.get_tile_counts_buffer());
 	uniforms.push_back(counts_uniform);
+
+	// Previous-frame tile counts (ping-pong pair slot). Shared with the EMIT
+	// uniform set so the hotspot-aware pre-raster cull makes identical
+	// decisions in both passes.
+	RD::Uniform prev_counts_uniform;
+	prev_counts_uniform.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+	prev_counts_uniform.binding = 19;
+	prev_counts_uniform.append_id(owner.global_sort_resources.get_previous_tile_counts_buffer());
+	uniforms.push_back(prev_counts_uniform);
 
 	RD::Uniform debug_uniform;
 	debug_uniform.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;

--- a/modules/gaussian_splatting/renderer/tile_render_resources.cpp
+++ b/modules/gaussian_splatting/renderer/tile_render_resources.cpp
@@ -1348,6 +1348,17 @@ void TileGlobalSortResources::ensure_resources(uint32_t p_visible_count) {
 				device->set_resource_name(wg_offsets_buffer, "GS_TileRenderer_WorkgroupOffsetsBuffer");
 			}
 
+			// Zero-initialize both ping-pong tile-count buffers so that the
+			// "previous" buffer read by hotspot-aware pruning returns 0 (no
+			// pressure) on the first frame and after reallocation, instead of
+			// uninitialized data that could trigger spurious pruning.
+			if (tile_counts_buffers[0].is_valid()) {
+				device->buffer_clear(tile_counts_buffers[0], 0, counts_bytes);
+			}
+			if (tile_counts_buffers[1].is_valid()) {
+				device->buffer_clear(tile_counts_buffers[1], 0, counts_bytes);
+			}
+
 			tile_buffer_tiles = owner.grid_state.total_tiles;
 			tile_counts_bytes = counts_bytes;
 			tile_counts_index = 0;

--- a/modules/gaussian_splatting/renderer/tile_render_resources.h
+++ b/modules/gaussian_splatting/renderer/tile_render_resources.h
@@ -179,6 +179,14 @@ struct TileGlobalSortResources {
 		return tile_counts_buffers[tile_counts_index];
 	}
 
+	// Returns the OTHER slot of the ping-pong pair, which holds the previous
+	// frame's per-tile count (post-EMIT cursor == per-tile overlap count).
+	// Readers must tolerate an invalid/zeroed buffer on the very first frame
+	// and when the array has been reallocated this frame.
+	RID get_previous_tile_counts_buffer() const {
+		return tile_counts_buffers[tile_counts_index ^ 1u];
+	}
+
 	void advance_tile_counts_buffer();
 	void mark_tile_counts_dirty();
 	bool ensure_tile_counts_ready(RenderingDevice *p_device);

--- a/modules/gaussian_splatting/renderer/tile_render_stages.cpp
+++ b/modules/gaussian_splatting/renderer/tile_render_stages.cpp
@@ -347,6 +347,10 @@ TileRenderParamsGPU TileRenderer::TileRenderParamsBuilder::build_params(const Re
 	params.effector_config[1] = p_params.sphere_effector_strength;
 	params.effector_config[2] = MAX(0.001f, p_params.sphere_effector_falloff);
 	params.effector_config[3] = MAX(0.1f, p_params.sphere_effector_frequency);
+	params.hotspot_cull_config[0] = float(p_params.hotspot_pressure_threshold);
+	params.hotspot_cull_config[1] = MAX(0.0f, p_params.hotspot_min_radius_px);
+	params.hotspot_cull_config[2] = 0.0f;
+	params.hotspot_cull_config[3] = 0.0f;
 
 	return params;
 }

--- a/modules/gaussian_splatting/renderer/tile_render_types.h
+++ b/modules/gaussian_splatting/renderer/tile_render_types.h
@@ -361,6 +361,11 @@ struct TileRenderParams {
 	bool lod_blend_enabled = true;
 	float lod_blend_factor = 1.0f;
 	float lod_blend_distance = 5.0f;
+	// Hotspot-aware pre-raster cull (shared by COUNT and EMIT). Defaults match
+	// RasterParams so a tile needs >4096 prior records and the candidate splat
+	// needs raw_min_radius_px<0.7 to be pruned. Set either to 0 to disable.
+	uint32_t hotspot_pressure_threshold = 4096;
+	float hotspot_min_radius_px = 0.7f;
 	bool wind_enabled = false;
 	Vector3 wind_direction = Vector3(1.0f, 0.0f, 0.0f);
 	float wind_strength = 0.0f;

--- a/modules/gaussian_splatting/shaders/includes/gs_culling_utils.glsl
+++ b/modules/gaussian_splatting/shaders/includes/gs_culling_utils.glsl
@@ -46,6 +46,37 @@ bool gs_should_distance_cull(uint p_stable_splat_key, float world_distance) {
     return rand < cull_probability;
 }
 
+// Hotspot-aware pre-raster cull. Deterministic per (splat, tile) so COUNT and
+// EMIT reach identical decisions without a shared visibility buffer.
+//
+// The predicate is:
+//   enabled  AND  prev_tile_count > pressure_threshold  AND  raw_min_radius_px < min_radius_threshold
+//
+// Rationale:
+// - prev_tile_count is last frame's overlap count for this tile. A tile that
+//   was hot last frame is very likely hot this frame (camera motion between
+//   frames is bounded), so the prior-frame signal is a reasonable proxy for
+//   this-frame pressure without requiring a second GPU pass.
+// - raw_min_radius_px already folds opacity-aware sigma and the subpixel
+//   visibility threshold; splats below a floor here are the same marginal
+//   contributors the hotspot raster probe showed producing ~1-14% contrib%.
+//
+// Both thresholds are zero by default => no-op. Callers can rely on this
+// function returning false when the feature is disabled.
+bool gs_should_hotspot_prune_overlap(
+        uint prev_tile_count,
+        float raw_min_radius_px,
+        uint pressure_threshold,
+        float min_radius_threshold) {
+    if (pressure_threshold == 0u || min_radius_threshold <= 0.0) {
+        return false;
+    }
+    if (prev_tile_count <= pressure_threshold) {
+        return false;
+    }
+    return raw_min_radius_px < min_radius_threshold;
+}
+
 // Decide whether to keep an overlap record for diagnostics or coverage sampling.
 bool gs_keep_overlap_record(uint gaussian_idx, uint instance_id, uint tile_idx) {
     float keep_ratio = gs_get_overlap_keep_ratio();

--- a/modules/gaussian_splatting/shaders/includes/gs_render_params.glsl
+++ b/modules/gaussian_splatting/shaders/includes/gs_render_params.glsl
@@ -1,6 +1,6 @@
 #ifndef GS_RENDER_PARAMS_GLSL
 #define GS_RENDER_PARAMS_GLSL
-#define GS_RENDER_PARAMS_LAYOUT_VERSION 16 // Keep in sync with gaussian_gpu_layout.h
+#define GS_RENDER_PARAMS_LAYOUT_VERSION 17 // Keep in sync with gaussian_gpu_layout.h
 
 // Instance pipeline only: uses SplatRef indirection and asset-local quantization.
 
@@ -97,6 +97,11 @@ layout(set = 1, binding = 0, std140) uniform RenderParams {
     // effector_config: x = enabled (0/1), y = displacement strength (meters), z = falloff exponent, w = reserved
     vec4 effector_sphere;
     vec4 effector_config;
+    // Hotspot-aware pre-raster cull (deterministic, shared by COUNT and EMIT):
+    // x = hotspot_pressure_threshold (absolute previous-frame tile count; 0 disables)
+    // y = hotspot_min_radius_px (raw minor-axis radius threshold for pruning)
+    // z,w = reserved
+    vec4 hotspot_cull_config;
 } params;
 
 // Helper to get current SH band level from params
@@ -160,6 +165,22 @@ bool gs_is_wind_enabled() {
 // Return whether the sphere effector is enabled.
 bool gs_is_sphere_effector_enabled() {
     return params.effector_config.x > 0.5 && params.effector_sphere.w > 0.0;
+}
+
+// Hotspot-aware pre-raster cull accessors.
+// Absolute previous-frame tile count above which the prune fires. 0 disables.
+uint gs_get_hotspot_pressure_threshold() {
+    return uint(max(params.hotspot_cull_config.x, 0.0));
+}
+
+// Raw minor-axis screen radius threshold for pruning splats from hot tiles.
+float gs_get_hotspot_min_radius_px() {
+    return max(params.hotspot_cull_config.y, 0.0);
+}
+
+// Whether the hotspot-pressure cull is enabled for this frame.
+bool gs_is_hotspot_cull_enabled() {
+    return gs_get_hotspot_pressure_threshold() > 0u && gs_get_hotspot_min_radius_px() > 0.0;
 }
 
 #endif // GS_RENDER_PARAMS_GLSL

--- a/modules/gaussian_splatting/shaders/tile_binning.glsl
+++ b/modules/gaussian_splatting/shaders/tile_binning.glsl
@@ -157,6 +157,12 @@ layout(set = 0, binding = 5, std430) buffer TileCounts {
     uint counts[];
 } tile_counts;
 
+// Previous-frame tile counts (ping-pong pair slot). Populated by last frame's
+// EMIT cursor == this tile's overlap record count. Read-only for this frame.
+layout(set = 0, binding = 19, std430) readonly buffer PrevTileCounts {
+    uint counts[];
+} prev_tile_counts;
+
 #ifdef GS_TILE_GLOBAL_SORT_EMIT_PASS
 layout(set = 0, binding = 2, std430) buffer GlobalSortKeys {
 #if GS_SORT_KEY_BITS == 32
@@ -1017,12 +1023,19 @@ void main() {
 
 #ifdef GS_TILE_GLOBAL_SORT_COUNT_PASS
     // Pass 1: count overlaps per tile (no keys/values emitted).
+    uint hotspot_pressure_threshold = gs_get_hotspot_pressure_threshold();
+    float hotspot_min_radius = gs_get_hotspot_min_radius_px();
     for (int ty = min_tile_y; ty <= max_tile_y; ++ty) {
         for (int tx = min_tile_x; tx <= max_tile_x; ++tx) {
             if (!gs_tile_intersects_projected_ellipse(screen_pos, conic, ellipse_sigma2, tx, ty)) {
                 continue;
             }
             uint tile_idx = uint(ty) * uint(params.tile_count.x) + uint(tx);
+            uint prev_count = prev_tile_counts.counts[tile_idx];
+            if (gs_should_hotspot_prune_overlap(prev_count, raw_min_radius_px,
+                    hotspot_pressure_threshold, hotspot_min_radius)) {
+                continue;
+            }
             if (!gs_keep_overlap_record(gaussian_idx, splat_ref.instance_id, tile_idx)) {
                 continue;
             }
@@ -1211,6 +1224,8 @@ void main() {
 #ifdef GS_TILE_GLOBAL_SORT_EMIT_PASS
     projection_buffer.projected_gaussians[global_idx] = payload;
     uint emitted_overlap_count = 0u;
+    uint hotspot_pressure_threshold = gs_get_hotspot_pressure_threshold();
+    float hotspot_min_radius = gs_get_hotspot_min_radius_px();
 
     // Pass 2: emit one overlap record per covered tile into the global key/value arrays.
     for (int ty = min_tile_y; ty <= max_tile_y; ++ty) {
@@ -1219,6 +1234,11 @@ void main() {
                 continue;
             }
             uint tile_idx = uint(ty) * uint(params.tile_count.x) + uint(tx);
+            uint prev_count = prev_tile_counts.counts[tile_idx];
+            if (gs_should_hotspot_prune_overlap(prev_count, raw_min_radius_px,
+                    hotspot_pressure_threshold, hotspot_min_radius)) {
+                continue;
+            }
             if (!gs_keep_overlap_record(gaussian_idx, splat_ref.instance_id, tile_idx)) {
                 continue;
             }

--- a/modules/gaussian_splatting/tests/test_renderer_pipeline.h
+++ b/modules/gaussian_splatting/tests/test_renderer_pipeline.h
@@ -36,7 +36,7 @@
 
 namespace TestGaussianSplatting {
 
-static_assert(GS_RENDER_PARAMS_LAYOUT_VERSION == 16, "Render params layout version mismatch");
+static_assert(GS_RENDER_PARAMS_LAYOUT_VERSION == 17, "Render params layout version mismatch");
 
 static_assert(sizeof(InstanceDataGPU) == 96, "InstanceDataGPU size contract changed");
 static_assert(offsetof(InstanceDataGPU, lod) == 72, "InstanceDataGPU.lod offset contract changed");
@@ -52,7 +52,7 @@ static_assert(offsetof(PackedGaussian, sh) == 48, "PackedGaussian.sh offset cont
 static_assert(offsetof(PackedGaussian, sh_metadata) == 140, "PackedGaussian.sh_metadata offset contract changed");
 static_assert(sizeof(PackedGaussianF16) == 144, "PackedGaussianF16 size contract changed");
 static_assert(sizeof(PackedGaussianQuantized) == 80, "PackedGaussianQuantized size contract changed");
-static_assert(sizeof(TileRenderParamsGPU) == 720, "TileRenderParamsGPU size contract changed");
+static_assert(sizeof(TileRenderParamsGPU) == 736, "TileRenderParamsGPU size contract changed");
 static_assert(offsetof(TileRenderParamsGPU, viewport_size) == 256, "TileRenderParamsGPU.viewport_size offset contract changed");
 static_assert(offsetof(TileRenderParamsGPU, camera_position) == 320, "TileRenderParamsGPU.camera_position offset contract changed");
 static_assert(offsetof(TileRenderParamsGPU, lighting_mode) == 560, "TileRenderParamsGPU.lighting_mode offset contract changed");
@@ -339,7 +339,7 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] Instance cull failures without fallb
 }
 
 TEST_CASE("[GaussianSplatting] GPU layout contract invariants remain stable") {
-    CHECK(GS_RENDER_PARAMS_LAYOUT_VERSION == 16u);
+    CHECK(GS_RENDER_PARAMS_LAYOUT_VERSION == 17u);
     CHECK(sizeof(InstanceDataGPU) == size_t(96));
     CHECK(sizeof(AssetMetaGPU) == size_t(112));
     CHECK(sizeof(ChunkMetaGPU) == size_t(64));
@@ -347,7 +347,7 @@ TEST_CASE("[GaussianSplatting] GPU layout contract invariants remain stable") {
     CHECK(sizeof(PackedGaussian) == size_t(144));
     CHECK(sizeof(PackedGaussianF16) == size_t(144));
     CHECK(sizeof(PackedGaussianQuantized) == size_t(80));
-    CHECK(sizeof(TileRenderParamsGPU) == size_t(720));
+    CHECK(sizeof(TileRenderParamsGPU) == size_t(736));
 
     CHECK(offsetof(PackedGaussian, rotation) == size_t(32));
     CHECK(offsetof(PackedGaussian, sh) == size_t(48));


### PR DESCRIPTION
## Summary

Pre-raster overlap-pruning optimization for dense scenes. Skips `(splat, tile)` pairs in both COUNT and EMIT when last frame's per-tile pressure was high AND the splat's projected radius is below a threshold — cheap overlap records that would contribute little in a hot tile are dropped before they reach the raster loop.

- **Previous-frame tile-count SSBO ping-pong**: each frame's per-tile count buffer is retained and bound read-only to the next frame's binning dispatch.
- **Shared helper** `gs_should_hotspot_prune_overlap()` in `gs_culling_utils.glsl` keeps COUNT and EMIT in lockstep so the binning and overflow counters stay consistent.
- **Default threshold**: `0.7px`. Configurable via `hotspot_min_radius_px` in the render params.
- Applies to both fragment and compute raster paths through the shared binning stage.

Layout: `GS_RENDER_PARAMS_LAYOUT_VERSION` bumped to 17; `TileRenderParamsGPU` grew 720→736 bytes; test assertion updated.

## Provenance

Extracted from diagnostic work on `feat/streaming-tier2-refactor` (originally `ea6d1594ec` + `ff3d85986f`). The hotspot telemetry plumbing that accompanied those experiments is intentionally omitted — useful for perf investigation, but not needed in production. The diagnostic commits on that branch are not part of this PR.

## Test plan

- [x] Build clean (`scons platform=windows target=editor dev_build=yes ...`)
- [ ] Runtime verification — scene where tile pressure is known to be high (dense regions in the dream scene, open-world benchmark corridor) should show lower raster-stage cost with no visible quality change for marginal (sub-pixel) contributions
- [ ] Threshold tuning on a second scene — 0.7 px was tuned on one scene only; verify no visible fringing regression at camera angles where many splats project near the threshold
- [ ] Overflow-counter sanity — since pruning skips records before they're emitted, verify `overflow_splats_aggregated` / `tiles_with_overflow` reflect the new, correctly lower counts and that no test asserts on the old values

## Known limitations

- Uses the PREVIOUS frame's tile pressure, so a sudden camera cut can briefly misjudge hotspots for one frame. Acceptable for continuous playback; potentially visible on hard cuts.
- First frame after startup has no previous counts — the helper degrades to no-op, which is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)