### PR TITLE
fix: editor startup investigation + import deadlock fix

### DIFF
--- a/docs/reports/editor_startup_investigation_2026-04-16.md
+++ b/docs/reports/editor_startup_investigation_2026-04-16.md
@@ -1,0 +1,197 @@
+# Editor Startup Investigation (2026-04-16)
+
+## Summary
+
+Investigated a reported regression where the Godot editor in this fork
+became "slow to start up and noticeably laggy/unresponsive in the last
+1-2 days." Working from the benchmark snapshot captured at
+`.tmp-editor-bench.json` (cold run: `[Servers] Rendering = 21.30s`,
+`Main::Setup2 = 24.85s`), measured master HEAD (`b93ba6ef92`) against
+the suspected baseline `7c9a815f03` (streaming tier 2 / #229) on
+Windows, dev_build, debug_symbols, with a full rebuild for each.
+
+**No startup regression was found between the two commits.** Cold
+startup cost is essentially identical (within <1%), and the dominant
+cost is shader compilation during Godot's `rendering_server->init()` —
+engine-internal work that the Gaussian Splatting module does not
+contribute to.
+
+## Benchmark data
+
+Measurements taken with:
+
+```
+bin/godot.windows.editor.dev.x86_64.console.exe \
+  --path tests/examples/godot/test_project \
+  --benchmark --quit-after 1
+```
+
+| Phase                  | #229 cold | HEAD cold | HEAD warm (2nd run) |
+|------------------------|-----------|-----------|---------------------|
+| `[Servers] Rendering`  | 21.44s    | 20.72s    | 3.10s               |
+| `[Servers]` (total)    | 23.35s    | 22.57s    | 5.03s               |
+| `[Startup] Main::Setup2` | 24.67s  | 24.30s    | 6.32s               |
+
+Cold / warm distinction: "cold" = shader cache (`AppData\Roaming\Godot\
+app_userdata\GaussianSplattingTest\shader_cache`) wiped before run;
+"warm" = cache from a prior successful run present.
+
+The user's bench file (`.tmp-editor-bench.json`) at 21.30s rendering
+matches the cold profile almost exactly. HEAD is actually very slightly
+faster than #229 on both cold and warm runs, so the observation that
+the editor became *slower* in the last 1-2 days is not supported by
+measurement on the two reference commits.
+
+## Where the 21s cold window actually goes
+
+With `--verbose --benchmark` against a wiped cache, every shader
+emits a `Shader '<name>' ... SHA256: ...` / `Shader cache miss for
+<name>/...` line in order of compilation. Cross-referencing the
+benchmark closing line (`- Rendering: 20626.087 msec.`) with the
+shader log shows that the following shaders compile **before** the
+Rendering benchmark closes (all engine-internal Godot shaders, not
+ours):
+
+- Canvas: `CanvasSdfShaderRD`, `CanvasShaderRD`, `CanvasOcclusionShaderRD`
+- Scene skeleton/particles: `SkeletonShaderRD`, `SortShaderRD`,
+  `ParticlesShaderRD`, `ParticlesCopyShaderRD`
+- Forward+ core: `ClusterRenderShaderRD`, `ClusterStoreShaderRD`,
+  `ClusterDebugShaderRD`, `SceneForwardClusteredShaderRD` (4 groups,
+  3 variants each on the hot path)
+- PBR/Normals: `BestFitNormalShaderRD`, `IntegrateDfgShaderRD`
+- Resolve/TAA/FSR2/FSR: `ResolveShaderRD`, `TaaResolveShaderRD`,
+  `Fsr2*ShaderRD` (8 stages), `FsrUpscaleShaderRD`
+- Screen-space effects: `SsEffectsDownsampleShaderRD`, `Ssil*ShaderRD`
+  (4), `Ssao*ShaderRD` (4), `ScreenSpaceReflection*ShaderRD` (3)
+- SSS/Sky/GI: `SubsurfaceScatteringShaderRD`, `SkyShaderRD`,
+  `VoxelGi*ShaderRD` (2), `Sdfgi*ShaderRD` (5), `GiShaderRD`
+- Volumetric: `VolumetricFog*ShaderRD` (2 × 4 groups)
+- Post: `BokehDofShaderRD`, `Copy*ShaderRD` (2), `Cubemap*ShaderRD`
+  (3), `SpecularMergeShaderRD`, `ShadowFrustumShaderRD`,
+  `MotionVectorsShaderRD`, `LuminanceReduceShaderRD`, `Smaa*ShaderRD`
+  (3), `TonemapShaderRD`, `VrsShaderRD`, `BlitShaderRD`
+
+That is ~50 engine shaders compiling serially under dev_build with
+debug_symbols, which is the known-slow mode for shader compilation
+because the GLSL compiler runs at low optimization inside an
+unoptimized Godot. At roughly 300-500 ms per shader on cold cache,
+20-21s is consistent.
+
+**Our module's shaders compile *after* the Rendering benchmark
+closes**, during scene load / first render_scene_instance — the
+verbose output confirms `SobelOutlineShaderRD`, `BrushAccumulateShaderRD`,
+`GaussianSplatShaderRD`, `TileBinningShaderRD`, `TileRasterizerShaderRD`,
+`TileRasterizerComputeShaderRD`, `TilePrefixScanShaderRD`,
+`TileResolveShaderRD`, `FrustumCullShaderRD`, `DepthComputeShaderRD`,
+`InstanceCountClampShaderRD`, `InstanceChunkDispatchShaderRD` all
+print after `- Rendering: 20626.087 msec.`. These compiles land in
+`[Startup] Load Game` / `Main::Start`, not in `[Servers] Rendering`.
+
+## What does not appear to be happening
+
+- No heavy work in `register_types.cpp` at `MODULE_INITIALIZATION_LEVEL_SERVERS`
+  (the module doesn't hook that level at all — only SCENE and EDITOR).
+- No filesystem scans, no eager RID allocation, no forced shader
+  precompile in our `GaussianSplatManager::initialize_module()` — it's
+  just `GLOBAL_DEF` calls and a `gs::sorting_settings::*` registration.
+- No static constructors / `__attribute__((constructor))` in the module
+  that would fire before `main()` and block rendering server init.
+- `servers/rendering/renderer_rd/` has had **zero** non-trivial changes
+  from us in the last 30 days (one `WARN_PRINT_ONCE` and an
+  include-hook style fix). The `GaussianSplatStorage` ctor is
+  trivial.
+
+## Why the user may perceive a recent slowdown
+
+Three plausible explanations, none a code regression in the last 1-2
+days:
+
+1. **Shader cache thrash from commit-switching.** Godot keys shader
+   caches by source SHA256 + driver id. If the user has been switching
+   between branches with shader-source churn
+   (`shaders/includes/gs_render_params.glsl`, `tile_binning.glsl`,
+   `tile_rasterizer_compute.glsl`, `tile_resolve.glsl`,
+   `gs_directional_shadow.glsl`, `gs_culling_utils.glsl` all changed
+   between #229 and HEAD), each switch forces a cold window on our
+   shaders. Godot engine shaders stay cached across our switches, but
+   ~12 of our custom shaders recompile per switch.
+
+2. **Stuck headless-import zombies.** When I landed on this worktree,
+   two `bin/godot.windows.editor.dev.x86_64(.console).exe --headless
+   --import --path tests/examples/godot/test_project` processes
+   (PIDs 42020 and 63672) were still running and were holding a lock
+   on the editor binary (`Zugriff verweigert` on `scons` link step).
+   A stuck headless import on the same project blocks later editor
+   launches from acquiring the project or completes the import on top
+   of the new run, each of which looks like "the editor is frozen"
+   from the user's side. Killing both unlocked the build and editor
+   launch. Worth checking `Task-Manager` for leftover
+   `godot.windows.editor.dev.x86_64*.exe` processes next time this
+   gets reported.
+
+3. **dev_build overhead amplified by project state.** With an empty
+   `.godot/imported/` (which this worktree's test project had), the
+   first editor open has to import every resource under the project —
+   and PRs #229 and #240 introduced 8 synthetic `.ply` fixtures under
+   `tests/examples/godot/test_project/tests/fixtures/` (sizes up to
+   1.6 MB). Those imports are the first thing
+   `EditorFileSystem` will do after startup benchmarks close,
+   contributing to a laggy-feeling post-splash experience. The
+   benchmark file does not capture this because import happens after
+   `Main::Setup2`. If this is the observed slowness, it's one-time
+   per fresh worktree, not a progressive regression.
+
+## What was changed in this commit
+
+Removed leftover `[DIAG-*]` `print_line` blocks that were introduced
+under the "corridor black screen investigation" (added as part of PR
+#229, at `a7e950de79`). These use a `static int _diag_N = 0; if
+(++... <= N || ... % 60 == 0) print_line(...)` pattern — classic
+temporary-debug style — and fire on the per-frame render path
+(`render_scene_instance`, `_select_backend_plan`,
+`_record_raster_metrics`, `_dispatch_raster`, etc.). They are *not*
+the cause of the 21s cold startup, but they make the stdout of a
+running editor noisy forever (one line per second roughly, per
+diagnostic) and they survived past the investigation they were
+created for.
+
+Files touched:
+
+- `modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp` —
+  removed `[DIAG-RESIDENT]`, `[DIAG-RSI]`, `[DIAG-ROUTE]`.
+- `modules/gaussian_splatting/renderer/render_pipeline_stages.cpp` —
+  removed `[DIAG-RASTER]`, `[DIAG-DISPATCH]`, `[DIAG-RRESULT]`.
+- `modules/gaussian_splatting/interfaces/output_compositor.cpp` —
+  removed `[DIAG-COPY-DEVICE]`, `[DIAG-COMPOSITOR]`,
+  `[DIAG-COMPOSITOR2]`; also the now-unused `godot_rd` local.
+- `modules/gaussian_splatting/core/gaussian_streaming.cpp` — removed
+  `[DIAG-SYNC-LOAD]` (pack/success variants) and `[DIAG-UPLOAD]`.
+
+The module already has a gated debug infrastructure
+(`enable_pipeline_trace`, `enable_frame_logging`, 38+ instrumentation
+points via `render_debug_state_orchestrator`, and a `gs_debug_trace`
+data-flow system). All of it is off by default and is the
+supported way to reproduce what the DIAG prints were giving. See
+`CLAUDE.md#Debugging Rendering Issues` for how to enable.
+
+## What is still open
+
+- The **warm** `[Servers] Rendering = 3.1s` is higher than a vanilla
+  Godot editor on the same hardware (expected <1s). Roughly 2s of
+  overhead is attributable to having the Gaussian Splatting module
+  linked in — I did not nail down whether this is shader-cache IO,
+  `RendererCompositorRD` storage setup, or something the dev_build
+  asserts amplify. For normal use this is fine and it's not a
+  recent regression, but if the user wants startup tighter, the next
+  thing to profile is the `RendererCompositorRD::RendererCompositorRD()`
+  ctor and `scene->init()` call.
+
+- **Editor-time FPS floor**. During `--quit-after 300` I observed
+  the editor running at 7-9 FPS while previewing
+  `public_evaluator.tscn`. This is a dev_build symptom (scene
+  previews with a `GaussianSplatWorld3D` ride the full pipeline even
+  when just 5 splats are visible); it is not a new regression to my
+  knowledge but is worth flagging if the user considers 8 FPS in the
+  editor to be the "laggy/unresponsive" symptom. Next steps if it is:
+  capture a frame with RenderDoc while the editor is idle on that
+  scene and look at the per-dispatch cost.

--- a/modules/gaussian_splatting/core/gaussian_streaming.cpp
+++ b/modules/gaussian_splatting/core/gaussian_streaming.cpp
@@ -3215,13 +3215,6 @@ Error GaussianStreamingSystem::_load_chunk(uint32_t asset_id, uint32_t chunk_idx
     Vector<PackedGaussian> chunk_data;
     SHCompressionMetrics metrics;
     if (!_pack_chunk_data(asset_id, chunk_idx, *asset, chunk, chunk_data, metrics)) {
-        static int _diag_pack = 0;
-        if (++_diag_pack <= 5) {
-            print_line(vformat("[DIAG-SYNC-LOAD] _pack_chunk_data FAILED asset=%d chunk=%d data=%s payload=%s",
-                    asset_id, chunk_idx,
-                    asset->data.is_valid() ? "valid" : "null",
-                    asset->payload_source.is_valid() ? "valid" : "null"));
-        }
         _rollback_pending_chunk(asset_id, chunk_idx, chunk, true);
         return FAILED;
     }
@@ -3229,14 +3222,6 @@ Error GaussianStreamingSystem::_load_chunk(uint32_t asset_id, uint32_t chunk_idx
     if (!_upload_chunk_to_gpu(submission_rd, buffer_offset, chunk_data, asset_id, chunk_idx, buffer_slot, chunk.count)) {
         _rollback_pending_chunk(asset_id, chunk_idx, chunk, true);
         return FAILED;
-    }
-    {
-        static int _diag_sync = 0;
-        if (++_diag_sync <= 5) {
-            print_line(vformat("[DIAG-SYNC-LOAD] chunk=%d slot=%d count=%d packed_bytes=%d offset=%d",
-                    chunk_idx, buffer_slot, chunk.count,
-                    chunk_data.size() * int(sizeof(PackedGaussian)), buffer_offset));
-        }
     }
     _finalize_chunk_load(asset_id, chunk_idx, chunk, buffer_slot, asset_chunks.size());
     return OK;
@@ -3431,16 +3416,6 @@ bool GaussianStreamingSystem::_upload_chunk_to_gpu(RenderingDevice *submission_r
     }
     if (upload_bytes > persistent_buffer_size || buffer_offset > persistent_buffer_size - upload_bytes) {
         return false;
-    }
-
-    static int upload_debug_count = 0;
-    if (++upload_debug_count <= 5 && chunk_data.size() > 0) {
-        const PackedGaussian &g0 = chunk_data[0];
-        print_line(vformat("[DIAG-UPLOAD] asset=%d chunk=%d slot=%d offset=%d count=%d pos=(%.3f,%.3f,%.3f) scale=(%.6f,%.6f,%.6f) opacity=%.3f",
-                asset_id, chunk_idx, buffer_slot, buffer_offset, chunk_count,
-                g0.position[0], g0.position[1], g0.position[2],
-                g0.scale[0], g0.scale[1], g0.scale[2],
-                g0.opacity));
     }
 
     submission_rd->buffer_update(persistent_buffer, buffer_offset,

--- a/modules/gaussian_splatting/interfaces/output_compositor.cpp
+++ b/modules/gaussian_splatting/interfaces/output_compositor.cpp
@@ -909,21 +909,6 @@ bool OutputCompositor::copy_to_framebuffer(const FramebufferCopyParams &p_params
         return false;
     }
 
-    RenderingDevice *godot_rd = RenderingDevice::get_singleton();
-    {
-        static int _diag_device = 0;
-        if (++_diag_device <= 5) {
-            bool valid_on_manager = main_rd->texture_is_valid(p_params.source_texture);
-            bool valid_on_godot = godot_rd && godot_rd->texture_is_valid(p_params.source_texture);
-            print_line(vformat("[DIAG-COPY-DEVICE] main_rd=%d godot_rd=%d same=%s src_valid_mgr=%s src_valid_godot=%s fb_valid_godot=%s",
-                    (uint64_t)main_rd, (uint64_t)godot_rd,
-                    (main_rd == godot_rd) ? "YES" : "NO",
-                    valid_on_manager ? "yes" : "NO",
-                    valid_on_godot ? "yes" : "NO",
-                    (godot_rd && godot_rd->framebuffer_is_valid(p_params.framebuffer)) ? "yes" : "NO"));
-        }
-    }
-
     if (!main_rd->texture_is_valid(p_params.source_texture)) {
         GS_LOG_ERROR_DEFAULT("[OutputCompositor] Source texture is not valid on main RenderingDevice; framebuffer copy unsupported");
         return false;
@@ -1158,19 +1143,6 @@ void OutputCompositor::integrate_final_output(GaussianSplatRenderer *p_renderer,
     final_render_texture = p_final_output;
     output_cache.has_valid_render = p_final_output.is_valid();
 
-    {
-        static int _diag_compositor = 0;
-        if (++_diag_compositor <= 10) {
-            print_line(vformat("[DIAG-COMPOSITOR] render_buffers_rd=%s final_output=%s viewport=%dx%d defer=%s painterly=%s cached_depth=%s",
-                    render_buffers_rd ? "valid" : "NULL",
-                    p_final_output.is_valid() ? "valid" : "invalid",
-                    p_viewport_size.x, p_viewport_size.y,
-                    p_defer_commit ? "yes" : "no",
-                    p_painterly_active ? "yes" : "no",
-                    p_cached_depth.is_valid() ? "valid" : "invalid"));
-        }
-    }
-
     if (render_buffers_rd && p_final_output.is_valid()) {
         Size2i viewport_size = p_viewport_size;
         if (viewport_size.x <= 0 || viewport_size.y <= 0) {
@@ -1237,20 +1209,6 @@ void OutputCompositor::integrate_final_output(GaussianSplatRenderer *p_renderer,
         const bool missing_required_scene_depth = scene_depth_test_requested && (!has_source_depth || !has_scene_depth);
         const bool allow_scene_blend_fallback = scene_depth_policy == GS_SCENE_COMPOSITE_DEPTH_POLICY_RELAXED;
 
-        {
-            static int _diag_comp2 = 0;
-            if (++_diag_comp2 <= 10) {
-                print_line(vformat("[DIAG-COMPOSITOR2] composited=%s render_target=%s rt_fb=%s depth_test_req=%s src_depth=%s scene_depth=%s missing=%s allow_fallback=%s",
-                        composited ? "yes" : "no",
-                        composite_target.is_valid() ? "valid" : "invalid",
-                        render_target_framebuffer.is_valid() ? "valid" : "invalid",
-                        scene_depth_test_requested ? "yes" : "no",
-                        has_source_depth ? "yes" : "no",
-                        has_scene_depth ? "yes" : "no",
-                        missing_required_scene_depth ? "yes" : "no",
-                        allow_scene_blend_fallback ? "yes" : "no"));
-            }
-        }
 
         if (!composited && (render_target_framebuffer.is_valid() || composite_target.is_valid())) {
             if (missing_required_scene_depth && !allow_scene_blend_fallback) {

--- a/modules/gaussian_splatting/io/resource_importer_ply.h
+++ b/modules/gaussian_splatting/io/resource_importer_ply.h
@@ -23,7 +23,14 @@ public:
 
     virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
-    virtual bool can_import_threaded() const override { return true; }
+    // Import runs on a WorkerThreadPool thread when this returns true, but our
+    // thumbnail path (ResourceSaver::save -> ImageTexture::_get("image") ->
+    // RenderingServer::texture_2d_get) is FUNC1RC = synchronous push_and_ret to
+    // the render thread. In `--headless --import` the main thread sits in
+    // EditorFileSystem's ep->step busy-loop and never pumps the RS command
+    // queue, so every worker deadlocks. Force serial import until the
+    // thumbnail pipeline no longer takes a sync RS round-trip.
+    virtual bool can_import_threaded() const override { return false; }
     virtual bool has_advanced_options() const override;
     virtual void show_advanced_options(const String &p_path) override;
 

--- a/modules/gaussian_splatting/io/resource_importer_spz.h
+++ b/modules/gaussian_splatting/io/resource_importer_spz.h
@@ -32,7 +32,10 @@ public:
             const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants,
             List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
-    virtual bool can_import_threaded() const override { return true; }
+    // Same deadlock as ResourceImporterPLY — thumbnail generation does a
+    // synchronous RenderingServer::texture_2d_get round-trip, which hangs on
+    // worker threads under `--headless --import`.
+    virtual bool can_import_threaded() const override { return false; }
     virtual bool has_advanced_options() const override;
     virtual void show_advanced_options(const String &p_path) override;
 

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
@@ -2011,15 +2011,6 @@ bool GaussianSplatRenderer::_try_render_resident_frame(RenderDataRD *p_render_da
     }
 #endif
 
-    {
-        static int _diag_res = 0;
-        if (++_diag_res <= 10 || _diag_res % 60 == 0) {
-            print_line(vformat("[DIAG-RESIDENT] has_dataset=%s has_buffer_mgr=%s",
-                    has_gaussian_dataset ? "YES" : "no",
-                    has_buffer_manager_data ? "YES" : "no"));
-        }
-    }
-
     if (!has_gaussian_dataset && !has_buffer_manager_data) {
         if (r_reason) {
             *r_reason = "no_render_data";
@@ -2087,14 +2078,6 @@ void GaussianSplatRenderer::_render_resident_frame(RenderDataRD *p_render_data, 
 void GaussianSplatRenderer::render_scene_instance(RenderDataRD *p_render_data) {
     // Render flow: render_scene_instance -> (streaming ? render_streaming_frame : render_resident_frame)
     // -> RenderPipelineStages::render_sorted_splats_with_context -> raster/composite.
-
-    {
-        static int _diag_rsi = 0;
-        if (++_diag_rsi <= 10 || _diag_rsi % 60 == 0) {
-            print_line(vformat("[DIAG-RSI] render_scene_instance called count=%d render_data=%s",
-                    _diag_rsi, p_render_data ? "valid" : "NULL"));
-        }
-    }
 
     if (debug_state_orchestrator) {
         DebugState &debug_state = get_debug_state();
@@ -2256,16 +2239,6 @@ void GaussianSplatRenderer::render_scene_instance(RenderDataRD *p_render_data) {
                         backend_plan.streaming_requested ? "YES" : "no",
                         backend_plan.streaming_ready ? "YES" : "no"),
                 false);
-    }
-    {
-        static int _diag_route = 0;
-        if (++_diag_route <= 10 || _diag_route % 60 == 0) {
-            print_line(vformat("[DIAG-ROUTE] prefer_resident=%s streaming_req=%s streaming_ready=%s visible=%d",
-                    backend_plan.prefer_resident_backend ? "YES" : "no",
-                    backend_plan.streaming_requested ? "YES" : "no",
-                    backend_plan.streaming_ready ? "YES" : "no",
-                    (int)get_frame_state().visible_splat_count.load(std::memory_order_relaxed)));
-        }
     }
     if (backend_plan.prefer_resident_backend) {
         String resident_attempt_reason;

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -1321,15 +1321,6 @@ struct RenderPipelineStages::RasterCompositeStage {
 		r_raster_output.raster_path = "unknown";
 		r_raster_output.sorted_splat_count = raster_input.sorted_splat_count;
 
-		{
-			static int _diag_raster = 0;
-			if (++_diag_raster <= 15 || _diag_raster % 60 == 0) {
-				print_line(vformat("[DIAG-RASTER] sorted_count=%d domain=%d viewport=%dx%d",
-						raster_input.sorted_splat_count,
-						(int)raster_input.sorted_index_domain,
-						raster_input.viewport_size.x, raster_input.viewport_size.y));
-			}
-		}
 		r_raster_output.content_generation = raster_input.content_generation;
 		{
 			Ref<TileRenderer> tile_renderer = renderer->get_tile_renderer();
@@ -1899,19 +1890,6 @@ Error RenderPipelineStages::RasterStage::render_tile_fallback(const Size2i &p_vi
 		render_params.interactive_state_uniform =
 			subsystem_state.interactive_state_manager->ensure_state_uniform_buffer(renderer, tile_device);
 	}
-	{
-		static int _diag_dispatch = 0;
-		if (++_diag_dispatch <= 15 || _diag_dispatch % 60 == 0) {
-			print_line(vformat("[DIAG-DISPATCH] splat_count=%d total_gauss=%d gauss_buf=%s sort_idx=%s splat_ref=%s chunk_meta=%s inst_buf=%s max_vis=%d",
-					render_params.splat_count, render_params.total_gaussians,
-					render_params.gaussian_buffer.is_valid() ? "Y" : "N",
-					render_params.sorted_indices.is_valid() ? "Y" : "N",
-					render_params.splat_ref_buffer.is_valid() ? "Y" : "N",
-					render_params.chunk_meta_buffer.is_valid() ? "Y" : "N",
-					render_params.instance_buffer.is_valid() ? "Y" : "N",
-					render_params.max_visible_splats));
-		}
-	}
 	RasterResult raster_result = subsystem_state.rasterizer->render_direct(tile_device, render_params);
 
 	r_color_output = raster_result.output_texture;
@@ -1931,19 +1909,6 @@ Error RenderPipelineStages::RasterStage::render_tile_fallback(const Size2i &p_vi
 
 	RasterStats raster_stats = subsystem_state.rasterizer->get_render_stats();
 	performance_state.metrics.raster_path = raster_stats.last_raster_used_compute ? "compute" : "fragment";
-	{
-		static int _diag_rr = 0;
-		if (++_diag_rr <= 10 || _diag_rr % 60 == 0) {
-			print_line(vformat("[DIAG-RRESULT] splats=%d overlaps=%d tiles=%d empty=%d max_per_tile=%d avg=%.1f compute=%s",
-					render_params.splat_count,
-					raster_stats.overlap_records,
-					raster_stats.total_tiles,
-					raster_stats.empty_tiles,
-					raster_stats.max_splats_in_tile,
-					raster_stats.average_splats_per_tile,
-					raster_stats.last_raster_used_compute ? "yes" : "no"));
-		}
-	}
 	if (pipeline && pipeline->debug_state_orchestrator) {
 		pipeline->debug_state_orchestrator->update_raster_metrics(raster_perf, raster_stats);
 	}


### PR DESCRIPTION
## Summary
- Removed ~130 lines of leftover `[DIAG-*]` print_line blocks from the corridor black-screen investigation (PR #229). These were temp debug with `static int` counters that survived past the investigation and spammed stdout once/second per diagnostic.
- Fixed `--headless --import` deadlock: `ResourceImporterPLY/SPZ` declared `can_import_threaded() = true` but the thumbnail path does a synchronous `RenderingServer::texture_2d_get` round-trip via `push_and_ret`, which deadlocks when workers block on the RS command queue that the main thread's busy-loop never drains. Flipped to `can_import_threaded() = false` on both importers. Verified: 8 synthetic PLY fixtures import in ~32s (was: infinite hang). Long-term restoration tracked in #251.
- Added `docs/reports/editor_startup_investigation_2026-04-16.md` documenting empirical startup timing comparison between master HEAD and #229 baseline (no regression found — 21s cold / 3s warm is Godot built-in shader compilation).

## Test plan
- [x] `scons platform=windows target=editor dev_build=yes` — builds clean
- [x] `--headless --import --path tests/examples/godot/test_project` — completes in ~32s (was infinite hang)
- [x] Synthetic benchmark scenes run and produce correct FPS numbers
- [x] No DIAG output in editor stdout on normal runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)