### PR TITLE
fix: use %d format specifier in HUD integer fields

### DIFF
--- a/modules/gaussian_splatting/interfaces/debug_overlay_system.cpp
+++ b/modules/gaussian_splatting/interfaces/debug_overlay_system.cpp
@@ -553,7 +553,7 @@ void DebugOverlaySystem::rebuild_renderer_performance_hud_lines(const DebugOverl
                     String::num_uint64(raster_stats.compute_raster_frames),
                     String::num_uint64(raster_stats.fragment_raster_frames)));
             debug_state.hud_lines.push_back(vformat("Tile Size: %d (compute max 32)", subsystem_state.rasterizer->get_tile_size()));
-            debug_state.hud_lines.push_back(vformat("Overlap Records: %u / %u (effective %u)",
+            debug_state.hud_lines.push_back(vformat("Overlap Records: %d / %d (effective %d)",
                     raster_stats.overlap_records,
                     raster_stats.overlap_record_budget_configured,
                     raster_stats.overlap_record_budget_effective));
@@ -568,13 +568,13 @@ void DebugOverlaySystem::rebuild_renderer_performance_hud_lines(const DebugOverl
         }
         if (debug_state_view.last_stage_metrics_valid) {
             const auto &stage_metrics = debug_state_view.last_stage_metrics;
-            debug_state.hud_lines.push_back(vformat("Cull: %.2f ms (cand %u -> vis %u)",
+            debug_state.hud_lines.push_back(vformat("Cull: %.2f ms (cand %d -> vis %d)",
                     stage_metrics.cull.cull_time_ms, stage_metrics.cull.candidate_count, stage_metrics.cull.visible_count));
             if (stage_metrics.sort.did_sort) {
-                debug_state.hud_lines.push_back(vformat("Sort: %.2f ms (in %u -> %u)",
+                debug_state.hud_lines.push_back(vformat("Sort: %.2f ms (in %d -> %d)",
                         stage_metrics.sort.sort_time_ms, stage_metrics.sort.input_count, stage_metrics.sort.sorted_count));
             } else {
-                debug_state.hud_lines.push_back(vformat("Sort: skipped (in %u)", stage_metrics.sort.input_count));
+                debug_state.hud_lines.push_back(vformat("Sort: skipped (in %d)", stage_metrics.sort.input_count));
             }
             const char *raster_label = stage_metrics.raster.reused_cached_render
                     ? "cached"


### PR DESCRIPTION
## Summary

Godot's `vformat` / `String.sprintf` does not accept `%u`. Four HUD lines in `DebugOverlaySystem::rebuild_renderer_performance_hud_lines` used `%u` for overlap-record counts, cull candidate/visible counts, and sort input/output counts, producing format errors or garbage output instead of integer values.

Replace with `%d`, matching the rest of the HUD formatter. Values are `int`-typed upstream so signedness is not a concern at HUD display.

4 lines changed in `modules/gaussian_splatting/interfaces/debug_overlay_system.cpp`.

## Scope

Extracted from commit `52daca4851` on `fix/dc-encoding-propagation` as part of that branch's 4-PR salvage split. This is the **only** net-unique HUD-related work in that commit.

Explicitly **not** included from `52daca4851`:
- **DC decode** changes — already superseded on master by PR #215 (`fix: remove global DC decode overrides`)
- **Descriptor cache invalidation** — already on master in `tile_renderer.cpp`
- **Compositor default-policy flip** (`depth_test=false`, relaxed scene-depth policy) — a behavior change that deserves its own explicit PR with reviewer discussion, not a quick salvage

## Test plan

- [x] Build clean on Windows MSVC dev editor
- [ ] Enable performance HUD (`renderer.set_debug_show_performance_hud(true)`) and confirm the 4 lines render integer values correctly instead of error text/garbage

🤖 Generated with [Claude Code](https://claude.com/claude-code)