### PR TITLE
fix: per-node color grading independence

### DIFF
--- a/modules/gaussian_splatting/docs/GAUSSIAN_EDITOR_UX_REDESIGN_CHECKLIST.md
+++ b/modules/gaussian_splatting/docs/GAUSSIAN_EDITOR_UX_REDESIGN_CHECKLIST.md
@@ -53,7 +53,7 @@ The Gaussian bottom panel is no longer part of the normal editor flow.
 - [ ] ~~Added `GaussianSplatNode3D` instantiation on viewport drop with undo/redo integration.~~ **Audit 2026-04-03: NOT implemented.** No code creates a new node on viewport drop.
 - [x] Removed the Gaussian bottom panel from `GaussianEditorPlugin` primary workflow.
 - [x] Gated painterly brush tools UI behind `painterly/enabled` and valid data. Brush UI no longer appears unconditionally for every node.
-- [x] Broadened shared-renderer color grading guard to cover both multi-instance and active world submissions. Renamed `_is_multi_instance_shared_renderer_active` to `_is_renderer_shared_with_other_content` and added `has_world_submission_for_renderer` check. Shared-renderer mode no longer leaks one node's grading to others or to world content.
+- [x] Broadened shared-renderer color grading guard to cover both multi-instance and active world submissions. Renamed `_is_multi_instance_shared_renderer_active` to `_is_renderer_shared_with_other_content` and added `has_world_submission_for_renderer` check. Shared-renderer mode no longer leaks one node's grading to others or to world content. **Superseded by PR #245**: the `rendering/color_grading` property now stays visible on every node and per-node grading reaches the renderer regardless of sharing (last-writer-wins between distinct setter calls; per-frame resync only fires single-owner). Per-instance grading in the instance pipeline is still the proper long-term fix.
 - [x] Added disabled states to bake/restore color grading buttons (disabled when no data, no grading, or wrong bake state).
 - [x] Added 4 color grading tests: single-node push, enter/exit tree survival, signal propagation, and world submission blocking node grading push with recovery.
 - [x] Reimport from the advanced import settings dialog now force-refreshes the loaded asset, sidecar-backed settings, preview scene, and stats without reopening the dialog.
@@ -92,8 +92,8 @@ Run these steps in the editor on a clean project copy:
 17. Drag a `.ply` file onto an existing `GaussianSplatNode3D` and confirm asset-first load (not `ply_file_path` fallback if already imported).
 18. Modify the asset, reimport it from the advanced import settings dialog, and confirm the dialog preview/stats refresh without reopening.
 19. Trigger any hot-reload path available on this branch and confirm all registered live nodes tied to the changed source/asset path refresh without losing their asset links or crashing.
-20. Add two `GaussianSplatNode3D` instances sharing one renderer. Confirm color grading property is hidden on both nodes.
-21. Remove one node. Confirm color grading reappears on the remaining node and reaches the renderer.
+20. Add two `GaussianSplatNode3D` instances sharing one renderer. Confirm `rendering/color_grading` property remains visible on both nodes (per-node grading is now the design intent — see PR #245).
+21. Remove one node. Confirm the remaining node's grading is restored on the renderer (single-owner per-frame resync).
 22. Confirm brush tools UI does not appear when `painterly/enabled` is false.
 23. Enable `painterly/enabled` on a node with valid data. Confirm brush tools appear.
 24. Confirm bake button is disabled when no `ColorGradingResource` is assigned. Assign one and confirm bake becomes enabled.

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -2116,6 +2116,12 @@ void GaussianSplatNode3D::_on_color_grading_changed() {
         // share a renderer, the most recently updated grading wins.
         renderer->set_color_grading(color_grading);
         renderer->invalidate_cached_render();
+        // Arm the data-ready replay guard: this explicit push satisfies the
+        // same invariant the _update_asset() first-data-ready replay would
+        // satisfy. Without arming the flag, a subsequent _update_asset call
+        // (hot-reload / reimport) on a shared renderer would re-push this
+        // node's grading and overwrite whichever node wrote last.
+        grading_pushed_for_current_data = true;
     }
 }
 
@@ -2189,6 +2195,13 @@ void GaussianSplatNode3D::set_color_grading(const Ref<ColorGradingResource> &p_g
         // until per-submission grading is wired through the pipeline.
         renderer->set_color_grading(color_grading);
         renderer->invalidate_cached_render();
+        // Arm the data-ready replay guard: an explicit user push satisfies
+        // the same invariant the _update_asset() first-data-ready replay
+        // would satisfy. Without arming the flag, a subsequent
+        // _update_asset call (hot-reload / reimport) on a shared renderer
+        // would re-push this node's grading and overwrite whichever node
+        // wrote last.
+        grading_pushed_for_current_data = true;
     }
 
     _mark_render_state_dirty();

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -368,10 +368,14 @@ void GaussianSplatNode3D::_notification_exit_tree() {
     renderer_helper.release_renderer_settings_ownership();
     _unregister_shared_renderer();
 
-    // Renderer relationship resets on tree-exit; next ensure_renderer pass
-    // (on re-entry) is responsible for the initial-sync push, which will
-    // re-arm this flag.
-    grading_pushed_for_current_data = false;
+    // NOTE: do NOT reset grading_pushed_for_current_data here. The
+    // owner.renderer reference is not cleared on tree-exit (only
+    // fetched when null in ensure_renderer), so the data-ready window
+    // for this renderer reference continues across exit/re-enter.
+    // Resetting here would let _update_asset re-clobber a peer's
+    // grading on a shared renderer after a transient detach. The flag
+    // is cleared in the right places: _clear_asset (data going away)
+    // and ensure_renderer (new renderer reference).
 
     // Release GPU storage when detached to avoid keeping allocations alive.
     // Storage will be reallocated on re-enter if needed.
@@ -842,6 +846,12 @@ void GaussianSplatNode3D::_finalize_manual_splat_setup(int splat_count) {
     _mark_render_state_dirty();
     update_gizmos();
     update_configuration_warnings();
+
+    // Procedural data path: set_splat_data bypasses set_splat_asset and
+    // _update_asset, so the cached color_grading would never reach the
+    // renderer for this node. Same first-data-ready replay as
+    // _update_asset. (Bot P1 on PR #245.)
+    _replay_color_grading_if_pending();
 }
 
 void GaussianSplatNode3D::set_quality_preset(QualityPreset p_preset) {
@@ -1552,22 +1562,32 @@ void GaussianSplatNode3D::_load_asset() {
 void GaussianSplatNode3D::_update_asset() {
     asset_helper.update_asset();
     update_gizmos();
+    _replay_color_grading_if_pending();
+}
 
-    // Replay cached color grading on the *first* transition from no-data to
-    // has-data within the current data-ready window. Covers the async/auto-
-    // load path: node enters the tree before its asset is ready, so the
-    // ensure_renderer() initial-sync push is skipped (no local source data
-    // at that point). When the asset arrives later and _update_asset runs
-    // from the first set_splat_asset() assignment, the cached grading needs
-    // to reach the renderer here.
+void GaussianSplatNode3D::_replay_color_grading_if_pending() {
+    // First-data-ready replay. Pushes the cached color_grading to the
+    // renderer exactly once per data-ready window, gated on the
+    // grading_pushed_for_current_data flag.
     //
-    // The grading_pushed_for_current_data gate is critical: _update_asset
-    // ALSO runs on the asset's "changed" signal (hot-reload / reimport via
-    // _on_asset_changed), and on a shared renderer an unconditional push
-    // here would let node A's reimport overwrite node B's grading even
+    // Why the flag matters: _update_asset (and the procedural
+    // _finalize_manual_splat_setup) can fire repeatedly — hot-reload /
+    // reimport via _on_asset_changed → _update_asset, multiple
+    // set_splat_data calls, etc. On a shared renderer, an unguarded push
+    // here would let node A's refresh overwrite node B's grading even
     // though no grading setter ran on either. The flag fires this push
-    // exactly once per data-ready window and is cleared by _clear_asset
-    // and NOTIFICATION_EXIT_TREE (the only paths that take data away).
+    // exactly once per data-ready window:
+    //  - cleared by _clear_asset (data going away)
+    //  - cleared inside ensure_renderer when a NEW renderer reference is
+    //    fetched (the old window ends)
+    //  - set by every push site (this helper, ensure_renderer initial-
+    //    sync, setter, signal handler) so subsequent implicit refreshes
+    //    don't re-push
+    //
+    // NOT cleared on NOTIFICATION_EXIT_TREE: owner.renderer reference
+    // persists across exit/re-enter, so the data-ready window persists
+    // too. Resetting here would let _update_asset re-clobber a peer
+    // after a transient detach. (Bot P2 on PR #245.)
     if (!grading_pushed_for_current_data && renderer.is_valid() && color_grading.is_valid() &&
             (renderer_data.is_valid() || splat_asset.is_valid() || runtime_asset.is_valid())) {
         renderer->set_color_grading(color_grading);

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -447,7 +447,11 @@ void GaussianSplatNode3D::_notification(int p_what) {
 
 void GaussianSplatNode3D::_validate_property(PropertyInfo &p_property) const {
     if (_is_renderer_shared_with_other_content(renderer)) {
-        if (p_property.name.begins_with("painterly/") || p_property.name == "rendering/color_grading" ||
+        // Color grading stays visible on every node even when the renderer is
+        // shared: each node pushes its own grading to the renderer (last
+        // write wins until per-submission grading lands). Painterly and
+        // debug overlays remain renderer-wide and are still hidden here.
+        if (p_property.name.begins_with("painterly/") ||
                 p_property.name == "debug/show_tile_grid" ||
                 p_property.name == "debug/show_density_heatmap" ||
                 p_property.name == "debug/show_performance_hud" ||
@@ -2079,11 +2083,9 @@ void GaussianSplatNode3D::_on_asset_changed() {
 
 void GaussianSplatNode3D::_on_color_grading_changed() {
     if (renderer.is_valid()) {
-        if (_is_renderer_shared_with_other_content(renderer)) {
-            renderer->set_color_grading(Ref<ColorGradingResource>());
-        } else {
-            renderer->set_color_grading(color_grading);
-        }
+        // Every node pushes its grading independently; when multiple nodes
+        // share a renderer, the most recently updated grading wins.
+        renderer->set_color_grading(color_grading);
         renderer->invalidate_cached_render();
     }
 }
@@ -2152,11 +2154,11 @@ void GaussianSplatNode3D::set_color_grading(const Ref<ColorGradingResource> &p_g
     }
 
     if (renderer.is_valid()) {
-        if (_is_renderer_shared_with_other_content(renderer)) {
-            renderer->set_color_grading(Ref<ColorGradingResource>());
-        } else {
-            renderer->set_color_grading(color_grading);
-        }
+        // Color grading is per-node: always push to the renderer regardless
+        // of whether the renderer is shared with other nodes or a world
+        // submission. Last-writer-wins when sharing, which is acceptable
+        // until per-submission grading is wired through the pipeline.
+        renderer->set_color_grading(color_grading);
         renderer->invalidate_cached_render();
     }
 

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -1585,6 +1585,9 @@ bool GaussianSplatNode3D::_push_color_grading_to_renderer(bool p_allow_null) {
     renderer->set_color_grading(color_grading);
     renderer->invalidate_cached_render();
     grading_pushed_for_current_data = true;
+    // The push satisfies any pending explicit edit too; clear so a later
+    // replay does not re-fire and clobber a peer that wrote in between.
+    grading_explicit_pending = false;
     return true;
 }
 
@@ -1612,7 +1615,19 @@ void GaussianSplatNode3D::_replay_color_grading_if_pending() {
     // too. Resetting here would let _update_asset re-clobber a peer after a
     // transient detach. Detached edits re-arm the replay by explicitly
     // clearing the flag in the setter/signal paths instead.
-    if (!grading_pushed_for_current_data) {
+    //
+    // Two-track replay:
+    //   - grading_explicit_pending: a user setter/signal call could not
+    //     push immediately (detached, or no data yet). User intent must
+    //     reach the renderer once the node activates, INCLUDING null
+    //     grading — last-writer-wins applies to explicit edits.
+    //   - grading_pushed_for_current_data: implicit init replay. Only
+    //     fires for non-null grading because pushing null implicitly
+    //     would wipe a peer's already-pushed grading on a shared
+    //     renderer (the original "empty node hijacks renderer" P1).
+    if (grading_explicit_pending) {
+        _push_color_grading_to_renderer(true);
+    } else if (!grading_pushed_for_current_data) {
         _push_color_grading_to_renderer(false);
     }
 }
@@ -2154,10 +2169,14 @@ void GaussianSplatNode3D::_on_asset_changed() {
 
 void GaussianSplatNode3D::_on_color_grading_changed() {
     if (!_push_color_grading_to_renderer(true)) {
-        // Detached or data-less resource edits should not mutate a shared
-        // renderer immediately. Keep a pending replay only for non-null
-        // grading; implicit paths must not clear a peer's grading.
-        grading_pushed_for_current_data = color_grading.is_null();
+        // Detached or data-less resource mutation: queue an explicit
+        // replay so the user's change (including null) reaches the
+        // renderer when this node next becomes active content. Arming
+        // the implicit-replay flag too keeps both replay tracks in
+        // sync; the explicit track wins because the replay helper
+        // checks it first.
+        grading_explicit_pending = true;
+        grading_pushed_for_current_data = false;
     }
 }
 
@@ -2225,11 +2244,17 @@ void GaussianSplatNode3D::set_color_grading(const Ref<ColorGradingResource> &p_g
     }
 
     if (!_push_color_grading_to_renderer(true)) {
-        // Cache detached/data-less edits locally and replay them only after
-        // the node becomes active content again. Null grading is still only
-        // propagated by explicit active pushes or the single-owner renderer
-        // settings path; implicit init/replay must not clear peers.
-        grading_pushed_for_current_data = color_grading.is_null();
+        // Detached or data-less setter: queue an explicit replay so the
+        // user's edit (including null) reaches the renderer once this
+        // node becomes active content. Without this, an explicit
+        // set_color_grading(null) made while detached would never reach
+        // the renderer because the implicit replay path rejects null
+        // (to protect peers from passive-init clobbering). Arming the
+        // implicit-replay flag too keeps both replay tracks in sync;
+        // the explicit track wins because the replay helper checks it
+        // first.
+        grading_explicit_pending = true;
+        grading_pushed_for_current_data = false;
     }
 
     _mark_render_state_dirty();

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -351,6 +351,7 @@ void GaussianSplatNode3D::_notification_enter_world() {
     _ensure_renderer();
     _update_render_instance();
     _register_shared_renderer();
+    _replay_color_grading_if_pending();
     debug_helper.apply_renderer_debug_settings();
     _update_debug_hud_visibility();
     notify_property_list_changed();
@@ -1565,10 +1566,32 @@ void GaussianSplatNode3D::_update_asset() {
     _replay_color_grading_if_pending();
 }
 
+bool GaussianSplatNode3D::_has_local_source_data() const {
+    return renderer_data.is_valid() || splat_asset.is_valid() || runtime_asset.is_valid();
+}
+
+bool GaussianSplatNode3D::_can_push_color_grading_to_renderer() const {
+    return renderer.is_valid() && is_inside_tree() && is_inside_world() && _has_local_source_data();
+}
+
+bool GaussianSplatNode3D::_push_color_grading_to_renderer(bool p_allow_null) {
+    if (!_can_push_color_grading_to_renderer()) {
+        return false;
+    }
+    if (!p_allow_null && color_grading.is_null()) {
+        return false;
+    }
+
+    renderer->set_color_grading(color_grading);
+    renderer->invalidate_cached_render();
+    grading_pushed_for_current_data = true;
+    return true;
+}
+
 void GaussianSplatNode3D::_replay_color_grading_if_pending() {
-    // First-data-ready replay. Pushes the cached color_grading to the
-    // renderer exactly once per data-ready window, gated on the
-    // grading_pushed_for_current_data flag.
+    // First-safe replay. Pushes the cached color_grading to the renderer
+    // exactly once per renderer/data window, gated on the
+    // grading_pushed_for_current_data flag and active-content checks.
     //
     // Why the flag matters: _update_asset (and the procedural
     // _finalize_manual_splat_setup) can fire repeatedly — hot-reload /
@@ -1585,13 +1608,12 @@ void GaussianSplatNode3D::_replay_color_grading_if_pending() {
     //    don't re-push
     //
     // NOT cleared on NOTIFICATION_EXIT_TREE: owner.renderer reference
-    // persists across exit/re-enter, so the data-ready window persists
-    // too. Resetting here would let _update_asset re-clobber a peer
-    // after a transient detach. (Bot P2 on PR #245.)
-    if (!grading_pushed_for_current_data && renderer.is_valid() && color_grading.is_valid() &&
-            (renderer_data.is_valid() || splat_asset.is_valid() || runtime_asset.is_valid())) {
-        renderer->set_color_grading(color_grading);
-        grading_pushed_for_current_data = true;
+    // persists across exit/re-enter, so the renderer/data window persists
+    // too. Resetting here would let _update_asset re-clobber a peer after a
+    // transient detach. Detached edits re-arm the replay by explicitly
+    // clearing the flag in the setter/signal paths instead.
+    if (!grading_pushed_for_current_data) {
+        _push_color_grading_to_renderer(false);
     }
 }
 
@@ -2131,17 +2153,11 @@ void GaussianSplatNode3D::_on_asset_changed() {
 }
 
 void GaussianSplatNode3D::_on_color_grading_changed() {
-    if (renderer.is_valid()) {
-        // Every node pushes its grading independently; when multiple nodes
-        // share a renderer, the most recently updated grading wins.
-        renderer->set_color_grading(color_grading);
-        renderer->invalidate_cached_render();
-        // Arm the data-ready replay guard: this explicit push satisfies the
-        // same invariant the _update_asset() first-data-ready replay would
-        // satisfy. Without arming the flag, a subsequent _update_asset call
-        // (hot-reload / reimport) on a shared renderer would re-push this
-        // node's grading and overwrite whichever node wrote last.
-        grading_pushed_for_current_data = true;
+    if (!_push_color_grading_to_renderer(true)) {
+        // Detached or data-less resource edits should not mutate a shared
+        // renderer immediately. Keep a pending replay only for non-null
+        // grading; implicit paths must not clear a peer's grading.
+        grading_pushed_for_current_data = color_grading.is_null();
     }
 }
 
@@ -2208,20 +2224,12 @@ void GaussianSplatNode3D::set_color_grading(const Ref<ColorGradingResource> &p_g
         color_grading->connect("changed", grading_changed);
     }
 
-    if (renderer.is_valid()) {
-        // Color grading is per-node: always push to the renderer regardless
-        // of whether the renderer is shared with other nodes or a world
-        // submission. Last-writer-wins when sharing, which is acceptable
-        // until per-submission grading is wired through the pipeline.
-        renderer->set_color_grading(color_grading);
-        renderer->invalidate_cached_render();
-        // Arm the data-ready replay guard: an explicit user push satisfies
-        // the same invariant the _update_asset() first-data-ready replay
-        // would satisfy. Without arming the flag, a subsequent
-        // _update_asset call (hot-reload / reimport) on a shared renderer
-        // would re-push this node's grading and overwrite whichever node
-        // wrote last.
-        grading_pushed_for_current_data = true;
+    if (!_push_color_grading_to_renderer(true)) {
+        // Cache detached/data-less edits locally and replay them only after
+        // the node becomes active content again. Null grading is still only
+        // propagated by explicit active pushes or the single-owner renderer
+        // settings path; implicit init/replay must not clear peers.
+        grading_pushed_for_current_data = color_grading.is_null();
     }
 
     _mark_render_state_dirty();

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -1547,6 +1547,22 @@ void GaussianSplatNode3D::_load_asset() {
 void GaussianSplatNode3D::_update_asset() {
     asset_helper.update_asset();
     update_gizmos();
+
+    // Replay cached color grading once data becomes available. Covers
+    // the async/auto-load path: node enters the tree before its asset
+    // is ready, so the ensure_renderer() initial-sync push is skipped
+    // (has_local_source_data is false at that point). When the asset
+    // arrives later and _update_asset runs (either from the first
+    // set_splat_asset() assignment or from the asset's "changed"
+    // signal via _on_asset_changed), the cached grading needs to
+    // reach the renderer here. Same gate as the initial-sync push:
+    // requires the renderer, a non-null grading, and at least one
+    // form of local source data so this never tints a peer's
+    // shared renderer when the node has no content.
+    if (renderer.is_valid() && color_grading.is_valid() &&
+            (renderer_data.is_valid() || splat_asset.is_valid() || runtime_asset.is_valid())) {
+        renderer->set_color_grading(color_grading);
+    }
 }
 
 void GaussianSplatNode3D::_clear_asset() {

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -368,6 +368,11 @@ void GaussianSplatNode3D::_notification_exit_tree() {
     renderer_helper.release_renderer_settings_ownership();
     _unregister_shared_renderer();
 
+    // Renderer relationship resets on tree-exit; next ensure_renderer pass
+    // (on re-entry) is responsible for the initial-sync push, which will
+    // re-arm this flag.
+    grading_pushed_for_current_data = false;
+
     // Release GPU storage when detached to avoid keeping allocations alive.
     // Storage will be reallocated on re-enter if needed.
     _release_gaussian_base();
@@ -1548,25 +1553,33 @@ void GaussianSplatNode3D::_update_asset() {
     asset_helper.update_asset();
     update_gizmos();
 
-    // Replay cached color grading once data becomes available. Covers
-    // the async/auto-load path: node enters the tree before its asset
-    // is ready, so the ensure_renderer() initial-sync push is skipped
-    // (has_local_source_data is false at that point). When the asset
-    // arrives later and _update_asset runs (either from the first
-    // set_splat_asset() assignment or from the asset's "changed"
-    // signal via _on_asset_changed), the cached grading needs to
-    // reach the renderer here. Same gate as the initial-sync push:
-    // requires the renderer, a non-null grading, and at least one
-    // form of local source data so this never tints a peer's
-    // shared renderer when the node has no content.
-    if (renderer.is_valid() && color_grading.is_valid() &&
+    // Replay cached color grading on the *first* transition from no-data to
+    // has-data within the current data-ready window. Covers the async/auto-
+    // load path: node enters the tree before its asset is ready, so the
+    // ensure_renderer() initial-sync push is skipped (no local source data
+    // at that point). When the asset arrives later and _update_asset runs
+    // from the first set_splat_asset() assignment, the cached grading needs
+    // to reach the renderer here.
+    //
+    // The grading_pushed_for_current_data gate is critical: _update_asset
+    // ALSO runs on the asset's "changed" signal (hot-reload / reimport via
+    // _on_asset_changed), and on a shared renderer an unconditional push
+    // here would let node A's reimport overwrite node B's grading even
+    // though no grading setter ran on either. The flag fires this push
+    // exactly once per data-ready window and is cleared by _clear_asset
+    // and NOTIFICATION_EXIT_TREE (the only paths that take data away).
+    if (!grading_pushed_for_current_data && renderer.is_valid() && color_grading.is_valid() &&
             (renderer_data.is_valid() || splat_asset.is_valid() || runtime_asset.is_valid())) {
         renderer->set_color_grading(color_grading);
+        grading_pushed_for_current_data = true;
     }
 }
 
 void GaussianSplatNode3D::_clear_asset() {
     asset_helper.clear_asset();
+    // Data is going away — next data-ready transition (new asset, async load
+    // completion, or hot-reload after a reset) should push grading once again.
+    grading_pushed_for_current_data = false;
 }
 
 void GaussianSplatNode3D::_update_bounds() {

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
@@ -167,6 +167,14 @@ private:
 
     // Color grading
     Ref<class ColorGradingResource> color_grading;
+    // Tracks whether the cached color_grading has already been pushed to the
+    // shared renderer for the current data-ready window. Set by ensure_renderer's
+    // initial-sync push and by _update_asset's first-data-ready push; cleared on
+    // _clear_asset (data going away) and tree-exit (renderer relationship reset).
+    // Prevents per-asset-refresh _update_asset calls from re-pushing this node's
+    // grading and clobbering a peer's grading on a shared renderer during
+    // hot-reload / reimport.
+    bool grading_pushed_for_current_data = false;
 
     // Performance monitoring
     uint32_t visible_splat_count = 0;

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
@@ -350,6 +350,16 @@ private:
 
     void _on_asset_changed();
     void _on_color_grading_changed();
+
+    // Push the cached color_grading to the renderer if it has not been
+    // pushed yet for the current data-ready window AND data is present.
+    // The first-data-ready replay path: covers async asset load
+    // (_update_asset after data finally arrives) and procedural data
+    // (_finalize_manual_splat_setup after set_splat_data). Skipping when
+    // the flag is already true prevents hot-reload / reimport from
+    // re-pushing this node's grading and clobbering a peer on a shared
+    // renderer.
+    void _replay_color_grading_if_pending();
     void _on_transform_changed();
     void _update_parent_visibility_tracking();
     void _clear_parent_visibility_tracking();

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
@@ -174,6 +174,14 @@ private:
     // shared renderer. Detached or data-less edits can re-arm a pending replay by
     // setting this back to false.
     bool grading_pushed_for_current_data = false;
+    // Tracks an explicit user grading edit (setter or resource "changed" signal)
+    // that could not be pushed immediately because the node was detached or had
+    // no local source data. Persists until the node next becomes active content
+    // and the cached color_grading — including null — is delivered to the
+    // renderer. Distinguishes user-explicit intent (which is allowed to push
+    // null and override peers under last-writer-wins) from implicit init replay
+    // (which must reject null to avoid wiping a peer that already pushed).
+    bool grading_explicit_pending = false;
 
     // Performance monitoring
     uint32_t visible_splat_count = 0;

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
@@ -168,12 +168,11 @@ private:
     // Color grading
     Ref<class ColorGradingResource> color_grading;
     // Tracks whether the cached color_grading has already been pushed to the
-    // shared renderer for the current data-ready window. Set by ensure_renderer's
-    // initial-sync push and by _update_asset's first-data-ready push; cleared on
-    // _clear_asset (data going away) and tree-exit (renderer relationship reset).
-    // Prevents per-asset-refresh _update_asset calls from re-pushing this node's
-    // grading and clobbering a peer's grading on a shared renderer during
-    // hot-reload / reimport.
+    // current renderer/data window while this node was active content. Cleared
+    // when the node loses its data or renderer relationship; left intact across
+    // detach/re-attach so passive tree transitions do not re-clobber peers on a
+    // shared renderer. Detached or data-less edits can re-arm a pending replay by
+    // setting this back to false.
     bool grading_pushed_for_current_data = false;
 
     // Performance monitoring
@@ -350,15 +349,16 @@ private:
 
     void _on_asset_changed();
     void _on_color_grading_changed();
+    bool _has_local_source_data() const;
+    bool _can_push_color_grading_to_renderer() const;
+    bool _push_color_grading_to_renderer(bool p_allow_null);
 
     // Push the cached color_grading to the renderer if it has not been
-    // pushed yet for the current data-ready window AND data is present.
-    // The first-data-ready replay path: covers async asset load
-    // (_update_asset after data finally arrives) and procedural data
-    // (_finalize_manual_splat_setup after set_splat_data). Skipping when
-    // the flag is already true prevents hot-reload / reimport from
-    // re-pushing this node's grading and clobbering a peer on a shared
-    // renderer.
+    // pushed yet for the current renderer/data window AND the node is active
+    // content. The replay path covers async asset load, procedural data
+    // setup, and deferred sync after detached edits. Skipping when the flag
+    // is already true prevents hot-reload / reimport from re-pushing this
+    // node's grading and clobbering a peer on a shared renderer.
     void _replay_color_grading_if_pending();
     void _on_transform_changed();
     void _update_parent_visibility_tracking();

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
@@ -1373,6 +1373,16 @@ void GaussianSplatNodeRendererHelper::ensure_renderer() {
             owner.renderer = director->get_shared_renderer(owner.get_world_3d().ptr());
             if (owner.renderer.is_valid()) {
                 apply_renderer_settings();
+                // Initial sync: push the cached color grading once when the
+                // renderer becomes available. set_color_grading() couldn't
+                // push earlier because the renderer was null (normal scene-
+                // deserialization path: property setter runs before ensure
+                // brings the renderer up). apply_renderer_settings() does
+                // not push grading per-frame to avoid the shared-renderer
+                // clobber, so this initial push is needed.
+                if (can_apply_renderer_settings()) {
+                    owner.renderer->set_color_grading(owner.color_grading);
+                }
             }
         }
     }

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
@@ -1374,21 +1374,31 @@ void GaussianSplatNodeRendererHelper::ensure_renderer() {
             if (owner.renderer.is_valid()) {
                 apply_renderer_settings();
                 // Initial sync: push the cached color grading once when the
-                // renderer becomes available. set_color_grading() couldn't
-                // push earlier because the renderer was null (normal scene-
-                // deserialization path: property setter runs before ensure
-                // brings the renderer up). apply_renderer_settings() does
-                // not push grading per-frame to avoid the shared-renderer
-                // clobber, so this initial push is needed.
+                // renderer becomes available, gated on actually-rendering
+                // local source data only (NOT on ownership).
                 //
-                // No ownership gate: set_color_grading() pushes regardless
-                // of ownership (per-node grading is the design intent), so
-                // initial sync must mirror that. Otherwise a non-owner node
-                // sharing a renderer with an active world submission would
-                // silently drop its persisted grading. Last-writer-wins
-                // between distinct ensure_renderer() calls matches the
-                // setter's existing semantics.
-                owner.renderer->set_color_grading(owner.color_grading);
+                // Why local-source-data gate: an empty GaussianSplatNode3D
+                // with no asset/data but a saved rendering/color_grading
+                // would otherwise grab the shared world renderer on tree-
+                // entry and tint other renderer users that have no
+                // relationship to it. Same predicate as
+                // can_apply_renderer_settings()'s data-content check.
+                //
+                // Why NOT the full can_apply_renderer_settings(): that
+                // also requires renderer-settings ownership, which fails
+                // for a non-owner node sharing a renderer with an active
+                // world submission. set_color_grading() bypasses ownership
+                // (per-node grading is the design intent), so initial sync
+                // must mirror that: every node WITH content pushes its
+                // grading on initial sync. Last-writer-wins between
+                // distinct ensure_renderer() calls matches the setter's
+                // existing semantics.
+                const bool has_local_source_data = owner.renderer_data.is_valid() ||
+                        owner.splat_asset.is_valid() ||
+                        owner.runtime_asset.is_valid();
+                if (has_local_source_data) {
+                    owner.renderer->set_color_grading(owner.color_grading);
+                }
             }
         }
     }

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
@@ -1418,19 +1418,11 @@ void GaussianSplatNodeRendererHelper::apply_renderer_settings() {
     owner.renderer->set_painterly_stroke_length(owner.stroke_width);
     owner.renderer->set_painterly_gamma(MAX(owner.temporal_blend, 0.01f));
     owner.renderer->set_opacity_multiplier(owner.opacity);
-    {
-        bool renderer_shared = false;
-        GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
-        if (director) {
-            renderer_shared = director->get_instance_count_for_renderer(owner.renderer.ptr()) > 1u ||
-                    director->has_world_submission_for_renderer(owner.renderer.ptr());
-        }
-        if (renderer_shared) {
-            owner.renderer->set_color_grading(Ref<ColorGradingResource>());
-        } else {
-            owner.renderer->set_color_grading(owner.color_grading);
-        }
-    }
+    // Color grading is per-node and always pushed to the renderer. When the
+    // renderer is shared (multi-instance or world submission), last-writer-
+    // wins applies; per-submission grading will be required to eliminate
+    // that limitation.
+    owner.renderer->set_color_grading(owner.color_grading);
     {
         GaussianStreamingSystem::ConfigOverrides overrides;
 

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
@@ -1407,6 +1407,11 @@ void GaussianSplatNodeRendererHelper::ensure_renderer() {
                 // explicit runtime user actions, not implicit init.
                 if (has_local_source_data && owner.color_grading.is_valid()) {
                     owner.renderer->set_color_grading(owner.color_grading);
+                    // Mark the data-ready replay window as already-served so the
+                    // _update_asset() first-data-ready push (which fires on every
+                    // asset refresh including hot-reload) doesn't re-push and
+                    // overwrite a peer's grading on a shared renderer.
+                    owner.grading_pushed_for_current_data = true;
                 }
             }
         }

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
@@ -1434,11 +1434,17 @@ void GaussianSplatNodeRendererHelper::apply_renderer_settings() {
     owner.renderer->set_painterly_stroke_length(owner.stroke_width);
     owner.renderer->set_painterly_gamma(MAX(owner.temporal_blend, 0.01f));
     owner.renderer->set_opacity_multiplier(owner.opacity);
-    // Color grading is intentionally NOT pushed here. set_color_grading() and
-    // _on_color_grading_changed() already push on the actual change events.
-    // Re-pushing every frame from this owner-only path would clobber a non-
-    // owner node's set_color_grading() call on the next frame, so per-node
-    // grading would never persist in shared-renderer scenes.
+    // Color grading per-frame push is gated on single-owner. Pushing while
+    // sharing would clobber another node's set_color_grading() call (the
+    // original P1 fix). Skipping always means a sharing-collapse transition
+    // (e.g. another node leaving) leaves the renderer with the departed
+    // node's last grading and never restores the remaining owner's
+    // (the third P1 fix). Single-owner per-frame push covers both: it
+    // resyncs after a transition without ever clobbering anyone, since by
+    // definition no other node could have written.
+    if (!_is_renderer_shared_with_other_content(owner)) {
+        owner.renderer->set_color_grading(owner.color_grading);
+    }
     {
         GaussianStreamingSystem::ConfigOverrides overrides;
 

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
@@ -1396,7 +1396,16 @@ void GaussianSplatNodeRendererHelper::ensure_renderer() {
                 const bool has_local_source_data = owner.renderer_data.is_valid() ||
                         owner.splat_asset.is_valid() ||
                         owner.runtime_asset.is_valid();
-                if (has_local_source_data) {
+                // Only push if this node actually has its own grading. A
+                // null cached grading would otherwise wipe another node's
+                // already-pushed grading when multiple nodes initialize
+                // through ensure_renderer() in sequence on the same
+                // shared renderer (e.g. node A loads first and pushes
+                // grading X, then node B with no grading loads and would
+                // push null, clearing X). Setter and signal-handler paths
+                // can still push null deliberately because those reflect
+                // explicit runtime user actions, not implicit init.
+                if (has_local_source_data && owner.color_grading.is_valid()) {
                     owner.renderer->set_color_grading(owner.color_grading);
                 }
             }

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
@@ -1380,9 +1380,15 @@ void GaussianSplatNodeRendererHelper::ensure_renderer() {
                 // brings the renderer up). apply_renderer_settings() does
                 // not push grading per-frame to avoid the shared-renderer
                 // clobber, so this initial push is needed.
-                if (can_apply_renderer_settings()) {
-                    owner.renderer->set_color_grading(owner.color_grading);
-                }
+                //
+                // No ownership gate: set_color_grading() pushes regardless
+                // of ownership (per-node grading is the design intent), so
+                // initial sync must mirror that. Otherwise a non-owner node
+                // sharing a renderer with an active world submission would
+                // silently drop its persisted grading. Last-writer-wins
+                // between distinct ensure_renderer() calls matches the
+                // setter's existing semantics.
+                owner.renderer->set_color_grading(owner.color_grading);
             }
         }
     }

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
@@ -1325,8 +1325,7 @@ bool GaussianSplatNodeRendererHelper::can_apply_renderer_settings() const {
         return false;
     }
 
-    const bool has_local_source_data = owner.renderer_data.is_valid() || owner.splat_asset.is_valid() || owner.runtime_asset.is_valid();
-    if (!has_local_source_data) {
+    if (!owner._has_local_source_data()) {
         return false;
     }
 
@@ -1380,46 +1379,7 @@ void GaussianSplatNodeRendererHelper::ensure_renderer() {
             owner.grading_pushed_for_current_data = false;
             if (owner.renderer.is_valid()) {
                 apply_renderer_settings();
-                // Initial sync: push the cached color grading once when the
-                // renderer becomes available, gated on actually-rendering
-                // local source data only (NOT on ownership).
-                //
-                // Why local-source-data gate: an empty GaussianSplatNode3D
-                // with no asset/data but a saved rendering/color_grading
-                // would otherwise grab the shared world renderer on tree-
-                // entry and tint other renderer users that have no
-                // relationship to it. Same predicate as
-                // can_apply_renderer_settings()'s data-content check.
-                //
-                // Why NOT the full can_apply_renderer_settings(): that
-                // also requires renderer-settings ownership, which fails
-                // for a non-owner node sharing a renderer with an active
-                // world submission. set_color_grading() bypasses ownership
-                // (per-node grading is the design intent), so initial sync
-                // must mirror that: every node WITH content pushes its
-                // grading on initial sync. Last-writer-wins between
-                // distinct ensure_renderer() calls matches the setter's
-                // existing semantics.
-                const bool has_local_source_data = owner.renderer_data.is_valid() ||
-                        owner.splat_asset.is_valid() ||
-                        owner.runtime_asset.is_valid();
-                // Only push if this node actually has its own grading. A
-                // null cached grading would otherwise wipe another node's
-                // already-pushed grading when multiple nodes initialize
-                // through ensure_renderer() in sequence on the same
-                // shared renderer (e.g. node A loads first and pushes
-                // grading X, then node B with no grading loads and would
-                // push null, clearing X). Setter and signal-handler paths
-                // can still push null deliberately because those reflect
-                // explicit runtime user actions, not implicit init.
-                if (has_local_source_data && owner.color_grading.is_valid()) {
-                    owner.renderer->set_color_grading(owner.color_grading);
-                    // Mark the data-ready replay window as already-served so the
-                    // _update_asset() first-data-ready push (which fires on every
-                    // asset refresh including hot-reload) doesn't re-push and
-                    // overwrite a peer's grading on a shared renderer.
-                    owner.grading_pushed_for_current_data = true;
-                }
+                owner._replay_color_grading_if_pending();
             }
         }
     }

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
@@ -1418,11 +1418,11 @@ void GaussianSplatNodeRendererHelper::apply_renderer_settings() {
     owner.renderer->set_painterly_stroke_length(owner.stroke_width);
     owner.renderer->set_painterly_gamma(MAX(owner.temporal_blend, 0.01f));
     owner.renderer->set_opacity_multiplier(owner.opacity);
-    // Color grading is per-node and always pushed to the renderer. When the
-    // renderer is shared (multi-instance or world submission), last-writer-
-    // wins applies; per-submission grading will be required to eliminate
-    // that limitation.
-    owner.renderer->set_color_grading(owner.color_grading);
+    // Color grading is intentionally NOT pushed here. set_color_grading() and
+    // _on_color_grading_changed() already push on the actual change events.
+    // Re-pushing every frame from this owner-only path would clobber a non-
+    // owner node's set_color_grading() call on the next frame, so per-node
+    // grading would never persist in shared-renderer scenes.
     {
         GaussianStreamingSystem::ConfigOverrides overrides;
 

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
@@ -1371,6 +1371,13 @@ void GaussianSplatNodeRendererHelper::ensure_renderer() {
         GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
         if (director) {
             owner.renderer = director->get_shared_renderer(owner.get_world_3d().ptr());
+            // A new renderer reference begins a fresh data-ready window;
+            // any prior flag value referred to the previous reference and
+            // is no longer meaningful. The conditional push below re-arms
+            // the flag if it actually pushes. (Bot P2 on PR #245: tree-
+            // exit must NOT reset this flag because the renderer
+            // reference persists; only renderer-reference change should.)
+            owner.grading_pushed_for_current_data = false;
             if (owner.renderer.is_valid()) {
                 apply_renderer_settings();
                 // Initial sync: push the cached color grading once when the

--- a/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
@@ -1942,6 +1942,80 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Detached color grad
     memdelete(node_a);
 }
 
+TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Detached set_color_grading(null) replays on re-enter and overrides peer") {
+    SceneTree *tree = SceneTree::get_singleton();
+    REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");
+
+    Window *root = tree->get_root();
+    REQUIRE_MESSAGE(root != nullptr, "SceneTree root window required");
+
+    // PR #245 Codex follow-up P2: previously, setting color_grading=null
+    // on a detached node armed grading_pushed_for_current_data=true
+    // (because color_grading.is_null()), which suppressed the implicit
+    // replay. The replay also rejected null. Result: the explicit null
+    // assignment was silently lost — last-writer-wins was broken when
+    // the latest writer wrote null while detached.
+    GaussianSplatNode3D *node_a = memnew(GaussianSplatNode3D);
+    GaussianSplatNode3D *node_b = memnew(GaussianSplatNode3D);
+    node_a->set_splat_asset(make_single_splat_asset(9801.0f));
+    node_b->set_splat_asset(make_single_splat_asset(9802.0f));
+
+    Ref<ColorGradingResource> grading_a = make_color_grading_resource();
+    Ref<ColorGradingResource> grading_b = make_color_grading_resource();
+    REQUIRE(grading_a.is_valid());
+    REQUIRE(grading_b.is_valid());
+    grading_a->set_exposure(0.40f);
+    grading_b->set_exposure(0.90f);
+
+    node_a->set_color_grading(grading_a);
+    node_b->set_color_grading(grading_b);
+
+    root->add_child(node_a);
+    root->add_child(node_b);
+    tree->process(0.0);
+
+    Ref<GaussianSplatRenderer> renderer = node_a->get_renderer();
+    if (!renderer.is_valid()) {
+        MESSAGE("Skipping test - renderer unavailable (headless mode)");
+        root->remove_child(node_b);
+        root->remove_child(node_a);
+        memdelete(node_b);
+        memdelete(node_a);
+        return;
+    }
+    REQUIRE_MESSAGE(renderer == node_b->get_renderer(), "Both nodes must share the same renderer for this test");
+
+    // Both nodes pushed; renderer reflects whichever ensure_renderer ran
+    // last. Assert via explicit setter so the test is deterministic.
+    node_b->set_color_grading(grading_b);
+    tree->process(0.0);
+    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
+            "Renderer should reflect node_b's grading before node_a detaches");
+
+    // Detach node_a, then explicitly clear its grading via setter.
+    root->remove_child(node_a);
+    tree->process(0.0);
+
+    node_a->set_color_grading(Ref<ColorGradingResource>());
+    tree->process(0.0);
+    // Detached null setter must NOT touch the renderer immediately.
+    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
+            "Detached set_color_grading(null) on node_a must not mutate the shared renderer immediately");
+
+    // Re-attach node_a. The explicit-pending replay must apply node_a's
+    // null grading (last-writer-wins) and clear the renderer's grading.
+    root->add_child(node_a);
+    tree->process(0.0);
+
+    CHECK_MESSAGE(renderer->get_color_grading().is_null(),
+            "Re-entering node_a after explicit set_color_grading(null) must apply the null and override node_b's grading");
+
+    root->remove_child(node_b);
+    root->remove_child(node_a);
+    memdelete(node_b);
+    memdelete(node_a);
+}
+
 TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer full-fidelity override only follows attached assets") {
     SceneTree *tree = SceneTree::get_singleton();
     REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");

--- a/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
@@ -1221,7 +1221,7 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer ins
     memdelete(node_a);
 }
 
-TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer hides node-local color grading property") {
+TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Color grading property stays exposed when renderer is shared") {
     SceneTree *tree = SceneTree::get_singleton();
     REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");
 
@@ -1240,7 +1240,6 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer hid
     root->add_child(node_b);
     tree->process(0.0);
 
-    // Shared renderer hides color_grading; requires GPU renderer to be available.
     Ref<GaussianSplatRenderer> renderer = node_a->get_renderer();
     if (!renderer.is_valid()) {
         MESSAGE("Skipping shared-renderer property check - renderer unavailable (headless mode)");
@@ -1251,11 +1250,12 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer hid
         return;
     }
 
-    CHECK_FALSE(is_property_editor_exposed(node_a, StringName("rendering/color_grading")));
-    CHECK_FALSE(is_property_editor_exposed(node_b, StringName("rendering/color_grading")));
+    // Color grading is per-node: the property must remain visible on every
+    // node, even when the renderer is shared between multiple instances.
+    CHECK(is_property_editor_exposed(node_a, StringName("rendering/color_grading")));
+    CHECK(is_property_editor_exposed(node_b, StringName("rendering/color_grading")));
 
-    // Remove the second node — shared renderer collapses to single-instance.
-    // Color grading property should become editor-visible again on the remaining node.
+    // It should also stay visible after the share collapses back to a single instance.
     root->remove_child(node_b);
     tree->process(0.0);
     CHECK(is_property_editor_exposed(node_a, StringName("rendering/color_grading")));
@@ -1265,7 +1265,7 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer hid
     memdelete(node_a);
 }
 
-TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] World submission blocks node color grading push to renderer") {
+TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Node color grading reaches renderer even with active world submission") {
     SceneTree *tree = SceneTree::get_singleton();
     REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");
 
@@ -1304,25 +1304,23 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] World submission bl
     Ref<ColorGradingResource> grading = make_color_grading_resource();
     graded_node->set_color_grading(grading);
 
-    // The renderer is shared with an active world submission, so color
-    // grading must NOT leak to the renderer.
+    // Color grading is per-node: even with an active world submission
+    // sharing the renderer, the node's grading must reach the renderer
+    // and the inspector property must stay visible.
     CHECK_MESSAGE(graded_node->get_color_grading() == grading,
             "Node retains its local color grading");
-    CHECK_MESSAGE(!renderer->get_color_grading().is_valid(),
-            "Renderer color grading must be null when world submission is active");
+    CHECK_MESSAGE(renderer->get_color_grading() == grading,
+            "Renderer color grading must reflect the node's grading even with a world submission");
+    CHECK(is_property_editor_exposed(graded_node, StringName("rendering/color_grading")));
 
-    // Color grading property should be hidden in the inspector.
-    CHECK_FALSE(is_property_editor_exposed(graded_node, StringName("rendering/color_grading")));
-
-    // Remove the world node — renderer is no longer shared with world content.
+    // Property and propagation should also hold after the world submission is removed.
     world_node->clear_world();
     root->remove_child(world_node);
     tree->process(0.0);
 
-    // Now the splat node is the sole user. Re-push grading and verify it reaches the renderer.
     graded_node->set_color_grading(grading);
     CHECK_MESSAGE(renderer->get_color_grading() == grading,
-            "Color grading should reach renderer after world submission is removed");
+            "Color grading should still reach renderer after world submission is removed");
     CHECK(is_property_editor_exposed(graded_node, StringName("rendering/color_grading")));
 
     root->remove_child(graded_node);
@@ -1381,8 +1379,11 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer pre
     CHECK(node_a->is_painterly_enabled());
     CHECK(node_a->get_color_grading().is_valid());
     CHECK(node_a->get_color_grading() == grading);
+    // Painterly is still renderer-wide and gated while the renderer is shared.
     CHECK_FALSE(renderer->get_painterly_enabled());
-    CHECK(renderer->get_color_grading().is_null());
+    // Color grading is per-node and propagates to the renderer regardless of sharing
+    // (last-writer-wins when multiple nodes share a renderer).
+    CHECK(renderer->get_color_grading() == grading);
 
     root->remove_child(node_b);
     tree->process(0.0);

--- a/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
@@ -1601,6 +1601,140 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Hot-reload of node 
     memdelete(node_a);
 }
 
+TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Procedural set_splat_data path replays cached color grading once data is ready") {
+    SceneTree *tree = SceneTree::get_singleton();
+    REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");
+
+    Window *root = tree->get_root();
+    REQUIRE_MESSAGE(root != nullptr, "SceneTree root window required");
+
+    // PR #245 P1: set_splat_data() bypasses set_splat_asset/_update_asset.
+    // Without _replay_color_grading_if_pending() in _finalize_manual_splat_setup,
+    // a node that received its data procedurally would never have its
+    // cached color_grading reach the renderer until a manual setter call.
+    GaussianSplatNode3D *node = memnew(GaussianSplatNode3D);
+
+    Ref<ColorGradingResource> grading = make_color_grading_resource();
+    REQUIRE(grading.is_valid());
+    grading->set_exposure(0.42f);
+
+    // Cache grading BEFORE entering tree, BEFORE any data is set.
+    node->set_color_grading(grading);
+    CHECK(node->get_color_grading() == grading);
+
+    root->add_child(node);
+    tree->process(0.0);
+
+    // Now feed the node procedural data. This is the path the bot
+    // flagged: ensure_renderer fires with no data (skips push), then
+    // _finalize_manual_splat_setup runs with data present.
+    PackedVector3Array positions;
+    positions.push_back(Vector3(9500.0f, 0.0f, 0.0f));
+    PackedColorArray colors;
+    colors.push_back(Color(1.0f, 1.0f, 1.0f, 1.0f));
+    PackedVector3Array scales;
+    scales.push_back(Vector3(1.0f, 1.0f, 1.0f));
+    PackedFloat32Array opacities;
+    opacities.push_back(1.0f);
+    TypedArray<Quaternion> rotations;
+    rotations.push_back(Quaternion());
+    PackedFloat32Array sh;
+    PackedInt32Array palette_ids;
+    PackedInt32Array painterly_flags;
+    PackedVector3Array normals;
+    PackedVector2Array brush_axes;
+    PackedFloat32Array stroke_ages;
+
+    node->set_splat_data(positions, colors, scales, opacities, rotations,
+            sh, palette_ids, painterly_flags, normals, brush_axes, stroke_ages, false);
+    tree->process(0.0);
+
+    Ref<GaussianSplatRenderer> renderer = node->get_renderer();
+    if (!renderer.is_valid()) {
+        MESSAGE("Skipping test - renderer unavailable (headless mode)");
+        root->remove_child(node);
+        memdelete(node);
+        return;
+    }
+
+    CHECK_MESSAGE(renderer->get_color_grading() == grading,
+            "Renderer must reflect the cached color grading after procedural set_splat_data");
+
+    root->remove_child(node);
+    memdelete(node);
+}
+
+TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Tree exit/re-enter must not allow _update_asset to re-clobber peer") {
+    SceneTree *tree = SceneTree::get_singleton();
+    REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");
+
+    Window *root = tree->get_root();
+    REQUIRE_MESSAGE(root != nullptr, "SceneTree root window required");
+
+    // PR #245 P2: NOTIFICATION_EXIT_TREE used to reset the guard, but
+    // owner.renderer is not cleared on tree-exit; ensure_renderer's
+    // initial-sync branch only runs when renderer is null. So on
+    // re-entry the guard would stay false, and the next _update_asset
+    // (e.g. hot-reload) would re-push this node's grading and clobber
+    // a peer that wrote in the meantime.
+    GaussianSplatNode3D *node_a = memnew(GaussianSplatNode3D);
+    GaussianSplatNode3D *node_b = memnew(GaussianSplatNode3D);
+    node_a->set_splat_asset(make_single_splat_asset(9601.0f));
+    node_b->set_splat_asset(make_single_splat_asset(9602.0f));
+
+    Ref<ColorGradingResource> grading_a = make_color_grading_resource();
+    Ref<ColorGradingResource> grading_b = make_color_grading_resource();
+    REQUIRE(grading_a.is_valid());
+    REQUIRE(grading_b.is_valid());
+    grading_a->set_exposure(0.30f);
+    grading_b->set_exposure(0.80f);
+
+    node_a->set_color_grading(grading_a);
+    node_b->set_color_grading(grading_b);
+
+    root->add_child(node_a);
+    root->add_child(node_b);
+    tree->process(0.0);
+
+    Ref<GaussianSplatRenderer> renderer = node_a->get_renderer();
+    if (!renderer.is_valid()) {
+        MESSAGE("Skipping test - renderer unavailable (headless mode)");
+        root->remove_child(node_b);
+        root->remove_child(node_a);
+        memdelete(node_b);
+        memdelete(node_a);
+        return;
+    }
+    REQUIRE_MESSAGE(renderer == node_b->get_renderer(), "Both nodes must share the same renderer for this test");
+
+    // Last writer is node_b.
+    node_b->set_color_grading(grading_b);
+    tree->process(0.0);
+    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
+            "Renderer should reflect node_b's grading after explicit setter");
+
+    // Detach node_a, then re-attach it without changing its grading or
+    // its asset. Then trigger a hot-reload via emit_changed(). The guard
+    // must remain set so the implicit _update_asset push doesn't fire.
+    root->remove_child(node_a);
+    tree->process(0.0);
+    root->add_child(node_a);
+    tree->process(0.0);
+
+    Ref<GaussianSplatAsset> asset_a = node_a->get_splat_asset();
+    REQUIRE(asset_a.is_valid());
+    asset_a->emit_changed();
+    tree->process(0.0);
+
+    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
+            "After tree exit/re-enter and hot-reload of node_a, renderer must still hold node_b's grading");
+
+    root->remove_child(node_b);
+    root->remove_child(node_a);
+    memdelete(node_b);
+    memdelete(node_a);
+}
+
 TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Setter after no-grading load arms guard so hot-reload does not re-clobber peer") {
     SceneTree *tree = SceneTree::get_singleton();
     REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");

--- a/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
@@ -1538,6 +1538,69 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Color grading signa
     memdelete(node);
 }
 
+TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Hot-reload of node A's asset must not clobber node B's grading on shared renderer") {
+    SceneTree *tree = SceneTree::get_singleton();
+    REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");
+
+    Window *root = tree->get_root();
+    REQUIRE_MESSAGE(root != nullptr, "SceneTree root window required");
+
+    GaussianSplatNode3D *node_a = memnew(GaussianSplatNode3D);
+    GaussianSplatNode3D *node_b = memnew(GaussianSplatNode3D);
+    node_a->set_splat_asset(make_single_splat_asset(9301.0f));
+    node_b->set_splat_asset(make_single_splat_asset(9302.0f));
+
+    Ref<ColorGradingResource> grading_a = make_color_grading_resource();
+    Ref<ColorGradingResource> grading_b = make_color_grading_resource();
+    REQUIRE(grading_a.is_valid());
+    REQUIRE(grading_b.is_valid());
+    grading_a->set_exposure(0.25f);
+    grading_b->set_exposure(0.75f);
+
+    node_a->set_color_grading(grading_a);
+    node_b->set_color_grading(grading_b);
+
+    root->add_child(node_a);
+    root->add_child(node_b);
+    tree->process(0.0);
+
+    Ref<GaussianSplatRenderer> renderer = node_a->get_renderer();
+    if (!renderer.is_valid()) {
+        MESSAGE("Skipping test - renderer unavailable (headless mode)");
+        root->remove_child(node_b);
+        root->remove_child(node_a);
+        memdelete(node_b);
+        memdelete(node_a);
+        return;
+    }
+    REQUIRE_MESSAGE(renderer == node_b->get_renderer(), "Both nodes must share the same renderer for this test");
+
+    // After explicit setters, renderer reflects the most recent push (node_b).
+    node_b->set_color_grading(grading_b);
+    tree->process(0.0);
+    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
+            "Renderer should reflect node_b's grading after explicit setter");
+
+    // Simulate hot-reload / reimport of node_a's asset via the asset's
+    // "changed" signal — this is the path that fires _on_asset_changed →
+    // _update_asset on node_a without any user grading edit.
+    Ref<GaussianSplatAsset> asset_a = node_a->get_splat_asset();
+    REQUIRE(asset_a.is_valid());
+    asset_a->emit_changed();
+    tree->process(0.0);
+
+    // The renderer's grading must remain node_b's. If the implicit
+    // _update_asset push were not gated to first-data-ready, node_a would
+    // overwrite node_b here even though no setter ran on node_a.
+    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
+            "Hot-reload of node_a must not clobber node_b's grading on shared renderer");
+
+    root->remove_child(node_b);
+    root->remove_child(node_a);
+    memdelete(node_b);
+    memdelete(node_a);
+}
+
 TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer full-fidelity override only follows attached assets") {
     SceneTree *tree = SceneTree::get_singleton();
     REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");

--- a/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
@@ -1601,6 +1601,86 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Hot-reload of node 
     memdelete(node_a);
 }
 
+TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Setter after no-grading load arms guard so hot-reload does not re-clobber peer") {
+    SceneTree *tree = SceneTree::get_singleton();
+    REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");
+
+    Window *root = tree->get_root();
+    REQUIRE_MESSAGE(root != nullptr, "SceneTree root window required");
+
+    // Reproduces the post-fix scenario from PR #245 P1#8:
+    //   - node_a loads with NO grading (so ensure_renderer skips its push;
+    //     the data-ready guard would stay false without the setter arming
+    //     it).
+    //   - node_b loads with grading_b (ensure_renderer pushes grading_b).
+    //   - user later assigns grading_a via the setter on node_a.
+    //   - user later assigns grading_b via the setter on node_b (renderer
+    //     now reflects grading_b, the most recent setter write).
+    //   - hot-reload of node_a's asset runs _update_asset on node_a. With
+    //     the setter arming the guard, this must NOT re-push grading_a
+    //     and must leave grading_b on the renderer.
+    GaussianSplatNode3D *node_a = memnew(GaussianSplatNode3D);
+    GaussianSplatNode3D *node_b = memnew(GaussianSplatNode3D);
+    node_a->set_splat_asset(make_single_splat_asset(9401.0f));
+    node_b->set_splat_asset(make_single_splat_asset(9402.0f));
+
+    Ref<ColorGradingResource> grading_b_initial = make_color_grading_resource();
+    REQUIRE(grading_b_initial.is_valid());
+    grading_b_initial->set_exposure(0.6f);
+    node_b->set_color_grading(grading_b_initial);
+
+    root->add_child(node_a);
+    root->add_child(node_b);
+    tree->process(0.0);
+
+    Ref<GaussianSplatRenderer> renderer = node_a->get_renderer();
+    if (!renderer.is_valid()) {
+        MESSAGE("Skipping test - renderer unavailable (headless mode)");
+        root->remove_child(node_b);
+        root->remove_child(node_a);
+        memdelete(node_b);
+        memdelete(node_a);
+        return;
+    }
+    REQUIRE_MESSAGE(renderer == node_b->get_renderer(), "Both nodes must share the same renderer for this test");
+
+    Ref<ColorGradingResource> grading_a = make_color_grading_resource();
+    Ref<ColorGradingResource> grading_b = make_color_grading_resource();
+    REQUIRE(grading_a.is_valid());
+    REQUIRE(grading_b.is_valid());
+    grading_a->set_exposure(0.25f);
+    grading_b->set_exposure(0.75f);
+
+    // Setter on node_a: must push grading_a AND arm the guard, so that
+    // a later _update_asset on node_a doesn't re-push.
+    node_a->set_color_grading(grading_a);
+    tree->process(0.0);
+    CHECK_MESSAGE(renderer->get_color_grading() == grading_a,
+            "Renderer must reflect node_a's grading after explicit setter");
+
+    // Setter on node_b: most recent push, renderer = grading_b.
+    node_b->set_color_grading(grading_b);
+    tree->process(0.0);
+    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
+            "Renderer must reflect node_b's grading after its setter");
+
+    // Hot-reload of node_a's asset. Without the setter arming the guard,
+    // _update_asset on node_a would re-push grading_a and clobber
+    // grading_b. With the fix, the guard is true and no push happens.
+    Ref<GaussianSplatAsset> asset_a = node_a->get_splat_asset();
+    REQUIRE(asset_a.is_valid());
+    asset_a->emit_changed();
+    tree->process(0.0);
+
+    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
+            "Hot-reload of node_a's asset must not re-clobber node_b after setter armed the guard");
+
+    root->remove_child(node_b);
+    root->remove_child(node_a);
+    memdelete(node_b);
+    memdelete(node_a);
+}
+
 TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer full-fidelity override only follows attached assets") {
     SceneTree *tree = SceneTree::get_singleton();
     REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");

--- a/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
@@ -1815,6 +1815,133 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Setter after no-gra
     memdelete(node_a);
 }
 
+TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Detached asset refresh and reassignment must not clobber active peer color grading") {
+    SceneTree *tree = SceneTree::get_singleton();
+    REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");
+
+    Window *root = tree->get_root();
+    REQUIRE_MESSAGE(root != nullptr, "SceneTree root window required");
+
+    GaussianSplatNode3D *node_a = memnew(GaussianSplatNode3D);
+    GaussianSplatNode3D *node_b = memnew(GaussianSplatNode3D);
+    node_a->set_splat_asset(make_single_splat_asset(9701.0f));
+    node_b->set_splat_asset(make_single_splat_asset(9702.0f));
+
+    Ref<ColorGradingResource> grading_a = make_color_grading_resource();
+    Ref<ColorGradingResource> grading_b = make_color_grading_resource();
+    REQUIRE(grading_a.is_valid());
+    REQUIRE(grading_b.is_valid());
+    grading_a->set_exposure(0.2f);
+    grading_b->set_exposure(0.9f);
+
+    node_a->set_color_grading(grading_a);
+    node_b->set_color_grading(grading_b);
+
+    root->add_child(node_a);
+    root->add_child(node_b);
+    tree->process(0.0);
+
+    Ref<GaussianSplatRenderer> renderer = node_a->get_renderer();
+    if (!renderer.is_valid()) {
+        MESSAGE("Skipping test - renderer unavailable (headless mode)");
+        root->remove_child(node_b);
+        root->remove_child(node_a);
+        memdelete(node_b);
+        memdelete(node_a);
+        return;
+    }
+    REQUIRE_MESSAGE(renderer == node_b->get_renderer(), "Both nodes must share the same renderer for this test");
+
+    node_b->set_color_grading(grading_b);
+    tree->process(0.0);
+    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
+            "Renderer should reflect node_b's grading before node_a is detached");
+
+    root->remove_child(node_a);
+    tree->process(0.0);
+
+    Ref<GaussianSplatAsset> detached_asset = node_a->get_splat_asset();
+    REQUIRE(detached_asset.is_valid());
+    detached_asset->emit_changed();
+    tree->process(0.0);
+    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
+            "Detached hot-reload of node_a must not overwrite node_b's grading");
+
+    Ref<GaussianSplatAsset> replacement_asset = make_single_splat_asset(9703.0f);
+    REQUIRE(replacement_asset.is_valid());
+    node_a->set_splat_asset(replacement_asset);
+    tree->process(0.0);
+    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
+            "Detached set_splat_asset() on node_a must not overwrite node_b's grading");
+
+    root->remove_child(node_b);
+    memdelete(node_b);
+    memdelete(node_a);
+}
+
+TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Detached color grading resource changes replay only after re-enter") {
+    SceneTree *tree = SceneTree::get_singleton();
+    REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");
+
+    Window *root = tree->get_root();
+    REQUIRE_MESSAGE(root != nullptr, "SceneTree root window required");
+
+    GaussianSplatNode3D *node_a = memnew(GaussianSplatNode3D);
+    GaussianSplatNode3D *node_b = memnew(GaussianSplatNode3D);
+    node_a->set_splat_asset(make_single_splat_asset(9711.0f));
+    node_b->set_splat_asset(make_single_splat_asset(9712.0f));
+
+    Ref<ColorGradingResource> grading_a = make_color_grading_resource();
+    Ref<ColorGradingResource> grading_b = make_color_grading_resource();
+    REQUIRE(grading_a.is_valid());
+    REQUIRE(grading_b.is_valid());
+    grading_a->set_exposure(0.35f);
+    grading_b->set_exposure(0.85f);
+
+    node_a->set_color_grading(grading_a);
+    node_b->set_color_grading(grading_b);
+
+    root->add_child(node_a);
+    root->add_child(node_b);
+    tree->process(0.0);
+
+    Ref<GaussianSplatRenderer> renderer = node_a->get_renderer();
+    if (!renderer.is_valid()) {
+        MESSAGE("Skipping test - renderer unavailable (headless mode)");
+        root->remove_child(node_b);
+        root->remove_child(node_a);
+        memdelete(node_b);
+        memdelete(node_a);
+        return;
+    }
+    REQUIRE_MESSAGE(renderer == node_b->get_renderer(), "Both nodes must share the same renderer for this test");
+
+    node_b->set_color_grading(grading_b);
+    tree->process(0.0);
+    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
+            "Renderer should reflect node_b's grading before node_a is detached");
+
+    root->remove_child(node_a);
+    tree->process(0.0);
+
+    grading_a->set_exposure(1.25f);
+    tree->process(0.0);
+    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
+            "Detached grading resource changes on node_a must not overwrite node_b immediately");
+
+    root->add_child(node_a);
+    tree->process(0.0);
+    REQUIRE(renderer->get_color_grading().is_valid());
+    CHECK_MESSAGE(renderer->get_color_grading() == grading_a,
+            "Re-entering node_a should replay its pending grading change exactly once");
+    CHECK(renderer->get_color_grading()->get_exposure() == doctest::Approx(1.25f));
+
+    root->remove_child(node_b);
+    root->remove_child(node_a);
+    memdelete(node_b);
+    memdelete(node_a);
+}
+
 TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer full-fidelity override only follows attached assets") {
     SceneTree *tree = SceneTree::get_singleton();
     REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");


### PR DESCRIPTION
## Summary
- Every `GaussianSplatNode3D` now unconditionally exposes `rendering/color_grading` in the inspector and always pushes its grading to the renderer, regardless of whether the renderer is shared with other nodes or an active world submission.
- When multiple nodes share a renderer, the most recently updated grading wins. This keeps each node's grading independently editable; a follow-up is tracked for wiring per-submission grading through the pipeline to eliminate the last-writer-wins behavior when sharing.

## What was broken
Master still carries the shared-renderer guard from an earlier iteration:
- `gaussian_splat_node_3d.cpp::_validate_property` hid `rendering/color_grading` whenever `_is_renderer_shared_with_other_content(renderer)` returned true (multi-instance or active world submission).
- `_on_color_grading_changed` and `set_color_grading` cleared the renderer's grading in the same shared case.
- `gaussian_splat_node_helpers.cpp::apply_renderer_settings` repeated the same clear when applying per-frame renderer state.
- Three unit tests at `tests/test_gaussian_splat_node.h` asserted this behavior, locking it in.

PR #220 already intended to remove these guards (`f5bb73d`: "always expose color grading"); this change mirrors that intent on current master, plus the helpers.cpp site the original commit missed and the corresponding test updates.

## What the fix does
- `nodes/gaussian_splat_node_3d.cpp`: drop `rendering/color_grading` from the shared-renderer property guard (painterly/* and `debug/show_*` overlays remain gated because they are genuinely renderer-wide). Simplify `_on_color_grading_changed` and `set_color_grading` to always push the node's grading to the renderer.
- `nodes/gaussian_splat_node_helpers.cpp`: drop the shared-renderer branch in `apply_renderer_settings` so each frame's renderer state reflects the owning node's grading.
- `tests/test_gaussian_splat_node.h`: rewrite the three affected test cases to assert the new correct behavior (property visible when shared, node grading reaches renderer with a world submission active, shared-renderer painterly stays gated while color grading propagates).

## Test plan
- [x] `scons platform=windows target=editor dev_build=yes tests=yes` builds clean.
- [x] `bin/godot.windows.editor.dev.x86_64.console.exe --headless --test --test-case="*color*grading*,*Shared renderer*"` passes (14 cases, 41 assertions). GPU-gated sub-assertions are skipped as expected in headless per the existing `[RequiresGPU]` pattern.
- [ ] Manual QA: open a scene with two `GaussianSplatNode3D` nodes sharing a renderer, assign different `ColorGradingResource` to each, confirm the property stays visible on both and the renderer reflects the most recently edited grading.
- [ ] Manual QA: load a `GaussianSplatWorld3D` scene, add a `GaussianSplatNode3D` under it, assign a grading on the node, confirm the grading is applied and the inspector property is visible.

## References
Addresses Issue 6 from the PR #220 residual-scope audit.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>