### PR TITLE
fix: restore resolve-mode lighting with weighted receiver depth

### DIFF
--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -1741,7 +1741,7 @@ Error RenderPipelineStages::RasterStage::render_tile_fallback(const Size2i &p_vi
 	render_params.shadow_receiver_bias_max = MAX(0.0f, shadow_receiver_bias_max);
 	render_params.enable_direct_lighting = true;
 	render_params.normal_mode = 0;
-	render_params.direct_lighting_mode = 1;
+	render_params.direct_lighting_mode = 0;
 	render_params.wind_enabled = wind_enabled;
 	render_params.wind_direction = wind_direction;
 	render_params.wind_strength = MAX(0.0f, wind_strength);

--- a/modules/gaussian_splatting/renderer/tile_render_types.h
+++ b/modules/gaussian_splatting/renderer/tile_render_types.h
@@ -343,7 +343,7 @@ struct TileRenderParams {
 	float shadow_receiver_bias_max = 0.0f;
 	bool enable_direct_lighting = true;
 	int normal_mode = 0;
-	int direct_lighting_mode = 1; // 0=resolve, 1=per-splat (binning), 2=both
+	int direct_lighting_mode = 0; // 0=resolve, 1=per-splat (binning), 2=both
 	float alpha_floor = 0.0f;
 	bool force_solid_coverage = false;
 	float cull_far_tolerance = 0.05f;

--- a/modules/gaussian_splatting/renderer/tile_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/tile_renderer.cpp
@@ -1233,7 +1233,7 @@ GaussianSplatting::TileRenderParams::TileRenderParams() {
 	shadow_receiver_bias_max = 0.0f;
 	enable_direct_lighting = true;
 	normal_mode = 0;
-	direct_lighting_mode = 1;
+	direct_lighting_mode = 0;
 	cull_far_tolerance = 0.05f;
 	tiny_splat_screen_radius = 0.3f;  // Drop subpixel splats to prevent tile overflow (#797)
 	max_conic_aspect = 10.0f;

--- a/modules/gaussian_splatting/shaders/includes/tile_raster_common.glsl
+++ b/modules/gaussian_splatting/shaders/includes/tile_raster_common.glsl
@@ -147,6 +147,7 @@ bool gs_rasterize_splat_batch(
         uint interactive_render_state,
         inout vec4 final_color,
         inout float final_depth,
+        inout float weighted_depth,
         inout vec3 final_normal,
         inout bool has_depth) {
     for (uint i = 0u; i < batch_size; ++i) {
@@ -224,6 +225,7 @@ bool gs_rasterize_splat_batch(
         final_color.rgb += base_color * blend_alpha;
         final_color.a = clamp(final_color.a + blend_alpha, 0.0, 1.0);
         final_normal += unpacked_normal * blend_alpha;
+        weighted_depth += linear_depth * blend_alpha;
         final_depth = has_depth ? min(final_depth, linear_depth) : linear_depth;
         has_depth = true;
 
@@ -299,6 +301,7 @@ void gs_rasterize_pixel(vec2 frag_coord, uint range_start, uint splat_count, uin
     vec4 final_color = vec4(0.0);
     vec3 final_normal = vec3(0.0);
     float final_depth = 1.0;
+    float weighted_depth = 0.0;
     bool has_depth = false;
 
     float highlight_strength = interactive_state.state_params.x;
@@ -504,6 +507,7 @@ void gs_rasterize_pixel(vec2 frag_coord, uint range_start, uint splat_count, uin
         final_color.rgb += base_color * blend_alpha;
         final_color.a = clamp(final_color.a + blend_alpha, 0.0, 1.0);
         final_normal += unpacked_normal * blend_alpha;
+        weighted_depth += linear_depth * blend_alpha;
 
         final_depth = has_depth ? min(final_depth, linear_depth) : linear_depth;
         has_depth = true;
@@ -640,7 +644,7 @@ void gs_rasterize_pixel(vec2 frag_coord, uint range_start, uint splat_count, uin
         return;
     }
 
-    // Dither alpha to soften 8-bit quantization on silhouettes.
+    float coverage_alpha = final_color.a;
     final_color.a = clamp(final_color.a + pixel_dither.r, 0.0, 1.0);
 
     // Optional solid-coverage mode: enforce a minimum alpha wherever splats contributed.
@@ -654,9 +658,18 @@ void gs_rasterize_pixel(vec2 frag_coord, uint range_start, uint splat_count, uin
     if (debug_tile_grid) {
         final_color.rgb = gs_apply_tile_grid(frag_coord, final_color.rgb, params.debug_overlay_opacity);
     }
+    vec3 output_normal = vec3(0.0);
+    float lighting_depth = depth_out;
+    if (coverage_alpha > 1e-6) {
+        vec3 normal_candidate = final_normal / coverage_alpha;
+        if (dot(normal_candidate, normal_candidate) > 1e-6) {
+            output_normal = normalize(normal_candidate);
+        }
+        lighting_depth = clamp(weighted_depth / coverage_alpha, 0.0, 1.0);
+    }
     out_color = clamp(final_color, vec4(0.0), vec4(1.0));
     out_depth = depth_out;
-    out_normal = vec4(final_normal, final_color.a);
+    out_normal = vec4(output_normal, lighting_depth);
 }
 
 #endif

--- a/modules/gaussian_splatting/shaders/tile_binning.glsl
+++ b/modules/gaussian_splatting/shaders/tile_binning.glsl
@@ -1132,13 +1132,14 @@ void main() {
         receiver_bias = min(receiver_bias, params.shadow_bias_config.z);
     }
 
+    uint lighting_mode = params.lighting_mode.x;
+    float sh_base_scale = (lighting_mode == 0u) ? 1.0 : params.lighting_config.y;
     // Per-splat direct lighting (Option A): add real-time lights before rasterization.
-    vec3 final_color = sh_color * params.lighting_config.y;
+    vec3 final_color = sh_color * sh_base_scale;
     float shadow_strength = clamp(params.shadow_strength.x, 0.0, 1.0);
     bool shadow_sampling_enabled = shadow_strength > 0.0;
     float sh_occlusion = 0.0;
     if (params.lighting_config.z > 0.5) {
-        uint lighting_mode = params.lighting_mode.x;
         if (lighting_mode == 1u || lighting_mode == 2u) {
             vec3 view_pos = view_pos_scene;
             vec3 view_dir = view_dir_scene;

--- a/modules/gaussian_splatting/shaders/tile_rasterizer_compute.glsl
+++ b/modules/gaussian_splatting/shaders/tile_rasterizer_compute.glsl
@@ -199,6 +199,7 @@ void main() {
     // Per-pixel state carried across batches
     vec4 final_color = vec4(0.0);
     float final_depth = 1.0;
+    float weighted_depth = 0.0;
     vec3 final_normal = vec3(0.0);
     bool has_depth = false;
     bool pixel_saturated = false;
@@ -238,7 +239,7 @@ void main() {
             pixel_saturated = gs_rasterize_splat_batch(
                     pixel_center, batch_size, lod_blend, pixel_dither,
                     highlight_strength, outline_width, render_state,
-                    final_color, final_depth, final_normal, has_depth);
+                    final_color, final_depth, weighted_depth, final_normal, has_depth);
             if (!pixel_saturated) {
                 atomicAnd(gs_shared_all_saturated, 0u);
             }
@@ -322,6 +323,7 @@ void main() {
         return;
     }
 
+    float coverage_alpha = final_color.a;
     final_color.a = clamp(final_color.a + pixel_dither.r, 0.0, 1.0);
     if (params.force_solid_coverage != 0u) {
         final_color.a = max(final_color.a, params.alpha_floor);
@@ -329,7 +331,16 @@ void main() {
     if (debug_tile_grid) {
         final_color.rgb = gs_apply_tile_grid(frag_coord, final_color.rgb, params.debug_overlay_opacity);
     }
+    vec3 output_normal = vec3(0.0);
+    float lighting_depth = depth_out;
+    if (coverage_alpha > 1e-6) {
+        vec3 normal_candidate = final_normal / coverage_alpha;
+        if (dot(normal_candidate, normal_candidate) > 1e-6) {
+            output_normal = normalize(normal_candidate);
+        }
+        lighting_depth = clamp(weighted_depth / coverage_alpha, 0.0, 1.0);
+    }
     imageStore(out_color_image, pixel, clamp(final_color, vec4(0.0), vec4(1.0)));
     imageStore(out_depth_image, pixel, vec4(depth_out, 0.0, 0.0, 0.0));
-    imageStore(out_normal_image, pixel, vec4(final_normal, final_color.a));
+    imageStore(out_normal_image, pixel, vec4(output_normal, lighting_depth));
 }

--- a/modules/gaussian_splatting/shaders/tile_resolve.glsl
+++ b/modules/gaussian_splatting/shaders/tile_resolve.glsl
@@ -171,6 +171,8 @@ void main() {
 
     vec4 color = sample_input_color(coord, uv);
     float depth = sanitize_linear_depth(sample_input_depth(coord, uv));
+    vec4 normal_sample = sample_input_normal(coord, uv);
+    float lighting_depth = sanitize_linear_depth(normal_sample.a > 0.0 ? normal_sample.a : depth);
 
     if (color.a > 0.0) {
         color.rgb /= color.a;
@@ -179,12 +181,12 @@ void main() {
     // Shadow debug overlay (debug_overlay_flags.x == 2).
     // Shows shadow factor per light type: R=dir shadow, G=omni shadow, B=spot shadow
     // Bright = lit (shadow=1), Dark = shadowed (shadow=0)
-    if (params.debug_overlay_flags.x > 1.5 && depth < 1.0 && color.a > 0.001) {
+    if (params.debug_overlay_flags.x > 1.5 && lighting_depth < 1.0 && color.a > 0.001) {
         bool gs_is_ortho = abs(params.projection_matrix[2][3]) < 0.5;
-        vec3 view_pos_gs = reconstruct_view_pos(params.inv_projection_matrix, uv, depth, params.near_plane, params.far_plane, gs_is_ortho);
+        vec3 view_pos_gs = reconstruct_view_pos(params.inv_projection_matrix, uv, lighting_depth, params.near_plane, params.far_plane, gs_is_ortho);
         vec3 view_pos = (scene_data_block.data.view_matrix * params.inv_view_matrix * vec4(view_pos_gs, 1.0)).xyz;
 
-        vec3 normal = sample_input_normal(coord, uv).xyz;
+        vec3 normal = normal_sample.rgb;
         if (length(normal) < 0.001) {
             normal = vec3(0.0, 0.0, 1.0);
         }
@@ -262,10 +264,10 @@ void main() {
     float sh_occlusion = 0.0;
 
     // Apply lighting to pixels with valid depth and non-zero alpha
-    if (params.lighting_config.z > 0.5 && resolve_direct && depth < 1.0 && color.a > 0.001) {
+    if (params.lighting_config.z > 0.5 && resolve_direct && lighting_depth < 1.0 && color.a > 0.001) {
         bool gs_is_ortho = abs(params.projection_matrix[2][3]) < 0.5;
         bool scene_is_ortho = abs(scene_data_block.data.projection_matrix[2][3]) < 0.5;
-        vec3 view_pos_gs = reconstruct_view_pos(params.inv_projection_matrix, uv, depth, params.near_plane, params.far_plane, gs_is_ortho);
+        vec3 view_pos_gs = reconstruct_view_pos(params.inv_projection_matrix, uv, lighting_depth, params.near_plane, params.far_plane, gs_is_ortho);
         // Convert GS view-space position to scene view-space so light positions match.
         vec4 world_pos = params.inv_view_matrix * vec4(view_pos_gs, 1.0);
         vec3 view_pos = (scene_data_block.data.view_matrix * world_pos).xyz;
@@ -294,7 +296,7 @@ void main() {
 
         // Debug: visualize view-space Z mismatch between GS projection and scene_data projection (F7 only).
         if (params.debug_overlay_flags.z > 0.5) {
-            vec3 view_pos_scene = reconstruct_view_pos(scene_data_block.data.inv_projection_matrix, uv, depth,
+            vec3 view_pos_scene = reconstruct_view_pos(scene_data_block.data.inv_projection_matrix, uv, lighting_depth,
                     params.near_plane, params.far_plane, scene_is_ortho);
             float diff = abs(view_pos_gs.z - view_pos_scene.z);
             float range = max(params.far_plane - params.near_plane, 0.01);
@@ -305,13 +307,9 @@ void main() {
             return;
         }
         vec3 view_dir = normalize(-view_pos);
-        vec4 normal_sample = sample_input_normal(coord, uv);
         vec3 normal = view_dir;
-        if (normal_sample.a > 1e-4) {
-            vec3 normal_candidate = normal_sample.rgb / max(normal_sample.a, 1e-6);
-            if (dot(normal_candidate, normal_candidate) > 1e-6) {
-                normal = normalize(normal_candidate);
-            }
+        if (dot(normal_sample.rgb, normal_sample.rgb) > 1e-6) {
+            normal = normalize(normal_sample.rgb);
         }
 
         hvec3 h_normal_base = hvec3(normal);
@@ -379,9 +377,7 @@ void main() {
         diffuse_light *= h_albedo;
         diffuse_light *= (half(1.0) - metallic);
         vec3 direct = vec3(diffuse_light + specular_light) * params.lighting_config.x;
-        // Scale lighting by alpha^2 for smooth edge falloff
-        float lighting_blend = color.a * color.a;
-        final_rgb += direct * lighting_blend;
+        final_rgb += direct * clamp(color.a, 0.0, 1.0);
 
     }
 


### PR DESCRIPTION
## Summary

Partial salvage from `fix/dc-encoding-propagation` — the minimal subset of the 5 resolve-mode lighting/shadow commits that still applies cleanly against the post-tier-2 architecture. 7 files changed, 45 insertions, 24 deletions.

### What's ported

- **Resolve mode as active lighting path** (from `cdd3e82c0e`). Per-splat SH is no longer double-scaled when resolve mode is active.
- **Weighted resolve receiver depth** (from `8675ee9fd2`). Raster now writes normalized blended normal plus coverage-weighted `lighting_depth` to an additional resolve input.
- **Lighting-depth-based shadow reconstruction** (from `a7bb3e7cff`). Resolve reconstructs lighting/shadow positions from `lighting_depth`; direct-light contribution is weighted by coverage alpha instead of α².

### Explicitly NOT ported from the source branch

The original branch had 5 commits and 17 files / 885 insertions. Dropped from this PR:

- **Ambient cubemap/radiance plumbing** (`8675ee9fd2`) — too invasive; ambient parity on resolve may need a separate focused PR.
- **Resolve-specific fixed-bias / zero-geo-normal shadow rewrite** (`a7bb3e7cff`) — needs broader shadow-bias retune to prove safe on current master.
- **World-up lighting proxy, uniform NdotL path, zero shadow normals, SH-occlusion removal** (`20e85220c2`) — the larger redesign the earlier triage flagged as "likely replay, not cherry-pick". Left for a future explicit redesign PR.
- **Color-grading changes** (`f5bb73d2e9`) — outside lighting/shadow scope.
- **Directional shadow cascade-validity guards** — covered by sibling PR #241 (`fix/shadow-cascade-blackout`); intentionally deferred to that PR to avoid collision.

### Manual review items for the reviewer

1. `tile_resolve.glsl:331` — resolve still uses the current blended normal + existing receiver-bias logic for shadow helpers. Is weighted depth alone enough, or does the old resolve-specific fixed-bias / zero-geo-normal path need to come back?
2. `tile_resolve.glsl:252` — radiance-cubemap ambient addition was NOT ported. Verify resolve ambient is close enough to per-splat ambient without it, or flag for follow-up.
3. Test with a scene that exercises resolve-mode direct lighting + shadows + blended normals to confirm no visual regressions vs per-splat.

## Test plan

- [x] Build clean on Windows MSVC dev editor
- [ ] Runtime: scene with directional light + Gaussian splats in a mix of SH bands — verify lighting is not double-scaled and no flat-shading regression
- [ ] Runtime: shadow reconstruction via weighted `lighting_depth` looks correct at splat edges
- [ ] Verify the two manual-review items above

## Risk

Medium. The port changes the active lighting path back to resolve mode. Individual hunks are small but the behavior change is meaningful. If any resolve-mode-specific scenes exist in your suite, they'll exercise the port; otherwise regressions may surface later in integration testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)