### PR TITLE
Ship a usable Windows nightly + sweep stale Linux-only docs + drop ODR test macro

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,7 +12,7 @@ GitHub's Actions tab can also show historical workflow names from past runs, dis
 | Docs Pages (Versioned) | `docs_pages.yml` | Builds and deploys MkDocs docs with mike versioning to `gh-pages`. | Publishes `latest` from `master/main` and versioned docs from `v*` tags. |
 | Gaussian Production Gates | `gaussian_production_gates.yml` | Enforces guard checks, pipeline smoke, runtime validation, the blocking streaming gate, and optional non-blocking benchmark evidence surfaces. | Owns the single Windows build for validation workflows. `streaming-gpu-ci` is the canonical blocking GPU-backed streaming runtime gate; `openworld-proof-dev` and `openworld-proof-weekly` are evidence-only benchmark surfaces. |
 | Gaussian Shader Validation | `gaussian_shader_validation.yml` | Validates shader compile matrix and host/shader contract checks. | Focused shader CI gate. |
-| Release Builds | `release_builds.yml` | Builds Linux and Windows editors for CI artifacts, nightly prereleases, and optional stable-tag publishes. | Workflow capability covers Linux and Windows; visible public Releases are still Linux-only until the first Windows publish lands. |
+| Release Builds | `release_builds.yml` | Builds Linux and Windows editors for CI artifacts, nightly prereleases, and optional stable-tag publishes. | Publishes Linux tarballs and Windows zips on the nightly schedule and on `v*` tag pushes. |
 
 ## Manual Dispatch Inputs
 

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -326,28 +326,38 @@ jobs:
           }
           python -m SCons @args
 
-      - name: Resolve Godot binary
+      - name: Resolve Godot binaries
         id: godot_bin
         shell: pwsh
         run: |
-          $candidates = @(
-            "bin\godot.windows.editor.dev.x86_64.console.exe",
-            "bin\godot.windows.editor.dev.x86_64.exe",
-            "bin\godot.windows.editor.x86_64.console.exe",
-            "bin\godot.windows.editor.x86_64.exe"
-          )
-          $resolved = $null
-          foreach ($candidate in $candidates) {
-            if (Test-Path -LiteralPath $candidate) {
-              $resolved = (Resolve-Path -LiteralPath $candidate).Path
-              break
-            }
+          # Godot's Windows build emits a pair: the main GUI editor exe and a
+          # small *.console.exe launcher that re-spawns the main exe with stdout
+          # attached. Both must ship in the release zip. Without the main exe
+          # (~230 MB), the launcher (~160 KB) cannot find its sibling and the
+          # download is unusable.
+          $allExes = @(Get-ChildItem -Path "bin" -Filter "godot.windows.editor*.x86_64.exe" -File -ErrorAction SilentlyContinue)
+          $mainExes = @($allExes | Where-Object { $_.Name -notlike "*.console.exe" })
+          $consoleExes = @($allExes | Where-Object { $_.Name -like "*.console.exe" })
+
+          if ($mainExes.Count -eq 0) {
+            Write-Host "bin\ contents:"
+            Get-ChildItem -Path "bin" -ErrorAction SilentlyContinue | Format-Table Name, Length | Out-String | Write-Host
+            throw "Could not find main Godot editor exe in bin\ (looked for godot.windows.editor*.x86_64.exe excluding .console.exe)."
           }
-          if (-not $resolved) {
-            throw "Could not find built Godot binary in expected bin\ paths."
+
+          $main = ($mainExes | Sort-Object Name | Select-Object -First 1)
+          Write-Host "Resolved main editor: $($main.FullName) ($([math]::Round($main.Length / 1MB, 1)) MB)"
+          "main_path=$($main.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "main_name=$($main.Name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+          if ($consoleExes.Count -gt 0) {
+            $console = ($consoleExes | Sort-Object Name | Select-Object -First 1)
+            Write-Host "Resolved console wrapper: $($console.FullName) ($([math]::Round($console.Length / 1KB, 1)) KB)"
+            "console_path=$($console.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            "console_name=$($console.Name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          } else {
+            Write-Host "No .console.exe wrapper found; shipping main editor only."
           }
-          Write-Host "Resolved Godot binary: $resolved"
-          "path=$resolved" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Package artifacts + checksums
         id: package
@@ -356,9 +366,16 @@ jobs:
           $ErrorActionPreference = "Stop"
           New-Item -ItemType Directory -Force -Path dist | Out-Null
 
-          $binaryPath = "${{ steps.godot_bin.outputs.path }}"
-          $binaryName = Split-Path -Leaf $binaryPath
-          Copy-Item -LiteralPath $binaryPath -Destination (Join-Path "dist" $binaryName) -Force
+          $mainPath = "${{ steps.godot_bin.outputs.main_path }}"
+          $mainName = "${{ steps.godot_bin.outputs.main_name }}"
+          Copy-Item -LiteralPath $mainPath -Destination (Join-Path "dist" $mainName) -Force
+
+          $consolePath = "${{ steps.godot_bin.outputs.console_path }}"
+          $consoleName = "${{ steps.godot_bin.outputs.console_name }}"
+          $hasConsole = -not [string]::IsNullOrWhiteSpace($consolePath)
+          if ($hasConsole) {
+            Copy-Item -LiteralPath $consolePath -Destination (Join-Path "dist" $consoleName) -Force
+          }
 
           $versionLabel = "${{ needs.release_metadata.outputs.tag }}"
           if ([string]::IsNullOrWhiteSpace($versionLabel)) {
@@ -379,17 +396,28 @@ jobs:
             "publish=${{ needs.release_metadata.outputs.publish }}"
             "tag=${{ needs.release_metadata.outputs.tag }}"
             "commit=${{ github.sha }}"
-            "binary=$binaryName"
-            "generated_at_utc=$(Get-Date -AsUTC -Format o)"
+            "binary=$mainName"
           )
+          if ($hasConsole) {
+            $buildInfoLines += "console_binary=$consoleName"
+          }
+          $buildInfoLines += "generated_at_utc=$(Get-Date -AsUTC -Format o)"
           $buildInfoLines | Set-Content -Path $buildInfoPath -Encoding utf8
+
+          $filesToCompress = @($mainName, "BUILD-INFO.txt")
+          if ($hasConsole) {
+            $filesToCompress = @($mainName, $consoleName, "BUILD-INFO.txt")
+          }
 
           Push-Location $distPath
           try {
-            Compress-Archive -Path $binaryName, "BUILD-INFO.txt" -DestinationPath $archivePath -Force
+            Compress-Archive -Path $filesToCompress -DestinationPath $archivePath -Force
           } finally {
             Pop-Location
           }
+
+          $archiveSizeMB = [math]::Round((Get-Item $archivePath).Length / 1MB, 1)
+          Write-Host "Built archive $archiveName ($archiveSizeMB MB) containing: $($filesToCompress -join ', ')"
 
           $hash = Get-FileHash -Algorithm SHA256 -Path $archivePath
           "{0}  {1}" -f $hash.Hash.ToLower(), $archiveName | Out-File -FilePath $checksumPath -Encoding ascii

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -339,19 +339,37 @@ jobs:
           $mainExes = @($allExes | Where-Object { $_.Name -notlike "*.console.exe" })
           $consoleExes = @($allExes | Where-Object { $_.Name -like "*.console.exe" })
 
+          # A clean build (the runner does `git clean -ffdx` before invoking
+          # scons) produces exactly one main exe and at most one console
+          # wrapper per channel. Fail fast if the glob matches more than one
+          # main exe — it means bin\ has stale artifacts from a previous
+          # build with a different flavor, and silently picking one variant
+          # is what caused the original broken-zip bug this commit fixes.
           if ($mainExes.Count -eq 0) {
             Write-Host "bin\ contents:"
             Get-ChildItem -Path "bin" -ErrorAction SilentlyContinue | Format-Table Name, Length | Out-String | Write-Host
             throw "Could not find main Godot editor exe in bin\ (looked for godot.windows.editor*.x86_64.exe excluding .console.exe)."
           }
+          if ($mainExes.Count -gt 1) {
+            Write-Host "bin\ contents:"
+            Get-ChildItem -Path "bin" -ErrorAction SilentlyContinue | Format-Table Name, Length | Out-String | Write-Host
+            $mainNames = ($mainExes | ForEach-Object { $_.Name }) -join ", "
+            throw "Ambiguous main editor in bin\ — expected exactly one match for 'godot.windows.editor*.x86_64.exe' (excluding .console.exe), found $($mainExes.Count): $mainNames. Clean bin\ before rebuilding."
+          }
+          if ($consoleExes.Count -gt 1) {
+            Write-Host "bin\ contents:"
+            Get-ChildItem -Path "bin" -ErrorAction SilentlyContinue | Format-Table Name, Length | Out-String | Write-Host
+            $consoleNames = ($consoleExes | ForEach-Object { $_.Name }) -join ", "
+            throw "Ambiguous console wrapper in bin\ — expected at most one '*.console.exe', found $($consoleExes.Count): $consoleNames. Clean bin\ before rebuilding."
+          }
 
-          $main = ($mainExes | Sort-Object Name | Select-Object -First 1)
+          $main = $mainExes[0]
           Write-Host "Resolved main editor: $($main.FullName) ($([math]::Round($main.Length / 1MB, 1)) MB)"
           "main_path=$($main.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "main_name=$($main.Name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
-          if ($consoleExes.Count -gt 0) {
-            $console = ($consoleExes | Sort-Object Name | Select-Object -First 1)
+          if ($consoleExes.Count -eq 1) {
+            $console = $consoleExes[0]
             Write-Host "Resolved console wrapper: $($console.FullName) ($([math]::Round($console.Length / 1KB, 1)) KB)"
             "console_path=$($console.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
             "console_name=$($console.Name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ GodotGS is a Godot 4.5 fork with an in-tree Gaussian Splatting module for import
 
 Nightly editor builds for Linux and Windows are published as prereleases on GitHub. Pick the latest:
 
-- **[Latest nightly release](https://github.com/klausi3D/godotGS/releases/latest)** — `godotgs-windows-x86_64-<date>.zip` for Windows, `godotgs-linux-x86_64-<date>.tar.xz` for Linux
+- **[GitHub Releases](https://github.com/klausi3D/godotGS/releases)** — pick the most recent `nightly-YYYYMMDD` entry at the top. Each nightly includes `godotgs-windows-x86_64-<date>.zip` for Windows and `godotgs-linux-x86_64-<date>.tar.xz` for Linux.
 - macOS users currently need to [build from source](docs/BUILDING.md)
 
 No named stable (`v*`) release is published yet, so nightly is the only public install path today. See [Release Channels](docs/development/release-channels.md) for the full publishing model.

--- a/README.md
+++ b/README.md
@@ -2,19 +2,26 @@
 
 GodotGS is a Godot 4.5 fork with an in-tree Gaussian Splatting module for importing, rendering, and tuning splat-based scenes in the editor and at runtime.
 <video src="https://github.com/user-attachments/assets/71542f8d-ccf6-433c-b920-66fdf9ae8c84" autoplay loop muted playsinline></video>
+
+## Download
+
+Nightly editor builds for Linux and Windows are published as prereleases on GitHub. Pick the latest:
+
+- **[Latest nightly release](https://github.com/klausi3D/godotGS/releases/latest)** — `godotgs-windows-x86_64-<date>.zip` for Windows, `godotgs-linux-x86_64-<date>.tar.xz` for Linux
+- macOS users currently need to [build from source](docs/BUILDING.md)
+
+No named stable (`v*`) release is published yet, so nightly is the only public install path today. See [Release Channels](docs/development/release-channels.md) for the full publishing model.
+
 ## Current Status
 
 | Area | State |
 | --- | --- |
 | Maturity | Alpha |
-| Fastest public evaluation path | Linux nightly editor |
-| Windows | Release packaging path exists; public Releases are still Linux-only |
+| Public binaries | Linux nightly editor + Windows nightly editor |
 | macOS | Source build first |
-| Public binaries | Linux editor |
+| Stable release | Not yet published |
 | Compatibility truth | [Compatibility Matrix](docs/reference/compatibility-matrix.md) |
 | Performance truth | [Performance Dashboard](docs/performance/index.md) |
-
-No named non-nightly release is published yet. If you want the fastest way to evaluate the project, use the Linux nightly path first. The release workflow on this branch now packages Windows, but the visible public Releases surface is still Linux-only until the first Windows publish lands. macOS still starts with a source build.
 
 ## Who This Is For
 
@@ -31,7 +38,7 @@ No named non-nightly release is published yet. If you want the fastest way to ev
 
 ## Current Public Evidence
 
-- Compatibility snapshot: Windows is `editor-tested` on the self-hosted Vulkan Forward+ lane with `NVIDIA GeForce RTX 3090`; the release workflow on this branch now packages Windows, but the visible public Releases surface is still Linux-only. Linux is `sample-project-tested` on `ubuntu-24.04` with `xvfb` and `mesa-vulkan-drivers 25.2.8-0ubuntu0.24.04.1`; macOS is currently `build-supported`.
+- Compatibility snapshot: Windows is `editor-tested` on the self-hosted Vulkan Forward+ lane with `NVIDIA GeForce RTX 3090` and now ships a nightly editor zip. Linux is `sample-project-tested` on `ubuntu-24.04` with `xvfb` and `mesa-vulkan-drivers 25.2.8-0ubuntu0.24.04.1` and ships a nightly editor tarball. macOS is currently `build-supported`.
 - Benchmark snapshot: the public dashboard currently contains one committed `static_baseline` row at 74.0 average FPS and 15.62 ms P99 frame time.
 - Visual proof: real editor screenshots and short workflow clips are still pending. The current figures are technical diagrams, not product captures.
 

--- a/docs/.pages
+++ b/docs/.pages
@@ -1,6 +1,7 @@
 nav:
   - Start Here:
       - getting-started/index.md
+      - getting-started/downloads.md
       - getting-started/try-in-5-minutes.md
       - getting-started/installation.md
       - getting-started/quick-start.md

--- a/docs/contributor/reviewer-fast-path.md
+++ b/docs/contributor/reviewer-fast-path.md
@@ -15,7 +15,7 @@ This path is for reviewers, maintainers, and contributors who want to understand
 
 ## What To Check
 
-1. Confirm the project is still Alpha and that the preferred public evaluation path is Linux nightly. The workflow now packages Windows, but the visible public Windows release has not landed yet.
+1. Confirm the project is still Alpha and that nightly Linux and Windows editor builds are the public evaluation path. macOS still requires a source build.
 2. Read `ENGINE_PATCHES.md` before opening engine-root changes.
 3. Inspect `modules/gaussian_splatting/` for the module implementation that owns the fork delta.
 4. Use the sample project in `tests/examples/godot/test_project` to verify the current runtime path.

--- a/docs/contributor/reviewer-fast-path.md
+++ b/docs/contributor/reviewer-fast-path.md
@@ -37,4 +37,4 @@ python scripts/docs/release_acceptance.py
 
 - [Build from Source](../BUILDING.md) for a module-enabled editor from this fork.
 - [First Run](../getting-started/quick-start.md) for the sample-project path after the editor is built.
-- [Try in 5 Minutes](../getting-started/try-in-5-minutes.md) for the fastest nightly-first evaluation loop. Do not assume a Windows public binary is already visible on Releases.
+- [Try in 5 Minutes](../getting-started/try-in-5-minutes.md) for the fastest nightly-first evaluation loop; nightly Linux and Windows editor archives are published on Releases.

--- a/docs/development/release-channels.md
+++ b/docs/development/release-channels.md
@@ -8,16 +8,15 @@ Define how executable builds are distributed from this repository and what guara
 
 - Public GitHub releases are currently nightlies first.
 - The stable `v*` publish path exists in automation, but it is not the default public install track.
-- Visible public binaries currently cover the Linux editor only.
-- The release workflow on this branch now packages Windows as well, but that path is not yet visible on Releases until the first publish lands.
-- Preferred evaluation path: use the latest Linux nightly if it fits your environment, build from source on Windows until the public Windows publish exists, and build from source on macOS.
+- Visible public binaries cover the Linux editor (`tar.xz`) and the Windows editor (`zip`).
+- Preferred evaluation path: use the latest Linux or Windows nightly. macOS still requires building from source.
 
 ## Channels
 
 | Channel | Source | Current public reality | Intended audience | Stability expectation |
 | --- | --- | --- | --- | --- |
 | CI artifact | `.github/workflows/release_builds.yml` on PR/push | Builds Linux and Windows contributor artifacts, not a public install surface | Contributors validating branch changes | No compatibility guarantee; debugging/testing only |
-| Nightly prerelease | `.github/workflows/release_builds.yml` schedule/manual with `publish_channel=nightly` | Primary visible public binary channel at present; publishes Linux assets today and Windows assets once the first Windows publish lands | Early testers validating latest integration changes | May break at any time; not for production |
+| Nightly prerelease | `.github/workflows/release_builds.yml` schedule/manual with `publish_channel=nightly` | Primary visible public binary channel at present; publishes Linux and Windows editor assets every night | Early testers validating latest integration changes | May break at any time; not for production |
 | Stable tag path | Tag push `v*` or manual with `publish_channel=stable` | Automation path exists, but users should only treat it as active when a visible `v*` release is actually published | Later versioned drops and downstream integrators | Intended stable path when used, but not the default public install track |
 
 ## Trigger Model
@@ -26,7 +25,7 @@ Define how executable builds are distributed from this repository and what guara
 | --- | --- |
 | Pull request touching engine/module paths | Build the Linux editor on a GitHub-hosted runner and upload its contributor artifact. The Windows editor lane is intentionally skipped for pull requests because it runs on a self-hosted runner and must not execute untrusted PR code. |
 | Push to `master`/`main`/`develop` | Build Linux and Windows editors and upload contributor artifacts |
-| Nightly schedule (`30 2 * * *` UTC) | Build and publish nightly prerelease (`nightly-YYYYMMDD`) with Linux assets today and Windows assets once the first Windows publish lands, then prune old nightlies |
+| Nightly schedule (`30 2 * * *` UTC) | Build and publish nightly prerelease (`nightly-YYYYMMDD`) with Linux and Windows editor assets, then prune old nightlies |
 | Tag push (`v*`) | Build and publish a versioned stable-tag release with Linux and Windows assets when that path is intentionally used |
 | Manual dispatch | Optional publish mode: `none`, `nightly`, or `stable` |
 
@@ -47,7 +46,7 @@ Each publish includes:
 | Actions artifacts | Retention window is bounded by GitHub settings and this workflow's retention setting |
 | Public install guidance | Treat nightlies as the default public install path until a visible `v*` series exists on Releases/Tags |
 | Stable wording | Do not describe the repo as having a stable public channel unless a versioned release is actually visible |
-| Platform coverage (current) | Visible public binaries are Linux-only today; Windows packaging exists in the workflow but has not landed in Releases yet; macOS currently requires source builds |
+| Platform coverage (current) | Visible public binaries cover Linux and Windows editors; macOS currently requires source builds |
 
 ## Manual Examples
 

--- a/docs/getting-started/downloads.md
+++ b/docs/getting-started/downloads.md
@@ -1,0 +1,64 @@
+# Downloads
+
+Public binaries for godotGS are published as nightly prereleases on GitHub. There is no stable `v*` release yet — see [Release Channels](../development/release-channels.md) for the full publishing model.
+
+## Latest Nightly
+
+[**Open the latest nightly release**](https://github.com/klausi3D/godotGS/releases/latest)
+
+Each nightly contains the editor for both supported platforms plus integrity files:
+
+| Asset | Platform | Contents |
+| --- | --- | --- |
+| `godotgs-linux-x86_64-<tag>.tar.xz` | Linux x86_64 | Editor binary |
+| `godotgs-windows-x86_64-<tag>.zip` | Windows x86_64 | GUI editor (`.exe`) + console wrapper (`.console.exe`) |
+| `*.sha256` | both | SHA-256 checksum sidecars |
+| `BUILD-INFO.txt` | shared | Channel, commit hash, binary names, generation timestamp |
+
+macOS is not yet covered by a published binary — [Build from Source](../BUILDING.md).
+
+## Run It
+
+### Linux
+
+```bash
+tar -xJf godotgs-linux-x86_64-<tag>.tar.xz
+chmod +x godot.linuxbsd.editor.dev.x86_64
+./godot.linuxbsd.editor.dev.x86_64
+```
+
+### Windows
+
+Unzip and pick the variant that fits how you want to run the editor:
+
+- `godot.windows.editor.dev.x86_64.exe` — GUI editor with no console window. Use this for the normal editor experience.
+- `godot.windows.editor.dev.x86_64.console.exe` — same editor with a console window attached for stdout/stderr. Use this when debugging or when a script needs to capture editor output.
+
+Both binaries ship in the same zip; you can keep just one or both side-by-side.
+
+## Verify the Download
+
+Match the published checksum against your local file:
+
+```bash
+# Linux / WSL / git-bash
+sha256sum godotgs-windows-x86_64-<tag>.zip
+# compare to the contents of godotgs-windows-x86_64-<tag>.sha256
+```
+
+```powershell
+# Windows PowerShell
+Get-FileHash -Algorithm SHA256 .\godotgs-windows-x86_64-<tag>.zip
+```
+
+## Stability Expectations
+
+Nightlies are prereleases by design — they may break at any time. They are intended for evaluation, prototypes, and contributor work, not production. See the [stability column in Release Channels](../development/release-channels.md#channels) for the per-channel guarantees.
+
+## Building From Source
+
+Use [Build from Source](../BUILDING.md) when:
+
+- you are on macOS,
+- you need a custom build flavor (release-stripped, different optimizer settings, debug symbols, etc.),
+- or you want to reproduce a specific commit's binary.

--- a/docs/getting-started/downloads.md
+++ b/docs/getting-started/downloads.md
@@ -4,7 +4,7 @@ Public binaries for godotGS are published as nightly prereleases on GitHub. Ther
 
 ## Latest Nightly
 
-[**Open the latest nightly release**](https://github.com/klausi3D/godotGS/releases/latest)
+[**Open the Releases page**](https://github.com/klausi3D/godotGS/releases) and pick the most recent `nightly-YYYYMMDD` entry at the top. (There is no stable `v*` release yet, so GitHub's "latest release" shortcut does not resolve to a nightly; always use the list.)
 
 Each nightly contains the editor for both supported platforms plus integrity files:
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -22,11 +22,19 @@ Visual captures for the user journey are still pending, so the linked workflow p
 
 <div class="grid cards" markdown>
 
+- __Download a nightly editor__
+
+    ---
+
+    Get a Linux tarball or Windows zip from GitHub Releases. macOS users still need a source build.
+
+    [Open downloads](downloads.md)
+
 - __Try in 5 minutes__
 
     ---
 
-    Use the latest Linux or Windows nightly editor for the shortest honest evaluation loop through the public evaluator. macOS users still need a source build.
+    Use the latest Linux or Windows nightly editor for the shortest honest evaluation loop through the public evaluator.
 
     [Open try in 5 minutes](try-in-5-minutes.md)
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -10,7 +10,7 @@ hide:
 
 Reach a first visible splat quickly and decide whether godotGS is the right evaluation target for your project.
 
-Alpha today. Linux nightly is the fastest evaluation path, the Windows release packaging path exists in the workflow but is not yet visible on Releases, and macOS still means building from source.
+Alpha today. Linux and Windows nightly editor builds are published on GitHub Releases; macOS still means building from source.
 
 Visual captures for the user journey are still pending, so the linked workflow pages stay text-first until real editor screenshots are available.
 
@@ -26,7 +26,7 @@ Visual captures for the user journey are still pending, so the linked workflow p
 
     ---
 
-    Use the Linux nightly editor path when you want the shortest honest evaluation loop through the public evaluator; Windows users still need a source build until the first Windows public release lands.
+    Use the latest Linux or Windows nightly editor for the shortest honest evaluation loop through the public evaluator. macOS users still need a source build.
 
     [Open try in 5 minutes](try-in-5-minutes.md)
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -16,7 +16,7 @@ Use this page when you need prerequisites, toolchain setup, or an editor built f
 
 | Option | When to use it | Next step |
 | --- | --- | --- |
-| Reuse a public or local editor | You already have a Linux nightly or a binary you built locally. Windows release packaging exists in the workflow, but a visible public Windows release is not yet available. | [Public Evaluator](quick-start.md) |
+| Reuse a public or local editor | You already have a nightly editor download or a binary you built locally. See [Downloads](downloads.md) for the public nightly binaries. | [Public Evaluator](quick-start.md) |
 | Build an editor locally | You need a fresh binary from this checkout, or you are on macOS and need a source build. | [Build from Source](../BUILDING.md) |
 | Build an editor for validation | You plan to run guard, QA, or runtime validation commands. | [Build / Test / CI Command Reference](../reference/build-test-ci.md) |
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -16,7 +16,7 @@ export GODOT_BINARY=/absolute/path/to/your/godot-editor
 $env:GODOT_BINARY="C:\absolute\path\to\your\godot-editor.exe"
 ```
 
-Need a binary first? Grab the [latest nightly](https://github.com/klausi3D/godotGS/releases/latest) — Linux tarball or Windows zip. macOS users [Build from Source](../BUILDING.md), then come back here and set `GODOT_BINARY` to the binary you have.
+Need a binary first? Open [GitHub Releases](https://github.com/klausi3D/godotGS/releases) and grab the most recent `nightly-YYYYMMDD` prerelease — Linux tarball or Windows zip. macOS users [Build from Source](../BUILDING.md), then come back here and set `GODOT_BINARY` to the binary you have.
 
 After a successful build, point `GODOT_BINARY` at the editor binary:
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -16,7 +16,7 @@ export GODOT_BINARY=/absolute/path/to/your/godot-editor
 $env:GODOT_BINARY="C:\absolute\path\to\your\godot-editor.exe"
 ```
 
-Need a binary first? Use the Linux nightly editor. The Windows release path exists in the workflow, but a public Windows release has not landed yet; if you are on Windows and need an editor today, use [Build from Source](../BUILDING.md). If you are on macOS, use [Build from Source](../BUILDING.md), then come back here and set `GODOT_BINARY` to the binary you have.
+Need a binary first? Grab the [latest nightly](https://github.com/klausi3D/godotGS/releases/latest) — Linux tarball or Windows zip. macOS users [Build from Source](../BUILDING.md), then come back here and set `GODOT_BINARY` to the binary you have.
 
 After a successful build, point `GODOT_BINARY` at the editor binary:
 

--- a/docs/getting-started/try-in-5-minutes.md
+++ b/docs/getting-started/try-in-5-minutes.md
@@ -1,14 +1,16 @@
 # Try in 5 Minutes
 
-This is the shortest honest path to a visible result: download the Linux nightly editor, open the sample project, and confirm the public evaluator in the viewport. The Windows release path exists in the workflow, but a public Windows release has not landed yet, so Windows users should use [Build from Source](../BUILDING.md) for now. macOS still starts with [Build from Source](../BUILDING.md).
+This is the shortest honest path to a visible result: download the latest nightly editor for your platform, open the sample project, and confirm the public evaluator in the viewport. macOS still starts with [Build from Source](../BUILDING.md).
 
-## 1. Get the Linux Nightly Editor
+## 1. Get the Nightly Editor
 
-Open the repository releases page and download the newest Linux nightly editor archive:
+Open the [latest nightly release](https://github.com/klausi3D/godotGS/releases/latest) and download the archive that matches your platform:
 
-- [GitHub Releases](https://github.com/klausi3D/godotGS/releases)
+- **Linux:** `godotgs-linux-x86_64-<date>.tar.xz`
+- **Windows:** `godotgs-windows-x86_64-<date>.zip` (contains both the GUI editor and the console wrapper — pick whichever fits your workflow)
+- **macOS:** no published binary; stop here and use [Build from Source](../BUILDING.md).
 
-If you are on Windows, stop here and use [Build from Source](../BUILDING.md). The Windows release path is already wired into the workflow, but it is not yet visible on Releases. If you are on macOS, stop here and use [Build from Source](../BUILDING.md).
+See the [Downloads page](downloads.md) for verification and integrity-check details.
 
 ## 2. Open the Project
 

--- a/docs/getting-started/try-in-5-minutes.md
+++ b/docs/getting-started/try-in-5-minutes.md
@@ -4,7 +4,7 @@ This is the shortest honest path to a visible result: download the latest nightl
 
 ## 1. Get the Nightly Editor
 
-Open the [latest nightly release](https://github.com/klausi3D/godotGS/releases/latest) and download the archive that matches your platform:
+Open the [GitHub Releases](https://github.com/klausi3D/godotGS/releases) page, pick the most recent `nightly-YYYYMMDD` entry at the top of the list, and download the archive that matches your platform:
 
 - **Linux:** `godotgs-linux-x86_64-<date>.tar.xz`
 - **Windows:** `godotgs-windows-x86_64-<date>.zip` (contains both the GUI editor and the console wrapper — pick whichever fits your workflow)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,9 +25,9 @@ godotGS is a Godot 4.5 fork with an in-tree Gaussian Splatting module for import
 
 ### Current Status
 
-- Preferred install path: Linux nightly for the fastest evaluation path, with the Windows release packaging path present in the workflow but the visible public Releases surface still Linux-only, and [Build from Source](BUILDING.md) still required on macOS.
+- Preferred install path: download the [latest nightly](https://github.com/klausi3D/godotGS/releases/latest) — Linux tarball or Windows zip. macOS still requires [Build from Source](BUILDING.md).
 - Release reality: public GitHub releases are currently nightly-first, and no named stable series is published yet.
-- Binary coverage: visible public binaries currently cover the Linux editor only.
+- Binary coverage: nightly Linux and Windows editors are published as prereleases.
 - Usage fit: evaluation, prototypes, and contributor work.
 
 </div>
@@ -36,7 +36,7 @@ godotGS is a Godot 4.5 fork with an in-tree Gaussian Splatting module for import
 
 ## Start Here
 
-1. [Choose the current install path](getting-started/installation.md): Linux nightly for the fastest evaluation path, the workflow-backed Windows release path is not yet visible on Releases, and [Build from Source](BUILDING.md) on macOS and for custom binaries.
+1. [Choose the current install path](getting-started/installation.md): nightly Linux or Windows editor from [Releases](https://github.com/klausi3D/godotGS/releases/latest), or [Build from Source](BUILDING.md) on macOS and for custom binaries.
 2. [Run First Run and reach a first visible splat](getting-started/quick-start.md).
 3. [Check platform status](reference/compatibility-matrix.md), [release-channel reality](development/release-channels.md), and [known recurring issues](troubleshooting/recurring-issues.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ godotGS is a Godot 4.5 fork with an in-tree Gaussian Splatting module for import
 
 ### Current Status
 
-- Preferred install path: download the [latest nightly](https://github.com/klausi3D/godotGS/releases/latest) — Linux tarball or Windows zip. macOS still requires [Build from Source](BUILDING.md).
+- Preferred install path: open the [GitHub Releases](https://github.com/klausi3D/godotGS/releases) page and pick the most recent `nightly-YYYYMMDD` prerelease — Linux tarball or Windows zip. macOS still requires [Build from Source](BUILDING.md).
 - Release reality: public GitHub releases are currently nightly-first, and no named stable series is published yet.
 - Binary coverage: nightly Linux and Windows editors are published as prereleases.
 - Usage fit: evaluation, prototypes, and contributor work.
@@ -36,7 +36,7 @@ godotGS is a Godot 4.5 fork with an in-tree Gaussian Splatting module for import
 
 ## Start Here
 
-1. [Choose the current install path](getting-started/installation.md): nightly Linux or Windows editor from [Releases](https://github.com/klausi3D/godotGS/releases/latest), or [Build from Source](BUILDING.md) on macOS and for custom binaries.
+1. [Choose the current install path](getting-started/installation.md): nightly Linux or Windows editor from [Releases](https://github.com/klausi3D/godotGS/releases), or [Build from Source](BUILDING.md) on macOS and for custom binaries.
 2. [Run First Run and reach a first visible splat](getting-started/quick-start.md).
 3. [Check platform status](reference/compatibility-matrix.md), [release-channel reality](development/release-channels.md), and [known recurring issues](troubleshooting/recurring-issues.md).
 

--- a/docs/reference/compatibility-matrix.md
+++ b/docs/reference/compatibility-matrix.md
@@ -1,6 +1,6 @@
 # Compatibility Matrix
 
-Last generated: 2026-04-08
+Last generated: 2026-04-16
 
 ## Purpose
 Use this matrix to track evidence-backed platform status for godotGS Gaussian Splatting.
@@ -31,7 +31,7 @@ The state shown for each platform is the strongest evidence level currently docu
 
 | Platform | Current state | Public binaries | Evidence | Notes |
 | --- | --- | --- | --- | --- |
-| Windows | `editor-tested` | The release workflow on this branch now packages Windows, but visible public Releases are still Linux-only until the first Windows publish lands. | SUPPORTED_PLATFORMS in modules/gaussian_splatting/config.py accepts windows.<br>Gaussian Production Gates builds a Windows editor and runs windows-vulkan runtime validation in .github/workflows/gaussian_production_gates.yml.<br>Release Builds compiles and publishes the Windows editor in .github/workflows/release_builds.yml.<br>The production evidence route in tests/ci/collect_production_evidence.ps1 exercises non-headless Vulkan runtime scripts on Windows. | Windows is the strongest in-repo validation lane currently, but visible public Releases are still Linux-only until the first Windows publish lands. |
+| Windows | `editor-tested` | Nightly Windows editor zips published to GitHub Releases (godotgs-windows-x86_64-<tag>.zip). | SUPPORTED_PLATFORMS in modules/gaussian_splatting/config.py accepts windows.<br>Gaussian Production Gates builds a Windows editor and runs windows-vulkan runtime validation in .github/workflows/gaussian_production_gates.yml.<br>Release Builds compiles and publishes the Windows editor in .github/workflows/release_builds.yml.<br>The production evidence route in tests/ci/collect_production_evidence.ps1 exercises non-headless Vulkan runtime scripts on Windows. | Windows is the strongest in-repo validation lane and now ships nightly editor zips. No stable v* release is published yet. |
 | Linux | `sample-project-tested` | Primary fast public binary lane: Linux editor CI artifacts and nightly prereleases. | SUPPORTED_PLATFORMS in modules/gaussian_splatting/config.py accepts linuxbsd.<br>Release Builds compiles and publishes the Linux editor in .github/workflows/release_builds.yml.<br>Baseline QA builds a Linux editor, imports the project, and runs baseline QA under xvfb in .github/workflows/baseline_qa.yml. | Linux remains the fastest public evaluation path. The documented validation includes a sample-project QA lane under xvfb, but it is still not an interactive editor validation row. |
 | macOS | `build-supported` | No public macOS binaries at present; build from source. | SUPPORTED_PLATFORMS in modules/gaussian_splatting/config.py accepts macos. | The repo allows macOS builds, but no published smoke, editor, or sample-project evidence is checked in yet. |
 | Android | `unsupported` | None. | Android is not listed in SUPPORTED_PLATFORMS in modules/gaussian_splatting/config.py. | The build system rejects this platform. |

--- a/docs/reference/compatibility_sources.yaml
+++ b/docs/reference/compatibility_sources.yaml
@@ -9,13 +9,13 @@ status_levels:
 platforms:
   Windows:
     state: editor-tested
-    public_binaries: "The release workflow on this branch now packages Windows, but visible public Releases are still Linux-only until the first Windows publish lands."
+    public_binaries: "Nightly Windows editor zips published to GitHub Releases (godotgs-windows-x86_64-<tag>.zip)."
     evidence:
       - "SUPPORTED_PLATFORMS in modules/gaussian_splatting/config.py accepts windows."
       - "Gaussian Production Gates builds a Windows editor and runs windows-vulkan runtime validation in .github/workflows/gaussian_production_gates.yml."
       - "Release Builds compiles and publishes the Windows editor in .github/workflows/release_builds.yml."
       - "The production evidence route in tests/ci/collect_production_evidence.ps1 exercises non-headless Vulkan runtime scripts on Windows."
-    notes: "Windows is the strongest in-repo validation lane currently, but visible public Releases are still Linux-only until the first Windows publish lands."
+    notes: "Windows is the strongest in-repo validation lane and now ships nightly editor zips. No stable v* release is published yet."
   Linux:
     state: sample-project-tested
     public_binaries: "Primary fast public binary lane: Linux editor CI artifacts and nightly prereleases."

--- a/docs/reports/ci_release_audit_2026-04-16.md
+++ b/docs/reports/ci_release_audit_2026-04-16.md
@@ -1,0 +1,211 @@
+# CI & Windows Release Audit — 2026-04-16
+
+**Branch:** `investigate/ci-and-windows-release` (worktree at `C:/projects/godotgs-ci-audit`)
+**Base:** master @ `b93ba6ef92` (current master tip @ `63d990eb10` — commit `b93ba6ef92` is one revert behind tip)
+**Repo under audit:** `klausi3D/godotGS` (the fork; not upstream `godotengine/godot`)
+
+---
+
+## TL;DR
+
+1. **A Windows zip IS being published.** The `nightly-20260416` release (today, 03:53 UTC) contains `godotgs-windows-x86_64-nightly-20260416.zip`. This is the **first** nightly to include a Windows artifact. Yesterday's `nightly-20260415` and earlier were Linux-only. The `release_builds.yml` Windows lane is now wired through end-to-end.
+2. **README is stale.** `README.md` still says "public Releases are still Linux-only until the first Windows publish lands" — that publish landed today. Same stale claim in `.github/workflows/README.md:15`.
+3. **3 of 4 master CI workflows are red on the latest push** (`63d990eb10`, PR #245). Two failures point at real code-level issues (one Linux-only ODR error from `#define private public`, one module test failure on Windows). One failure is a simple broken docs link — fixed in this audit branch.
+4. **No README → download path exists for end users.** README links to docs but never names "Releases" or links the GitHub Releases page. A first-time user has no obvious path to the Windows zip.
+
+---
+
+## 1. Workflow Inventory
+
+5 active workflows in `.github/workflows/` plus 5 archived in `.github/archived-workflows/`.
+
+| Workflow | File | Triggers | Purpose | Latest master status |
+| --- | --- | --- | --- | --- |
+| Release Builds | `release_builds.yml` | push (master/main/develop on src paths), PR (same), tag `v*`, schedule `30 2 * * *`, dispatch | Build Linux (ubuntu-latest) + Windows (self-hosted) editor; package to `.tar.xz` / `.zip`; nightly publish to GitHub Releases; prune old nightlies | ✅ success (38m18s, run 24506709811) — produced `godotgs-linux-ci-249` and `godotgs-windows-ci-249` artifacts |
+| Baseline QA Automation | `baseline_qa.yml` | push (master/develop/feature/phase on `modules/gaussian_splatting/**`/`tests/**`), PR (master/develop), merge_group, schedule `30 3 * * *`, dispatch | Linux CPU job (ubuntu-latest, full build + headless QA categories `ply,pipeline,runtime,module`) + Windows GPU job (self-hosted, `sorting` category) | ❌ failure (run 24506709782) — Linux build failed, Windows passed |
+| Gaussian Production Gates | `gaussian_production_gates.yml` | PR (master), push (master/develop), merge_group, schedule `30 3 * * 1` (weekly), dispatch | Guards (Windows self-hosted) → GPU evidence requirement (Linux compute) → Module Build + Runtime Harness (Windows self-hosted self-hosted GPU) → optional openworld-proof evidence | ❌ failure (run 24506709800) — `Run module tests` failed |
+| Docs Pages (Versioned) | `docs_pages.yml` | push (master/main on `docs/**`/scripts/mkdocs/module), tag `v*`, dispatch | mkdocs build (`--strict`) + mike deploy to `gh-pages` (`latest` from master, versioned from `v*` tags) | ❌ failure (run 24506709793) — mkdocs strict mode aborted on broken intra-docs link |
+| Gaussian Shader Validation | `gaussian_shader_validation.yml` | PR + push (master/develop) on shader/renderer paths, merge_group, dispatch | Shader compile matrix + contracts on self-hosted Windows runner | (no recent run — gated path didn't trigger; not in this push's check set) |
+
+Archived (in `.github/archived-workflows/`, suffix `.disabled` so GitHub ignores them): `benchmark.yml`, `build-engine.yml`, `gaussian_pipeline_validation.yml`, `test_gaussian_splatting.yml`, `test_phase4.yml`. Each tracked in `.github/workflows/README.md:54-58`.
+
+The `.github/workflows/README.md` file is well-maintained and authoritative — it lists triggers, dispatch inputs, schedules, and dependencies. Match against actual yml files: ✅ accurate as of `b93ba6ef92`.
+
+---
+
+## 2. Master Failure Diagnosis
+
+All three failures are on commit `63d990eb10` (PR #245 "fix: per-node color grading independence"), pushed to master at 11:03 UTC. The `Release Builds` workflow on the same commit succeeded.
+
+### 2.1 Docs Pages — broken link in `docs/reports/index.md` ⚠️ FIXED IN THIS AUDIT
+
+**Run:** [`24506709793`](https://github.com/klausi3D/godotGS/actions/runs/24506709793) — failed in `Validate MkDocs build (strict)` after 2m05s.
+
+**Root cause:** `docs/reports/index.md:7` links to `streaming_remaining_architecture_issue_backlog_2026-04-10.md`, which doesn't exist anywhere in the tree (verified by Grep). `mkdocs build --strict` (workflow line 75) treats unresolved intra-docs links as fatal:
+
+```
+WARNING - Doc file 'reports/index.md' contains a link 'streaming_remaining_architecture_issue_backlog_2026-04-10.md',
+          but the target 'reports/streaming_remaining_architecture_issue_backlog_2026-04-10.md' is not found
+          among documentation files.
+Aborted with 1 warnings in strict mode!
+##[error]Process completed with exit code 1.
+```
+
+The two sibling roadmap docs (`streaming_tier2_execution_roadmap_2026-04-09.md`, `streaming_tier2_phase4c1_issue_backlog_2026-04-09.md`) exist; only the `2026-04-10` backlog file is missing. `git log --all` shows no record of that file ever being committed — the index entry was added speculatively.
+
+**Classification:** Misconfigured docs (stale link), not a code regression.
+
+**Fix:** Removed the dead link in `docs/reports/index.md`. Committed in this audit branch (see §5).
+
+### 2.2 Baseline QA Automation (Linux CPU lane) — `#define private public` GCC ODR error ❌ NEEDS USER REVIEW
+
+**Run:** [`24506709782`](https://github.com/klausi3D/godotGS/actions/runs/24506709782) — Linux job failed in `Build module-enabled Godot editor` after 6m18s. Windows GPU lane (sorting category) passed.
+
+**Root cause:** Compilation of `modules/gaussian_splatting/tests/test_gaussian_streaming_lifecycle.cpp` fails with:
+
+```
+./core/templates/list.h:223:9: error: 'struct List<T, A>::_Data' redeclared with different access
+./core/templates/rb_map.h:196:9: error: 'struct RBMap<K, V, C, A>::_Data' redeclared with different access
+./core/templates/rb_set.h:167:9: error: 'struct RBSet<T, C, A>::_Data' redeclared with different access
+./core/io/resource_loader.h:176:9: error: 'struct ResourceLoader::ThreadLoadTask' redeclared with different access
+scons: *** [bin/obj/modules/gaussian_splatting/tests/test_gaussian_streaming_lifecycle.linuxbsd.editor.dev.x86_64.o] Error 1
+```
+
+The test file at `modules/gaussian_splatting/tests/test_gaussian_streaming_lifecycle.cpp:1-5` does:
+
+```cpp
+#define _ALLOW_KEYWORD_MACROS
+#define private public
+#include "../core/gaussian_streaming.h"
+#undef private
+```
+
+`gaussian_streaming.h` transitively pulls Godot core templates (`list.h`, `rb_map.h`, `rb_set.h`, `resource_loader.h`). With `private` redefined to `public` during that include, the inner `_Data` / `ThreadLoadTask` structs end up declared with `public` access. Other TUs see them with `private`. GCC under strict flags treats this as ODR violation; MSVC silently merges them, which is why the Windows lane passes.
+
+**Classification:** Real code regression in this fork's test code, Linux-only. Same family as the documented `MSVC PMF forward-decl ODR trap` (project memory) — different mechanism, same root cause (test code reaching into private state via header trickery).
+
+**Fix proposal:** Replace the `#define private public` hack with a proper test-only `friend` declaration in `gaussian_streaming.h`, or move the test to use only public API. **Do not band-aid.** This is the kind of issue the team has already paid for once with the PMF/ODR incident — worth fixing properly. Out of scope for this audit (touches module test surface and core header guarantees).
+
+### 2.3 Gaussian Production Gates — module test failure ❌ NEEDS USER REVIEW
+
+**Run:** [`24506709800`](https://github.com/klausi3D/godotGS/actions/runs/24506709800) — `Module Build + Runtime Harness (Windows Self-Hosted)` failed in `Run module tests` after 3m09s. Build succeeded, smoke tests succeeded.
+
+**Root cause (from log):**
+
+```
+[module-tests] 'GaussianSplatting [Editor]' failed.
+##[error]Process completed with exit code 1.
+```
+
+The doctest `GaussianSplatting [Editor]` suite fails. Per project memory (`project_test_baseline.md`), there are 4 pre-existing GaussianSplatting test failures proven on `d78d180c70`. **This may be a known-pre-existing failure.** Cannot confirm from CI log alone — it just reports the suite name failed without listing which test cases.
+
+**Fix proposal:** Verify against the documented test baseline. If this is one of the 4 known pre-existing failures, the gate should either be marked non-blocking or those tests should be quarantined with an explicit skip + tracking issue. If it's a *new* failure introduced by PR #245 (color grading per-node), it needs a code fix. The PR #245 area (color grading) is plausibly related to the `[Editor]` suite scope. Out of scope for this audit — the test runner output needs to be expanded to surface which doctest cases failed.
+
+### 2.4 Why was master red yesterday too?
+
+Looking back at the runs list: every master push since at least `2026-04-15 13:58Z` shows the same pattern — `Release Builds` ✅, `Baseline QA Automation` ❌, `Gaussian Production Gates` ❌, `Docs Pages` ❌. The failure mode is consistent with what's documented above (build error from `#define private public`, doctest failure, broken docs link). **None of these are flakes.**
+
+---
+
+## 3. Release Pipeline Audit
+
+### Where Windows builds are produced
+
+`release_builds.yml`, job `build_windows` (lines 272-407). Triggers on push (master/main/develop), tag `v*`, nightly schedule (`30 2 * * *`), and dispatch. **Does not** run on PRs (line 278: `if: github.event_name != 'pull_request'`) — this is a deliberate guard against running self-hosted Windows on untrusted PR code, which is correct.
+
+Build command (lines 313-327):
+```powershell
+python -m SCons platform=windows target=editor gs_native_arch=no \
+    cache_path=C:/godotgs-scons-cache cache_limit=50 -j12
+# + dev_build=yes tests=yes for non-stable channels
+```
+
+### Artifact format and location
+
+- **Format:** `godotgs-windows-x86_64-<tag>.zip` containing the editor binary + `BUILD-INFO.txt`. SHA256 sidecar `.sha256`.
+- **CI artifact (per run):** uploaded as `godotgs-windows-<channel>-<run_number>` to the workflow artifacts dropdown (14-day retention, lines 400-407).
+- **Public release attachment:** when `publish=true` (nightly schedule or `v*` tag), `softprops/action-gh-release@v2` (lines 437-453) attaches the Windows zip + sha256 to a GitHub Release on `klausi3D/godotGS`.
+
+### Existing GitHub Releases
+
+20 releases on `klausi3D/godotGS`, all `nightly-YYYYMMDD` prereleases (no `v*` stable tags ever published). Sample audit:
+
+| Release | Linux tar.xz | Windows zip | Notes |
+| --- | --- | --- | --- |
+| nightly-20260416 (today) | ✅ | ✅ **first Windows publish** | Includes BUILD-INFO.txt, both sha256 sidecars |
+| nightly-20260415 | ✅ | ❌ Linux-only | |
+| nightly-20260406 | ✅ | ❌ Linux-only | |
+| (older nightlies) | ✅ | ❌ Linux-only | |
+
+The Windows publish landed today (2026-04-16 03:53 UTC) — likely the first night after PR #239 ("tier1 adoption path — public evaluator scene, Windows release packaging, docs", in nightly-20260416 changelog) reached master.
+
+### End-user reachability
+
+Walk the path a first-time visitor takes:
+
+1. Visit `https://github.com/klausi3D/godotGS` (1 click).
+2. Read README. The README mentions "Linux nightly editor" as the fastest evaluation path, never names "Releases" page, never links it. Lines 11/17/34 explicitly say Windows is *not* in public releases (now stale).
+3. To find the Windows zip, the user has to know to click the "Releases" sidebar link on the GitHub repo page, then expand the latest prerelease → scroll to assets → click `godotgs-windows-x86_64-nightly-20260416.zip`.
+
+**Click count:** 4-5 clicks, none of them signposted. The README actively misdirects users away from looking for a Windows download.
+
+---
+
+## 4. Gap Punch List (ordered by effort)
+
+### Easy (≤30 min, individually)
+
+1. **Update README to tell users where the Windows zip is.** Update lines 11, 17, 34 to reflect that Windows nightly zips now ship. Add a "Download" section at the top with a direct link to `https://github.com/klausi3D/godotGS/releases/latest`. ⚠️ User decision: phrasing/positioning of the alpha disclaimer.
+2. **Update `.github/workflows/README.md:15`** to drop "still Linux-only" caveat now that Windows is publishing.
+3. **Already done in this audit:** removed broken docs link in `docs/reports/index.md` (see §5).
+4. **Add Node.js 24 opt-in to workflows** to silence the deprecation warnings on every run. Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` at workflow `env:` level. Already done in `gaussian_shader_validation.yml:45` — the other four workflows haven't adopted it. Cosmetic but reduces noise; mandatory before September 2026 anyway.
+
+### Medium (1-3h)
+
+5. **Fix the `Run module tests` failure in `gaussian_production_gates.yml`.** Surface *which* doctest cases failed in the workflow log (currently the runner just prints `'GaussianSplatting [Editor]' failed`). If the failures match the 4 documented pre-existing ones, mark the suite continue-on-error or quarantine those specific cases with a tracking issue. If new, fix in code.
+6. **Make the test runner less opaque.** `tests/ci/run_module_tests.py` should print per-doctest pass/fail with a summary at the end, so failures surface in the GitHub Actions step summary, not just exit 1.
+7. **Wire a `Latest Windows Build` README badge** that points to `https://github.com/klausi3D/godotGS/releases/latest`. Trivial Markdown — but worth confirming with user that public links are wanted.
+
+### Larger (half-day or more)
+
+8. **Fix the Linux build error in `test_gaussian_streaming_lifecycle.cpp`.** Replace `#define private public` with proper friend declarations or restructure the test to use public APIs. Verify against full Linux QA suite. This is the same anti-pattern family as the previously documented `MSVC PMF forward-decl ODR trap` — worth doing right.
+9. **First stable release.** No `v*` tag has ever been pushed. The `release_builds.yml` workflow already supports stable tags (line 105-110: tag `v*` push → `channel=stable`, full build without `dev_build=yes`, attached to a non-prerelease release). Cutting `v0.1.0-alpha` would give end users a non-prerelease download to land on. Decision needed on naming + readiness.
+10. **Decide what "ready to ship" means** for the Windows binary. The current zip is a `dev_build=yes` editor (not optimized, not stripped, with debug assertions). For end-user evaluation that's fine; for a stable tag, the workflow already switches to the optimized `target=editor` build automatically (line 208). User decision: communicate to users that the nightly zip is dev-flavored.
+
+---
+
+## 5. Quick-Fix Commit Manifest
+
+One commit on `investigate/ci-and-windows-release`:
+
+| Commit | File(s) | Reason | Risk |
+| --- | --- | --- | --- |
+| (this audit's commit) | `docs/reports/index.md` (-1 line), `docs/reports/ci_release_audit_2026-04-16.md` (new) | Removes the broken link to a never-existed file. Unblocks `Docs Pages (Versioned)` workflow without touching content semantics. | Low — the deleted line pointed at a 404. No content lost (file never existed). |
+
+**Not auto-committed (deferred for user review):**
+
+- README changes about Windows availability — touches user-facing claims about project state, user should land that themselves with chosen messaging.
+- Workflows README "still Linux-only" line — same reasoning.
+- Node.js 24 opt-in — should be done as a coordinated single PR across all four workflows.
+
+---
+
+## 6. Decisions Needed From User
+
+1. **Where to link the Windows zip from the README** — direct link to releases page? Releases badge? A new "Downloads" section at the top of the README?
+2. **Whether to cut a stable `v0.1.0-alpha` (or similar) tag** to give end users a non-prerelease landing page. Workflow is ready; just needs tag + go-ahead.
+3. **How to handle the `Run module tests` failure** — quarantine known pre-existing tests vs. fix forward. Need to know if those 4 baseline failures are still authoritative.
+4. **Whether the `#define private public` test pattern should be eradicated** repo-wide or only in the file currently breaking. There may be other test files using the same trick that haven't yet broken on Linux.
+5. **Should the dev-flavored nightly Windows zip be marked clearly** as "developer build, not optimized" in the release body? `BUILD-INFO.txt` is in the zip but no end user looks inside before downloading.
+
+---
+
+## Appendix: Tools used
+
+- `gh run list --repo klausi3D/godotGS --branch master --limit 15`
+- `gh run view <id> --repo klausi3D/godotGS --log-failed`
+- `gh release view nightly-2026041{5,6} --repo klausi3D/godotGS`
+- `gh release list --repo klausi3D/godotGS --limit 20`
+- File reads on `.github/workflows/*.yml`, `README.md`, `docs/reports/index.md`, `modules/gaussian_splatting/tests/test_gaussian_streaming_lifecycle.cpp`
+
+**Important:** the local `gh` config defaults to `godotengine/godot` (upstream) in this worktree because the `audit` remote points at upstream. All `gh` calls in this audit explicitly used `--repo klausi3D/godotGS` to target the fork. Future investigators should do the same or set `gh repo set-default klausi3D/godotGS` in the worktree.

--- a/docs/reports/index.md
+++ b/docs/reports/index.md
@@ -4,7 +4,6 @@ Use these pages as supporting records, not as the primary entry point for the cu
 
 - [Streaming Tier 2 Execution Roadmap - 2026-04-09](streaming_tier2_execution_roadmap_2026-04-09.md)
 - [Streaming Tier 2 Phase 4C.1 Issue Backlog - 2026-04-09](streaming_tier2_phase4c1_issue_backlog_2026-04-09.md)
-- [Streaming Remaining Architecture Issue Backlog - 2026-04-10](streaming_remaining_architecture_issue_backlog_2026-04-10.md)
 - [Latest Assessment](latest-assessment.md)
 - [Documentation Assessment Report (Historical Snapshot)](docs_assessment_2026-03-19.md)
 - [Documentation Remediation Summary (Historical Snapshot)](docs_remediation_summary.md)


### PR DESCRIPTION
## Summary

Four focused commits from an audit (also included as `docs/reports/ci_release_audit_2026-04-16.md`). The headline finding was that nightly Windows zips were shipping only the **161 KB console-launcher stub** instead of the **~230 MB editor** — anyone downloading the Windows nightly got a broken archive.

### Commits in order

1. **`docs: CI/release audit + drop broken reports/index link`** — adds the audit report and removes a dead `reports/index.md` link to a never-existed file (was breaking `mkdocs --strict` on every Docs Pages run).
2. **`fix(ci): ship the actual Windows editor in release zip`** — `release_builds.yml` resolved `bin/godot.windows.editor*.exe` in priority order and stopped at the first match (the console launcher), so the real editor never made it into the zip. Now globs both flavors and packs them together.
3. **`docs: surface nightly Windows editor download`** — sweeps stale "Linux-only" claims across `README.md`, `docs/index.md`, `docs/getting-started/{index,try-in-5-minutes,quick-start}.md`, `docs/development/release-channels.md`, `docs/contributor/reviewer-fast-path.md`, `docs/reference/compatibility_sources.yaml` (regenerated `compatibility-matrix.md`), and `.github/workflows/README.md`. README adds a `Download` section linking `releases/latest`.
4. **`docs: add Downloads page under Start Here`** — new `docs/getting-started/downloads.md` is the canonical "where do I get a binary" page; lists archive contents (incl. the `.exe` vs `.console.exe` choice on Windows), per-platform unpack commands, SHA-256 verification.

### What changed since the original PR

The fifth original commit (`fix(test): drop #define private public from streaming lifecycle test`) was cherry-picked into PR #250 to keep that sweep complete in one PR, and #250 has since merged. Rebasing this branch on master auto-dropped that commit ("patch contents already upstream"). Net effect: the lifecycle macro fix is on master already; this PR is now strictly Windows release packaging + docs sweep.

## Verification request

The packaging fix can't be tested without running the workflow on the self-hosted runner. Two options:

- **Cheap:** `workflow_dispatch` Release Builds on this branch with `publish_channel=none` — uploads as an Actions artifact (no public release), confirm the zip is ~80–100 MB and contains both `.exe` files.
- **Cheaper:** merge to master and let the next nightly verify (02:30 UTC).

## Test plan

- [ ] (Recommended) Trigger Release Builds via `workflow_dispatch` on this branch with `publish_channel=none`; download the `godotgs-windows-...` artifact and confirm it contains `godot.windows.editor.dev.x86_64.exe` (~230 MB) plus `godot.windows.editor.dev.x86_64.console.exe` plus `BUILD-INFO.txt`.
- [ ] Verify Docs Pages (Versioned) workflow turns green on this branch (broken `reports/index.md` link is fixed).
- [ ] Spot-check the Downloads page renders on the staged docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)