### PR TITLE
feat: per-instance color grading (fixes shared-renderer clobber)

### DIFF
--- a/docs/api/gaussian_splat_node3d.md
+++ b/docs/api/gaussian_splat_node3d.md
@@ -198,8 +198,22 @@ Use `GaussianSplatNode3D` to render Gaussian splat assets or procedural splat ar
       <td><code>rendering/opacity</code></td>
       <td><code>float</code></td>
       <td><code>set_opacity</code>, <code>get_opacity</code></td>
-      <td>Clamped to <code>0.0..1.0</code>.</td>
+      <td>Per-instance opacity multiplier, clamped to <code>0.0..1.0</code>.</td>
       <td><code>modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp:927</code></td>
+    </tr>
+    <tr>
+      <td><code>rendering/effect_position_scale</code></td>
+      <td><code>float</code></td>
+      <td><code>set_effect_position_scale</code>, <code>get_effect_position_scale</code></td>
+      <td>Scales how strongly this node responds to sphere position deformation.</td>
+      <td><code>modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp</code></td>
+    </tr>
+    <tr>
+      <td><code>rendering/effect_opacity_scale</code></td>
+      <td><code>float</code></td>
+      <td><code>set_effect_opacity_scale</code>, <code>get_effect_opacity_scale</code></td>
+      <td>Scales how strongly this node responds to sphere opacity deformation.</td>
+      <td><code>modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp</code></td>
     </tr>
     <tr>
       <td><code>rendering/color_grading</code></td>

--- a/modules/gaussian_splatting/compute/depth_compute.glsl
+++ b/modules/gaussian_splatting/compute/depth_compute.glsl
@@ -86,6 +86,7 @@ layout(set = 0, binding = 9, std140) uniform Params {
     vec4 wind_time_config;
     vec4 effector_sphere;
     vec4 effector_config;
+    vec4 effector_opacity_config;
     vec4 frustum_planes[6];
     vec4 camera_position_ortho; // xyz = camera position, w = orthographic flag
     vec4 cull_screen_distance; // x = pixel_scale_y, y = tiny_splat_radius_px, z = min_screen_threshold_px, w = max_distance_sq
@@ -171,16 +172,19 @@ void main() {
     float instance_intensity = max(instance.params.z, 0.0);
     float instance_wind_mode = instance.params.w;
     uint stable_seed = atlas_index ^ (visible_chunk.instance_id * 0x9e3779b9u);
-    world_position = gs_apply_wind_deformation(world_position,
+    GSDeformationResult deformation = gs_apply_wind_deformation(world_position,
             stable_seed,
             gaussian.opacity,
             instance_intensity,
             instance_wind_mode,
             instance.wind_params,
+            instance.effect_params,
             params.wind_dir_strength,
             params.wind_time_config,
             params.effector_sphere,
-            params.effector_config);
+            params.effector_config,
+            params.effector_opacity_config);
+    world_position = deformation.position;
 
     float local_radius = max(max(abs(local_scale.x), abs(local_scale.y)), abs(local_scale.z));
     if (local_radius <= 0.0) {

--- a/modules/gaussian_splatting/core/gaussian_splat_manager.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_manager.cpp
@@ -1013,6 +1013,10 @@ void GaussianSplatManager::initialize_module() {
     GLOBAL_DEF("rendering/gaussian_splatting/effects/sphere_effector_strength", 0.0f);
     GLOBAL_DEF("rendering/gaussian_splatting/effects/sphere_effector_falloff", 2.0f);
     GLOBAL_DEF("rendering/gaussian_splatting/effects/sphere_effector_frequency", 2.0f);
+    GLOBAL_DEF("rendering/gaussian_splatting/effects/sphere_effector_affect_position", true);
+    GLOBAL_DEF("rendering/gaussian_splatting/effects/sphere_effector_affect_opacity", false);
+    GLOBAL_DEF("rendering/gaussian_splatting/effects/sphere_effector_opacity_strength", 1.0f);
+    GLOBAL_DEF("rendering/gaussian_splatting/effects/sphere_effector_target_opacity", 0.0f);
 
     // Culling and LOD settings from PR #146
     GLOBAL_DEF("rendering/gaussian_splatting/culling/octree_max_depth", 8);

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -1442,8 +1442,13 @@ void GaussianSplatSceneDirector::invalidate_grading_for_renderer(const GaussianS
 	// on default grading edits — their fallback rows read from the renderer's
 	// get_color_grading() value and must refresh.
 	if (p_renderer) {
+		// Atomic increment — the streaming orchestrator reads this from the
+		// render thread to compute upload fingerprints without holding the
+		// director's world_mutex. Relaxed ordering is fine: the counter is
+		// a monotonic "did anything change since last frame" beacon.
 		const_cast<GaussianSplatRenderer *>(p_renderer)
-				->get_resource_state().instance_grading_defaults_generation++;
+				->get_resource_state().instance_grading_defaults_generation
+				.fetch_add(1, std::memory_order_relaxed);
 	}
 	MutexLock lock(world_mutex);
 	SharedWorld *world = const_cast<SharedWorld *>(_find_world_for_renderer(p_renderer));

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -547,7 +547,8 @@ void GaussianSplatSceneDirector::_prune_world_if_unused(const RID &p_scenario) {
 void GaussianSplatSceneDirector::register_instance(ObjectID p_node_id, const Ref<GaussianSplatAsset> &p_asset,
         const Transform3D &p_transform, float p_opacity, float p_lod_bias, uint32_t p_flags, bool p_casts_shadow,
         float p_wind_intensity, uint32_t p_wind_mode, const Vector3 &p_wind_direction, float p_wind_frequency,
-        bool p_visible, bool p_has_desired_residency_hint, int32_t p_desired_residency_hint) {
+        bool p_visible, bool p_has_desired_residency_hint, int32_t p_desired_residency_hint,
+        float p_effect_position_scale, float p_effect_opacity_scale) {
 	MutexLock lock(world_mutex);
 	SharedWorld *world = _get_world_for_instance(p_node_id);
 	if (!world) {
@@ -569,6 +570,8 @@ void GaussianSplatSceneDirector::register_instance(ObjectID p_node_id, const Ref
 	const float wind_intensity = MAX(0.0f, p_wind_intensity);
 	const uint32_t wind_mode = MIN(p_wind_mode, (uint32_t)INSTANCE_WIND_FORCE_ENABLED);
 	const float wind_frequency = MAX(0.0f, p_wind_frequency);
+	const float effect_position_scale = MAX(0.0f, p_effect_position_scale);
+	const float effect_opacity_scale = MAX(0.0f, p_effect_opacity_scale);
 	if (asset_id == 0) {
 		GaussianSplatting::debug_trace_record_event("instance_reg", "FAIL: asset_id=0", true);
 		return;
@@ -624,6 +627,14 @@ void GaussianSplatSceneDirector::register_instance(ObjectID p_node_id, const Ref
 			record.wind_frequency = wind_frequency;
 			dirty = true;
 		}
+		if (!Math::is_equal_approx(record.effect_position_scale, effect_position_scale)) {
+			record.effect_position_scale = effect_position_scale;
+			dirty = true;
+		}
+		if (!Math::is_equal_approx(record.effect_opacity_scale, effect_opacity_scale)) {
+			record.effect_opacity_scale = effect_opacity_scale;
+			dirty = true;
+		}
 		if (record.has_desired_residency_hint != p_has_desired_residency_hint) {
 			record.has_desired_residency_hint = p_has_desired_residency_hint;
 			dirty = true;
@@ -676,6 +687,8 @@ void GaussianSplatSceneDirector::register_instance(ObjectID p_node_id, const Ref
 	record.wind_mode = wind_mode;
 	record.wind_direction = p_wind_direction;
 	record.wind_frequency = wind_frequency;
+	record.effect_position_scale = effect_position_scale;
+	record.effect_opacity_scale = effect_opacity_scale;
 	record.asset_id = asset_id;
 	record.flags = p_flags;
 	record.last_lod = 0;
@@ -721,7 +734,8 @@ void GaussianSplatSceneDirector::update_instance_transform(ObjectID p_node_id, c
 void GaussianSplatSceneDirector::update_instance_params(ObjectID p_node_id, float p_opacity, float p_lod_bias,
 		uint32_t p_flags, bool p_casts_shadow, float p_wind_intensity, uint32_t p_wind_mode,
 		const Vector3 &p_wind_direction, float p_wind_frequency, bool p_visible,
-		bool p_has_desired_residency_hint, int32_t p_desired_residency_hint) {
+		bool p_has_desired_residency_hint, int32_t p_desired_residency_hint,
+		float p_effect_position_scale, float p_effect_opacity_scale) {
 	MutexLock lock(world_mutex);
 	SharedWorld *world = _get_world_for_instance(p_node_id);
 	if (!world) {
@@ -740,6 +754,8 @@ void GaussianSplatSceneDirector::update_instance_params(ObjectID p_node_id, floa
 	const float wind_intensity = MAX(0.0f, p_wind_intensity);
 	const uint32_t wind_mode = MIN(p_wind_mode, (uint32_t)INSTANCE_WIND_FORCE_ENABLED);
 	const float wind_frequency = MAX(0.0f, p_wind_frequency);
+	const float effect_position_scale = MAX(0.0f, p_effect_position_scale);
+	const float effect_opacity_scale = MAX(0.0f, p_effect_opacity_scale);
 	bool dirty = false;
 	bool asset_selection_dirty = false;
 	if (!Math::is_equal_approx(record.opacity, p_opacity)) {
@@ -778,6 +794,14 @@ void GaussianSplatSceneDirector::update_instance_params(ObjectID p_node_id, floa
 	}
 	if (!Math::is_equal_approx(record.wind_frequency, wind_frequency)) {
 		record.wind_frequency = wind_frequency;
+		dirty = true;
+	}
+	if (!Math::is_equal_approx(record.effect_position_scale, effect_position_scale)) {
+		record.effect_position_scale = effect_position_scale;
+		dirty = true;
+	}
+	if (!Math::is_equal_approx(record.effect_opacity_scale, effect_opacity_scale)) {
+		record.effect_opacity_scale = effect_opacity_scale;
 		dirty = true;
 	}
 	if (record.has_desired_residency_hint != p_has_desired_residency_hint) {
@@ -831,10 +855,12 @@ void GaussianSplatSceneDirector::unregister_instance(ObjectID p_node_id) {
 void GaussianSplatSceneDirector::register_instance_submission(ObjectID p_node_id, const Ref<GaussianSplatAsset> &p_asset,
 		const Transform3D &p_transform, float p_opacity, float p_lod_bias, uint32_t p_flags, bool p_casts_shadow,
 		float p_wind_intensity, uint32_t p_wind_mode, const Vector3 &p_wind_direction, float p_wind_frequency,
-		bool p_visible, bool p_has_desired_residency_hint, int32_t p_desired_residency_hint) {
+		bool p_visible, bool p_has_desired_residency_hint, int32_t p_desired_residency_hint,
+		float p_effect_position_scale, float p_effect_opacity_scale) {
 	register_instance(p_node_id, p_asset, p_transform, p_opacity, p_lod_bias, p_flags, p_casts_shadow,
 			p_wind_intensity, p_wind_mode, p_wind_direction, p_wind_frequency, p_visible,
-			p_has_desired_residency_hint, p_desired_residency_hint);
+			p_has_desired_residency_hint, p_desired_residency_hint, p_effect_position_scale,
+			p_effect_opacity_scale);
 }
 
 void GaussianSplatSceneDirector::update_instance_submission_transform(ObjectID p_node_id, const Transform3D &p_transform) {
@@ -844,10 +870,12 @@ void GaussianSplatSceneDirector::update_instance_submission_transform(ObjectID p
 void GaussianSplatSceneDirector::update_instance_submission_params(ObjectID p_node_id, float p_opacity, float p_lod_bias,
 		uint32_t p_flags, bool p_casts_shadow, float p_wind_intensity, uint32_t p_wind_mode,
 		const Vector3 &p_wind_direction, float p_wind_frequency, bool p_visible,
-		bool p_has_desired_residency_hint, int32_t p_desired_residency_hint) {
+		bool p_has_desired_residency_hint, int32_t p_desired_residency_hint,
+		float p_effect_position_scale, float p_effect_opacity_scale) {
 	update_instance_params(p_node_id, p_opacity, p_lod_bias, p_flags, p_casts_shadow, p_wind_intensity,
 			p_wind_mode, p_wind_direction, p_wind_frequency, p_visible,
-			p_has_desired_residency_hint, p_desired_residency_hint);
+			p_has_desired_residency_hint, p_desired_residency_hint, p_effect_position_scale,
+			p_effect_opacity_scale);
 }
 
 void GaussianSplatSceneDirector::unregister_instance_submission(ObjectID p_node_id) {
@@ -879,6 +907,8 @@ bool GaussianSplatSceneDirector::get_instance_submission(ObjectID p_node_id, Ins
 		r_submission->wind_mode = record.wind_mode;
 		r_submission->wind_direction = record.wind_direction;
 		r_submission->wind_frequency = record.wind_frequency;
+		r_submission->effect_position_scale = record.effect_position_scale;
+		r_submission->effect_opacity_scale = record.effect_opacity_scale;
 		r_submission->flags = record.flags;
 		r_submission->last_lod = record.last_lod;
 		r_submission->casts_shadow = record.casts_shadow;
@@ -1110,6 +1140,10 @@ void GaussianSplatSceneDirector::build_instance_buffer(LocalVector<InstanceDataG
 			entry.wind_params[1] = record.wind_direction.y;
 			entry.wind_params[2] = record.wind_direction.z;
 			entry.wind_params[3] = record.wind_frequency;
+			entry.effect_params[0] = record.effect_position_scale;
+			entry.effect_params[1] = record.effect_opacity_scale;
+			entry.effect_params[2] = 0.0f;
+			entry.effect_params[3] = 0.0f;
 
 			out.push_back(entry);
 		}
@@ -1152,6 +1186,8 @@ void GaussianSplatSceneDirector::build_instance_buffer_for_renderer(const Gaussi
 			entry.wind_params[1] = 0.0f;
 			entry.wind_params[2] = 0.0f;
 			entry.wind_params[3] = 1.0f;
+			entry.effect_params[0] = 1.0f;
+			entry.effect_params[1] = 1.0f;
 			out.push_back(entry);
 		}
 		return;
@@ -1235,6 +1271,10 @@ void GaussianSplatSceneDirector::build_instance_buffer_for_renderer(const Gaussi
 		entry.wind_params[1] = record.wind_direction.y;
 		entry.wind_params[2] = record.wind_direction.z;
 		entry.wind_params[3] = record.wind_frequency;
+		entry.effect_params[0] = record.effect_position_scale;
+		entry.effect_params[1] = record.effect_opacity_scale;
+		entry.effect_params[2] = 0.0f;
+		entry.effect_params[3] = 0.0f;
 
 		out.push_back(entry);
 		if (trace_enabled) {
@@ -1399,6 +1439,11 @@ void GaussianSplatSceneDirector::invalidate_grading_for_renderer(const GaussianS
 	MutexLock lock(world_mutex);
 	SharedWorld *world = const_cast<SharedWorld *>(_find_world_for_renderer(p_renderer));
 	if (!world) {
+		// Renderer-only / direct-data flow: no SharedWorld to bump. The caller
+		// (RenderConfigOrchestrator::set_color_grading) also bumps the renderer's
+		// `instance_grading_defaults_generation` counter which the streaming
+		// upload fingerprint includes, so the grading SSBO still re-uploads
+		// next frame even without a director entry.
 		return;
 	}
 	// Bump the instance generation so build_instance_grading_buffer_for_renderer

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -1436,14 +1436,18 @@ Ref<ColorGradingResource> GaussianSplatSceneDirector::get_instance_color_grading
 }
 
 void GaussianSplatSceneDirector::invalidate_grading_for_renderer(const GaussianSplatRenderer *p_renderer) {
+	// Always bump the renderer-wide grading defaults counter, even when there is
+	// no SharedWorld for this renderer. Renderer-only / direct-data flows (no
+	// director instances) need this so the streaming upload fingerprint changes
+	// on default grading edits — their fallback rows read from the renderer's
+	// get_color_grading() value and must refresh.
+	if (p_renderer) {
+		const_cast<GaussianSplatRenderer *>(p_renderer)
+				->get_resource_state().instance_grading_defaults_generation++;
+	}
 	MutexLock lock(world_mutex);
 	SharedWorld *world = const_cast<SharedWorld *>(_find_world_for_renderer(p_renderer));
 	if (!world) {
-		// Renderer-only / direct-data flow: no SharedWorld to bump. The caller
-		// (RenderConfigOrchestrator::set_color_grading) also bumps the renderer's
-		// `instance_grading_defaults_generation` counter which the streaming
-		// upload fingerprint includes, so the grading SSBO still re-uploads
-		// next frame even without a director entry.
 		return;
 	}
 	// Bump the instance generation so build_instance_grading_buffer_for_renderer

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -8,6 +8,7 @@
 #include "gaussian_splat_manager.h"
 #include "../renderer/gaussian_gpu_layout.h"
 #include "../renderer/render_debug_state_orchestrator.h"
+#include "../resources/color_grading_resource.h"
 #include "scene/3d/node_3d.h"
 
 static bool _is_scene_director_log_enabled() {
@@ -1270,6 +1271,186 @@ void GaussianSplatSceneDirector::build_instance_buffer_for_renderer(const Gaussi
 					skipped_instances > 0);
 		}
 	}
+}
+
+// Shared grading→GPU conversion. Mirrors the enabled/disabled logic used by
+// TileRenderParamsBuilder::build_params so the binding-stage shader sees identical
+// parameter semantics whether it reads the legacy UBO default or the new SSBO.
+static void _fill_instance_grading_entry(const Ref<ColorGradingResource> &p_grading, InstanceGradingGPU &r_entry) {
+	if (p_grading.is_valid() && p_grading->get_enabled()) {
+		r_entry.primary[0] = 1.0f; // enabled = true
+		r_entry.primary[1] = p_grading->get_exposure();
+		r_entry.primary[2] = p_grading->get_contrast();
+		r_entry.primary[3] = p_grading->get_saturation();
+		r_entry.secondary[0] = p_grading->get_temperature();
+		r_entry.secondary[1] = p_grading->get_tint();
+		r_entry.secondary[2] = p_grading->get_hue_shift();
+		r_entry.secondary[3] = 0.0f; // reserved
+	} else {
+		r_entry.primary[0] = 0.0f; // enabled = false
+		r_entry.primary[1] = 0.0f; // exposure = 0
+		r_entry.primary[2] = 1.0f; // contrast = 1
+		r_entry.primary[3] = 1.0f; // saturation = 1
+		r_entry.secondary[0] = 0.0f; // temperature
+		r_entry.secondary[1] = 0.0f; // tint
+		r_entry.secondary[2] = 0.0f; // hue_shift
+		r_entry.secondary[3] = 0.0f; // reserved
+	}
+}
+
+void GaussianSplatSceneDirector::build_instance_grading_buffer_for_renderer(const GaussianSplatRenderer *p_renderer,
+		LocalVector<InstanceGradingGPU> &out, bool p_shadow_casters_only) const {
+	MutexLock lock(world_mutex);
+	out.clear();
+
+	const SharedWorld *world = _find_world_for_renderer(p_renderer);
+	// Renderer-wide fallback; mirrors the legacy single-slot RenderConfig::color_grading
+	// semantics when a record has no per-instance grading ref. Passed by value to the
+	// helper so the renderer read is confined to this function.
+	Ref<ColorGradingResource> renderer_default;
+	if (p_renderer) {
+		renderer_default = const_cast<GaussianSplatRenderer *>(p_renderer)->get_color_grading();
+	}
+
+	if (!world) {
+		return;
+	}
+
+	// World-submission single-instance shim: mirrors the same path in
+	// build_instance_buffer_for_renderer so the shader always has a 1-row
+	// grading buffer indexable at splat_ref.instance_id == 0.
+	if (world->instances.is_empty()) {
+		if (world->world_submission.active &&
+				world->world_submission.gaussian_data.is_valid() &&
+				world->world_submission.gaussian_data->get_count() > 0) {
+			InstanceGradingGPU entry = {};
+			_fill_instance_grading_entry(renderer_default, entry);
+			out.push_back(entry);
+		}
+		return;
+	}
+
+	out.reserve(world->instances.size());
+	for (const InstanceRecord &record : world->instances) {
+		if (!record.visible) {
+			continue;
+		}
+		if (p_shadow_casters_only && !record.casts_shadow) {
+			continue;
+		}
+		const SharedWorld::AssetRecord *asset_record = world->asset_records.getptr(record.asset_id);
+		if (!asset_record || asset_record->data.is_null()) {
+			// Must match build_instance_buffer_for_renderer's skip logic exactly
+			// so rows stay 1:1 with instance_id.
+			continue;
+		}
+		InstanceGradingGPU entry = {};
+		const Ref<ColorGradingResource> &grading = record.color_grading.is_valid()
+				? record.color_grading
+				: renderer_default;
+		_fill_instance_grading_entry(grading, entry);
+		out.push_back(entry);
+	}
+}
+
+void GaussianSplatSceneDirector::update_instance_color_grading(ObjectID p_node_id,
+		const Ref<ColorGradingResource> &p_grading) {
+	MutexLock lock(world_mutex);
+	SharedWorld *world = _find_world_for_instance(p_node_id);
+	if (!world) {
+		return;
+	}
+	const uint32_t *pidx = world->instance_lookup.getptr(p_node_id);
+	if (!pidx) {
+		return;
+	}
+	InstanceRecord &record = world->instances[*pidx];
+	if (record.color_grading == p_grading) {
+		return;
+	}
+	record.color_grading = p_grading;
+	record.dirty = true;
+	// Bump the instance generation so downstream caches (sort/raster) see the
+	// change. Asset generation stays put — we did not touch asset topology.
+	_bump_instance_generation(world->instance_generation);
+}
+
+Ref<ColorGradingResource> GaussianSplatSceneDirector::get_instance_color_grading(ObjectID p_node_id) const {
+	MutexLock lock(world_mutex);
+	const SharedWorld *world = const_cast<GaussianSplatSceneDirector *>(this)->_find_world_for_instance(p_node_id);
+	if (!world) {
+		return Ref<ColorGradingResource>();
+	}
+	const uint32_t *pidx = world->instance_lookup.getptr(p_node_id);
+	if (!pidx) {
+		return Ref<ColorGradingResource>();
+	}
+	return world->instances[*pidx].color_grading;
+}
+
+uint64_t GaussianSplatSceneDirector::compute_color_grading_signature_for_renderer(
+		const GaussianSplatRenderer *p_renderer) const {
+	// FNV-1a-esque rolling hash over every per-instance grading tied to the renderer,
+	// including the renderer-wide default used as the fallback. The sort/raster cache
+	// invalidation path hashes this in, so any node grading edit busts the cache.
+	MutexLock lock(world_mutex);
+	uint64_t seed = 1469598103934665603ull;
+	auto mix_u64 = [&](uint64_t v) {
+		seed ^= v;
+		seed *= 1099511628211ull;
+	};
+	auto mix_f = [&](float f) {
+		union {
+			float f;
+			uint32_t u;
+		} c = { f };
+		mix_u64(uint64_t(c.u));
+	};
+	auto mix_grading = [&](const Ref<ColorGradingResource> &g) {
+		if (!g.is_valid()) {
+			mix_u64(0ull);
+			return;
+		}
+		mix_u64(1ull);
+		mix_u64(reinterpret_cast<uint64_t>(g.ptr()));
+		mix_u64(g->get_enabled() ? 1ull : 0ull);
+		mix_f(g->get_exposure());
+		mix_f(g->get_contrast());
+		mix_f(g->get_saturation());
+		mix_f(g->get_temperature());
+		mix_f(g->get_tint());
+		mix_f(g->get_hue_shift());
+	};
+
+	Ref<ColorGradingResource> renderer_default;
+	if (p_renderer) {
+		renderer_default = const_cast<GaussianSplatRenderer *>(p_renderer)->get_color_grading();
+	}
+	mix_grading(renderer_default);
+
+	const SharedWorld *world = _find_world_for_renderer(p_renderer);
+	if (!world) {
+		return seed;
+	}
+
+	if (world->instances.is_empty()) {
+		// World-submission shim uses the renderer default; already mixed.
+		return seed;
+	}
+
+	for (const InstanceRecord &record : world->instances) {
+		// Mirror the visibility/asset filters from build_instance_grading_buffer_for_renderer
+		// so signature reflects the exact set of gradings the shader will see.
+		if (!record.visible) {
+			continue;
+		}
+		const SharedWorld::AssetRecord *asset_record = world->asset_records.getptr(record.asset_id);
+		if (!asset_record || asset_record->data.is_null()) {
+			continue;
+		}
+		mix_grading(record.color_grading.is_valid() ? record.color_grading : renderer_default);
+	}
+	return seed;
 }
 
 uint64_t GaussianSplatSceneDirector::get_instance_generation_for_renderer(const GaussianSplatRenderer *p_renderer) const {

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -1395,6 +1395,19 @@ Ref<ColorGradingResource> GaussianSplatSceneDirector::get_instance_color_grading
 	return world->instances[*pidx].color_grading;
 }
 
+void GaussianSplatSceneDirector::invalidate_grading_for_renderer(const GaussianSplatRenderer *p_renderer) {
+	MutexLock lock(world_mutex);
+	SharedWorld *world = const_cast<SharedWorld *>(_find_world_for_renderer(p_renderer));
+	if (!world) {
+		return;
+	}
+	// Bump the instance generation so build_instance_grading_buffer_for_renderer
+	// re-runs next frame. Records without per-instance grading fall back to the
+	// renderer-wide default at build time, so those rows need to re-upload when
+	// the default changes even though no per-instance ref mutated.
+	_bump_instance_generation(world->instance_generation);
+}
+
 uint64_t GaussianSplatSceneDirector::compute_color_grading_signature_for_renderer(
 		const GaussianSplatRenderer *p_renderer, bool p_shadow_casters_only) const {
 	// FNV-1a-esque rolling hash over every per-instance grading tied to the renderer,

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -1353,26 +1353,32 @@ void GaussianSplatSceneDirector::build_instance_grading_buffer_for_renderer(cons
 	}
 }
 
-void GaussianSplatSceneDirector::update_instance_color_grading(ObjectID p_node_id,
+bool GaussianSplatSceneDirector::update_instance_color_grading(ObjectID p_node_id,
 		const Ref<ColorGradingResource> &p_grading) {
 	MutexLock lock(world_mutex);
 	SharedWorld *world = _find_world_for_instance(p_node_id);
 	if (!world) {
-		return;
+		return false;
 	}
 	const uint32_t *pidx = world->instance_lookup.getptr(p_node_id);
 	if (!pidx) {
-		return;
+		return false;
 	}
 	InstanceRecord &record = world->instances[*pidx];
-	if (record.color_grading == p_grading) {
-		return;
+	const bool ref_changed = record.color_grading != p_grading;
+	if (!ref_changed && p_grading.is_null()) {
+		// Per-frame apply path on a node with no grading — nothing to do, don't
+		// thrash the generation counter (would force a buffer re-upload every frame).
+		return true;
 	}
 	record.color_grading = p_grading;
 	record.dirty = true;
 	// Bump the instance generation so downstream caches (sort/raster) see the
-	// change. Asset generation stays put — we did not touch asset topology.
+	// change. We bump even when the ref is unchanged but valid, because the
+	// resource values (exposure/contrast/etc.) may have changed via slider edits
+	// and the signal handler re-pushes with the same ref.
 	_bump_instance_generation(world->instance_generation);
+	return true;
 }
 
 Ref<ColorGradingResource> GaussianSplatSceneDirector::get_instance_color_grading(ObjectID p_node_id) const {

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -1276,7 +1276,7 @@ void GaussianSplatSceneDirector::build_instance_buffer_for_renderer(const Gaussi
 // Shared grading→GPU conversion. Mirrors the enabled/disabled logic used by
 // TileRenderParamsBuilder::build_params so the binding-stage shader sees identical
 // parameter semantics whether it reads the legacy UBO default or the new SSBO.
-static void _fill_instance_grading_entry(const Ref<ColorGradingResource> &p_grading, InstanceGradingGPU &r_entry) {
+void GaussianSplatSceneDirector::fill_instance_grading_entry(const Ref<ColorGradingResource> &p_grading, InstanceGradingGPU &r_entry) {
 	if (p_grading.is_valid() && p_grading->get_enabled()) {
 		r_entry.primary[0] = 1.0f; // enabled = true
 		r_entry.primary[1] = p_grading->get_exposure();
@@ -1324,7 +1324,7 @@ void GaussianSplatSceneDirector::build_instance_grading_buffer_for_renderer(cons
 				world->world_submission.gaussian_data.is_valid() &&
 				world->world_submission.gaussian_data->get_count() > 0) {
 			InstanceGradingGPU entry = {};
-			_fill_instance_grading_entry(renderer_default, entry);
+			GaussianSplatSceneDirector::fill_instance_grading_entry(renderer_default, entry);
 			out.push_back(entry);
 		}
 		return;
@@ -1348,13 +1348,13 @@ void GaussianSplatSceneDirector::build_instance_grading_buffer_for_renderer(cons
 		const Ref<ColorGradingResource> &grading = record.color_grading.is_valid()
 				? record.color_grading
 				: renderer_default;
-		_fill_instance_grading_entry(grading, entry);
+		GaussianSplatSceneDirector::fill_instance_grading_entry(grading, entry);
 		out.push_back(entry);
 	}
 }
 
 bool GaussianSplatSceneDirector::update_instance_color_grading(ObjectID p_node_id,
-		const Ref<ColorGradingResource> &p_grading) {
+		const Ref<ColorGradingResource> &p_grading, bool p_force_refresh) {
 	MutexLock lock(world_mutex);
 	SharedWorld *world = _find_world_for_instance(p_node_id);
 	if (!world) {
@@ -1366,17 +1366,18 @@ bool GaussianSplatSceneDirector::update_instance_color_grading(ObjectID p_node_i
 	}
 	InstanceRecord &record = world->instances[*pidx];
 	const bool ref_changed = record.color_grading != p_grading;
-	if (!ref_changed && p_grading.is_null()) {
-		// Per-frame apply path on a node with no grading — nothing to do, don't
-		// thrash the generation counter (would force a buffer re-upload every frame).
+	if (!ref_changed && !p_force_refresh) {
+		// Per-frame apply / repeat-push path on an unchanged ref. Skip the
+		// generation bump entirely — every frame would otherwise bust sort/
+		// raster caches just because an unrelated setting re-ran settings apply.
 		return true;
 	}
 	record.color_grading = p_grading;
 	record.dirty = true;
 	// Bump the instance generation so downstream caches (sort/raster) see the
-	// change. We bump even when the ref is unchanged but valid, because the
-	// resource values (exposure/contrast/etc.) may have changed via slider edits
-	// and the signal handler re-pushes with the same ref.
+	// change. Fires when the ref actually changes, or when the caller explicitly
+	// asserts "values behind this ref just mutated" via p_force_refresh=true
+	// (used by the ColorGradingResource `changed` signal handler for slider edits).
 	_bump_instance_generation(world->instance_generation);
 	return true;
 }
@@ -1395,7 +1396,7 @@ Ref<ColorGradingResource> GaussianSplatSceneDirector::get_instance_color_grading
 }
 
 uint64_t GaussianSplatSceneDirector::compute_color_grading_signature_for_renderer(
-		const GaussianSplatRenderer *p_renderer) const {
+		const GaussianSplatRenderer *p_renderer, bool p_shadow_casters_only) const {
 	// FNV-1a-esque rolling hash over every per-instance grading tied to the renderer,
 	// including the renderer-wide default used as the fallback. The sort/raster cache
 	// invalidation path hashes this in, so any node grading edit busts the cache.
@@ -1445,9 +1446,15 @@ uint64_t GaussianSplatSceneDirector::compute_color_grading_signature_for_rendere
 	}
 
 	for (const InstanceRecord &record : world->instances) {
-		// Mirror the visibility/asset filters from build_instance_grading_buffer_for_renderer
-		// so signature reflects the exact set of gradings the shader will see.
+		// Mirror the visibility/shadow/asset filters from
+		// build_instance_grading_buffer_for_renderer so signature reflects the exact
+		// set of gradings the shader will actually see. Without the shadow filter,
+		// grading edits on non-shadow-caster nodes would spuriously bust the shadow
+		// sort/raster cache.
 		if (!record.visible) {
+			continue;
+		}
+		if (p_shadow_casters_only && !record.casts_shadow) {
 			continue;
 		}
 		const SharedWorld::AssetRecord *asset_record = world->asset_records.getptr(record.asset_id);

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
@@ -48,6 +48,8 @@ public:
         uint32_t wind_mode = INSTANCE_WIND_INHERIT;
         Vector3 wind_direction = Vector3();
         float wind_frequency = 1.0f;
+        float effect_position_scale = 1.0f;
+        float effect_opacity_scale = 1.0f;
         uint32_t flags = 0;
         uint32_t last_lod = 0;
         bool casts_shadow = false;
@@ -85,13 +87,15 @@ public:
 			float p_wind_intensity = 1.0f, uint32_t p_wind_mode = INSTANCE_WIND_INHERIT,
 			const Vector3 &p_wind_direction = Vector3(), float p_wind_frequency = 1.0f,
 			bool p_visible = true, bool p_has_desired_residency_hint = false,
-			int32_t p_desired_residency_hint = SUBMISSION_RESIDENCY_HINT_RESIDENT);
+			int32_t p_desired_residency_hint = SUBMISSION_RESIDENCY_HINT_RESIDENT,
+			float p_effect_position_scale = 1.0f, float p_effect_opacity_scale = 1.0f);
 	void update_instance_transform(ObjectID p_node_id, const Transform3D &p_transform);
 	void update_instance_params(ObjectID p_node_id, float p_opacity, float p_lod_bias, uint32_t p_flags, bool p_casts_shadow = false,
 			float p_wind_intensity = 1.0f, uint32_t p_wind_mode = INSTANCE_WIND_INHERIT,
 			const Vector3 &p_wind_direction = Vector3(), float p_wind_frequency = 1.0f,
 			bool p_visible = true, bool p_has_desired_residency_hint = false,
-			int32_t p_desired_residency_hint = SUBMISSION_RESIDENCY_HINT_RESIDENT);
+			int32_t p_desired_residency_hint = SUBMISSION_RESIDENCY_HINT_RESIDENT,
+			float p_effect_position_scale = 1.0f, float p_effect_opacity_scale = 1.0f);
 	void unregister_instance(ObjectID p_node_id);
 	void update_instance_lods(const Vector3 &p_camera_pos, const LODConfig &p_lod_config, float p_hysteresis_zone);
     void update_instance_lods_for_renderer(const GaussianSplatRenderer *p_renderer, const Vector3 &p_camera_pos,
@@ -151,14 +155,16 @@ public:
             uint32_t p_wind_mode = INSTANCE_WIND_INHERIT, const Vector3 &p_wind_direction = Vector3(),
             float p_wind_frequency = 1.0f, bool p_visible = true,
             bool p_has_desired_residency_hint = false,
-            int32_t p_desired_residency_hint = SUBMISSION_RESIDENCY_HINT_RESIDENT);
+            int32_t p_desired_residency_hint = SUBMISSION_RESIDENCY_HINT_RESIDENT,
+            float p_effect_position_scale = 1.0f, float p_effect_opacity_scale = 1.0f);
     void update_instance_submission_transform(ObjectID p_node_id, const Transform3D &p_transform);
     void update_instance_submission_params(ObjectID p_node_id, float p_opacity, float p_lod_bias, uint32_t p_flags,
             bool p_casts_shadow = false, float p_wind_intensity = 1.0f,
             uint32_t p_wind_mode = INSTANCE_WIND_INHERIT, const Vector3 &p_wind_direction = Vector3(),
             float p_wind_frequency = 1.0f, bool p_visible = true,
             bool p_has_desired_residency_hint = false,
-            int32_t p_desired_residency_hint = SUBMISSION_RESIDENCY_HINT_RESIDENT);
+            int32_t p_desired_residency_hint = SUBMISSION_RESIDENCY_HINT_RESIDENT,
+            float p_effect_position_scale = 1.0f, float p_effect_opacity_scale = 1.0f);
     void unregister_instance_submission(ObjectID p_node_id);
     bool get_instance_submission(ObjectID p_node_id, InstanceSubmission *r_submission) const;
 
@@ -194,6 +200,8 @@ private:
         uint32_t wind_mode = INSTANCE_WIND_INHERIT;
 		Vector3 wind_direction = Vector3();
 		float wind_frequency = 1.0f;
+		float effect_position_scale = 1.0f;
+		float effect_opacity_scale = 1.0f;
 		uint32_t asset_id = 0;
 		uint32_t flags = 0;
         uint32_t last_lod = 0;

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
@@ -106,15 +106,36 @@ public:
 	// produces a 1-row buffer so the shader always has a valid index.
 	void build_instance_grading_buffer_for_renderer(const GaussianSplatRenderer *p_renderer,
 			LocalVector<InstanceGradingGPU> &out, bool p_shadow_casters_only = false) const;
+	// Fill a single GPU grading row from a ColorGradingResource ref (null → neutral
+	// disabled). Exposed so streaming/resident fallback paths that inject synthetic
+	// instance rows outside the director's record list can still honor the renderer's
+	// color_grading default instead of forcing neutral.
+	static void fill_instance_grading_entry(const Ref<ColorGradingResource> &p_grading,
+			InstanceGradingGPU &r_entry);
 	// Per-instance color grading setter. Stores the grading ref on the record identified
 	// by node_id; the next frame's build_instance_grading_buffer_for_renderer picks it up.
 	// No-op when the node is unregistered.
-	bool update_instance_color_grading(ObjectID p_node_id, const Ref<ColorGradingResource> &p_grading);
+	//
+	// `p_force_refresh` controls cache-invalidation cadence. Callers that know the
+	// underlying grading values just changed (e.g. a ColorGradingResource `changed`
+	// signal for slider edits) pass true — the generation is bumped even when the
+	// ref is unchanged so the buffer re-uploads with fresh values. Callers that
+	// merely echo the current ref (per-frame apply) leave it false so unrelated
+	// setting churn does not bust sort/raster caches every frame.
+	bool update_instance_color_grading(ObjectID p_node_id, const Ref<ColorGradingResource> &p_grading,
+			bool p_force_refresh = false);
 	// Accessor for tests and diagnostics.
 	Ref<ColorGradingResource> get_instance_color_grading(ObjectID p_node_id) const;
 	// Hash every per-instance grading bound to this renderer. Used by the sort/raster cache
 	// invalidation path so any node's grading edit busts the cache.
-	uint64_t compute_color_grading_signature_for_renderer(const GaussianSplatRenderer *p_renderer) const;
+	//
+	// `p_shadow_casters_only` mirrors the filter in build_instance_grading_buffer_for_renderer.
+	// When the renderer is rendering a shadow pass, non-shadow-caster records are filtered
+	// out of the grading buffer — their gradings MUST not participate in the shadow cache
+	// signature either, otherwise grading edits on non-shadow nodes spuriously bust the
+	// shadow sort/raster cache.
+	uint64_t compute_color_grading_signature_for_renderer(const GaussianSplatRenderer *p_renderer,
+			bool p_shadow_casters_only = false) const;
 	uint32_t get_instance_count_for_renderer(const GaussianSplatRenderer *p_renderer) const;
 	uint64_t get_instance_generation_for_renderer(const GaussianSplatRenderer *p_renderer) const;
 	uint64_t get_instance_asset_generation_for_renderer(const GaussianSplatRenderer *p_renderer) const;

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
@@ -109,7 +109,7 @@ public:
 	// Per-instance color grading setter. Stores the grading ref on the record identified
 	// by node_id; the next frame's build_instance_grading_buffer_for_renderer picks it up.
 	// No-op when the node is unregistered.
-	void update_instance_color_grading(ObjectID p_node_id, const Ref<ColorGradingResource> &p_grading);
+	bool update_instance_color_grading(ObjectID p_node_id, const Ref<ColorGradingResource> &p_grading);
 	// Accessor for tests and diagnostics.
 	Ref<ColorGradingResource> get_instance_color_grading(ObjectID p_node_id) const;
 	// Hash every per-instance grading bound to this renderer. Used by the sort/raster cache

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
@@ -19,6 +19,8 @@
 #include "../lod/lod_config.h"
 #include "../renderer/gaussian_splat_renderer.h"
 
+class ColorGradingResource;
+
 class GaussianSplatSceneDirector : public Object {
     GDCLASS(GaussianSplatSceneDirector, Object);
 
@@ -52,6 +54,7 @@ public:
         bool visible = true;
         bool has_desired_residency_hint = false;
         int32_t desired_residency_hint = SUBMISSION_RESIDENCY_HINT_RESIDENT;
+        Ref<ColorGradingResource> color_grading;
     };
 
     struct WorldSubmission {
@@ -96,6 +99,22 @@ public:
     void build_instance_buffer(LocalVector<InstanceDataGPU> &out) const;
 	void build_instance_buffer_for_renderer(const GaussianSplatRenderer *p_renderer, LocalVector<InstanceDataGPU> &out,
 			bool p_shadow_casters_only = false) const;
+	// Build the per-instance color grading SSBO for the supplied renderer. Walks the same
+	// instance list as build_instance_buffer_for_renderer; falls back to the renderer's
+	// RenderConfig::color_grading when a record has no per-instance ref. When no director
+	// instances exist but the renderer is active (early setup / legacy world-submission shim),
+	// produces a 1-row buffer so the shader always has a valid index.
+	void build_instance_grading_buffer_for_renderer(const GaussianSplatRenderer *p_renderer,
+			LocalVector<InstanceGradingGPU> &out, bool p_shadow_casters_only = false) const;
+	// Per-instance color grading setter. Stores the grading ref on the record identified
+	// by node_id; the next frame's build_instance_grading_buffer_for_renderer picks it up.
+	// No-op when the node is unregistered.
+	void update_instance_color_grading(ObjectID p_node_id, const Ref<ColorGradingResource> &p_grading);
+	// Accessor for tests and diagnostics.
+	Ref<ColorGradingResource> get_instance_color_grading(ObjectID p_node_id) const;
+	// Hash every per-instance grading bound to this renderer. Used by the sort/raster cache
+	// invalidation path so any node's grading edit busts the cache.
+	uint64_t compute_color_grading_signature_for_renderer(const GaussianSplatRenderer *p_renderer) const;
 	uint32_t get_instance_count_for_renderer(const GaussianSplatRenderer *p_renderer) const;
 	uint64_t get_instance_generation_for_renderer(const GaussianSplatRenderer *p_renderer) const;
 	uint64_t get_instance_asset_generation_for_renderer(const GaussianSplatRenderer *p_renderer) const;
@@ -156,6 +175,7 @@ private:
         bool has_desired_residency_hint = false;
         int32_t desired_residency_hint = SUBMISSION_RESIDENCY_HINT_RESIDENT;
         bool dirty = true;
+        Ref<ColorGradingResource> color_grading;
 	};
 
     struct SharedWorld {

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
@@ -126,6 +126,12 @@ public:
 			bool p_force_refresh = false);
 	// Accessor for tests and diagnostics.
 	Ref<ColorGradingResource> get_instance_color_grading(ObjectID p_node_id) const;
+	// Bump the instance generation of the world bound to this renderer so the
+	// next frame rebuilds the grading SSBO. Called when the renderer's legacy
+	// renderer-wide color_grading default changes — records with no per-instance
+	// grading read from that default via the build step's fallback, so their
+	// rows need to re-upload even though no per-instance ref changed.
+	void invalidate_grading_for_renderer(const GaussianSplatRenderer *p_renderer);
 	// Hash every per-instance grading bound to this renderer. Used by the sort/raster cache
 	// invalidation path so any node's grading edit busts the cache.
 	//

--- a/modules/gaussian_splatting/core/gs_project_settings.h
+++ b/modules/gaussian_splatting/core/gs_project_settings.h
@@ -18,6 +18,7 @@
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
 #include "core/math/math_funcs.h"
+#include "core/math/vector3.h"
 #include "core/variant/variant.h"
 
 namespace gs {
@@ -167,6 +168,20 @@ enum GSStreamingRoutePolicy {
 	GS_ROUTE_STREAMING = 1,
 };
 
+struct GSSphereEffectorSettings {
+	int max_effectors = 1;
+	bool enabled = false;
+	Vector3 center = Vector3();
+	float radius = 0.0f;
+	float strength = 0.0f;
+	float falloff = 2.0f;
+	float frequency = 2.0f;
+	bool affect_position = true;
+	bool affect_opacity = false;
+	float opacity_strength = 1.0f;
+	float target_opacity = 0.0f;
+};
+
 static inline const char *get_streaming_route_policy_token(int p_policy) {
 	switch (p_policy) {
 		case GS_ROUTE_RESIDENT:
@@ -199,6 +214,39 @@ static inline int get_streaming_route_policy(ProjectSettings *p_ps) {
 	}
 	return (int)get_uint(p_ps, "rendering/gaussian_splatting/streaming/route_policy",
 			(uint32_t)GS_ROUTE_STREAMING);
+}
+
+static inline GSSphereEffectorSettings get_sphere_effector_settings(ProjectSettings *p_ps, bool p_warn_on_clamp = false) {
+	GSSphereEffectorSettings settings;
+	if (!p_ps) {
+		return settings;
+	}
+
+	const int requested_max_effectors = get_int(p_ps, "rendering/gaussian_splatting/effects/max_effectors", settings.max_effectors);
+	settings.max_effectors = CLAMP(requested_max_effectors, 0, 1);
+	if (p_warn_on_clamp && requested_max_effectors > 1) {
+		WARN_PRINT_ONCE("[GaussianSplatting] Only one sphere effector is currently supported. "
+				"'rendering/gaussian_splatting/effects/max_effectors' was clamped to 1.");
+	}
+
+	settings.enabled = get_bool(p_ps, "rendering/gaussian_splatting/effects/sphere_effector_enabled", settings.enabled);
+	settings.center.x = get_float(p_ps, "rendering/gaussian_splatting/effects/sphere_effector_center_x", settings.center.x);
+	settings.center.y = get_float(p_ps, "rendering/gaussian_splatting/effects/sphere_effector_center_y", settings.center.y);
+	settings.center.z = get_float(p_ps, "rendering/gaussian_splatting/effects/sphere_effector_center_z", settings.center.z);
+	settings.radius = MAX(get_float(p_ps, "rendering/gaussian_splatting/effects/sphere_effector_radius", settings.radius), 0.0f);
+	settings.strength = get_float(p_ps, "rendering/gaussian_splatting/effects/sphere_effector_strength", settings.strength);
+	settings.falloff = MAX(get_float(p_ps, "rendering/gaussian_splatting/effects/sphere_effector_falloff", settings.falloff), 0.001f);
+	settings.frequency = MAX(get_float(p_ps, "rendering/gaussian_splatting/effects/sphere_effector_frequency", settings.frequency), 0.1f);
+	settings.affect_position = get_bool(p_ps, "rendering/gaussian_splatting/effects/sphere_effector_affect_position", settings.affect_position);
+	settings.affect_opacity = get_bool(p_ps, "rendering/gaussian_splatting/effects/sphere_effector_affect_opacity", settings.affect_opacity);
+	settings.opacity_strength = CLAMP(
+			get_float(p_ps, "rendering/gaussian_splatting/effects/sphere_effector_opacity_strength", settings.opacity_strength),
+			0.0f, 1.0f);
+	settings.target_opacity = CLAMP(
+			get_float(p_ps, "rendering/gaussian_splatting/effects/sphere_effector_target_opacity", settings.target_opacity),
+			0.0f, 1.0f);
+	settings.enabled = settings.enabled && settings.max_effectors > 0;
+	return settings;
 }
 
 } // namespace settings

--- a/modules/gaussian_splatting/interfaces/gpu_sorting_pipeline.cpp
+++ b/modules/gaussian_splatting/interfaces/gpu_sorting_pipeline.cpp
@@ -2257,6 +2257,10 @@ bool GPUSortingPipeline::_sort_instance_pipeline(const Transform3D &p_cam_transf
     params.effector_config[1] = 0.0f;
     params.effector_config[2] = 2.0f;
     params.effector_config[3] = 2.0f; // Default frequency 2 Hz
+    params.effector_opacity_config[0] = 1.0f;
+    params.effector_opacity_config[1] = 0.0f;
+    params.effector_opacity_config[2] = 1.0f;
+    params.effector_opacity_config[3] = 0.0f;
     if (ProjectSettings *ps = ProjectSettings::get_singleton()) {
         static const StringName wind_enabled_path("rendering/gaussian_splatting/animation/wind_enabled");
         static const StringName wind_direction_x_path("rendering/gaussian_splatting/animation/wind_direction_x");
@@ -2266,16 +2270,6 @@ bool GPUSortingPipeline::_sort_instance_pipeline(const Transform3D &p_cam_transf
         static const StringName wind_frequency_path("rendering/gaussian_splatting/animation/wind_frequency");
         static const StringName wind_spatial_frequency_path("rendering/gaussian_splatting/animation/wind_spatial_frequency");
         static const StringName wind_time_scale_path("rendering/gaussian_splatting/animation/wind_time_scale");
-        static const StringName max_effectors_path("rendering/gaussian_splatting/effects/max_effectors");
-        static const StringName sphere_effector_enabled_path("rendering/gaussian_splatting/effects/sphere_effector_enabled");
-        static const StringName sphere_effector_center_x_path("rendering/gaussian_splatting/effects/sphere_effector_center_x");
-        static const StringName sphere_effector_center_y_path("rendering/gaussian_splatting/effects/sphere_effector_center_y");
-        static const StringName sphere_effector_center_z_path("rendering/gaussian_splatting/effects/sphere_effector_center_z");
-        static const StringName sphere_effector_radius_path("rendering/gaussian_splatting/effects/sphere_effector_radius");
-        static const StringName sphere_effector_strength_path("rendering/gaussian_splatting/effects/sphere_effector_strength");
-        static const StringName sphere_effector_falloff_path("rendering/gaussian_splatting/effects/sphere_effector_falloff");
-        static const StringName sphere_effector_frequency_path("rendering/gaussian_splatting/effects/sphere_effector_frequency");
-
         const bool wind_enabled = _get_bool_setting(ps, wind_enabled_path, false);
         const float wind_time_scale = MAX(_get_float_setting(ps, wind_time_scale_path, 1.0f), 0.0f);
         params.wind_dir_strength[0] = _get_float_setting(ps, wind_direction_x_path, 1.0f);
@@ -2288,17 +2282,19 @@ bool GPUSortingPipeline::_sort_instance_pipeline(const Transform3D &p_cam_transf
         params.wind_time_config[2] = _get_float_setting(ps, wind_spatial_frequency_path, 0.1f);
         params.wind_time_config[3] = wind_enabled ? 1.0f : 0.0f;
 
-        const int max_effectors = CLAMP((int)_get_float_setting(ps, max_effectors_path, 1.0f), 0, 1);
-        const bool sphere_effective_enabled = max_effectors > 0 &&
-                _get_bool_setting(ps, sphere_effector_enabled_path, false);
-        params.effector_sphere[0] = _get_float_setting(ps, sphere_effector_center_x_path, 0.0f);
-        params.effector_sphere[1] = _get_float_setting(ps, sphere_effector_center_y_path, 0.0f);
-        params.effector_sphere[2] = _get_float_setting(ps, sphere_effector_center_z_path, 0.0f);
-        params.effector_sphere[3] = MAX(_get_float_setting(ps, sphere_effector_radius_path, 0.0f), 0.0f);
-        params.effector_config[0] = sphere_effective_enabled ? 1.0f : 0.0f;
-        params.effector_config[1] = _get_float_setting(ps, sphere_effector_strength_path, 0.0f);
-        params.effector_config[2] = MAX(_get_float_setting(ps, sphere_effector_falloff_path, 2.0f), 0.001f);
-        params.effector_config[3] = MAX(_get_float_setting(ps, sphere_effector_frequency_path, 2.0f), 0.1f);
+        const gs::settings::GSSphereEffectorSettings sphere_effector_settings = gs::settings::get_sphere_effector_settings(ps, true);
+        params.effector_sphere[0] = sphere_effector_settings.center.x;
+        params.effector_sphere[1] = sphere_effector_settings.center.y;
+        params.effector_sphere[2] = sphere_effector_settings.center.z;
+        params.effector_sphere[3] = sphere_effector_settings.radius;
+        params.effector_config[0] = sphere_effector_settings.enabled ? 1.0f : 0.0f;
+        params.effector_config[1] = sphere_effector_settings.strength;
+        params.effector_config[2] = sphere_effector_settings.falloff;
+        params.effector_config[3] = sphere_effector_settings.frequency;
+        params.effector_opacity_config[0] = sphere_effector_settings.affect_position ? 1.0f : 0.0f;
+        params.effector_opacity_config[1] = sphere_effector_settings.affect_opacity ? 1.0f : 0.0f;
+        params.effector_opacity_config[2] = sphere_effector_settings.opacity_strength;
+        params.effector_opacity_config[3] = sphere_effector_settings.target_opacity;
     }
 
     Projection projection = sort_ctx.view.camera_projection;

--- a/modules/gaussian_splatting/interfaces/painterly_material_manager.cpp
+++ b/modules/gaussian_splatting/interfaces/painterly_material_manager.cpp
@@ -167,7 +167,9 @@ void PainterlyMaterialManager::update_resources() {
                               (stroke_density_buffer_size != required_size);
 
         if (needs_recreation) {
-            if (stroke_density_buffer.is_valid() && rd->buffer_is_valid(stroke_density_buffer)) {
+            if (stroke_density_buffer.is_valid() &&
+                    ResourceOwnerMismatchContract::is_device_generation_valid(rd, rd_device_id) &&
+                    rd->buffer_is_valid(stroke_density_buffer)) {
                 rd->free(stroke_density_buffer);
             }
             stroke_density_buffer = RID();

--- a/modules/gaussian_splatting/interfaces/painterly_material_manager.cpp
+++ b/modules/gaussian_splatting/interfaces/painterly_material_manager.cpp
@@ -101,6 +101,15 @@ void PainterlyMaterialManager::update_resources() {
         return;
     }
 
+    // Device-generation guard. The cached `rd` pointer may be stale if the
+    // rendering device has been recreated since `initialize()` — same concern
+    // as clear_resources(). Without this, buffer_is_valid()/free()/buffer_update()
+    // below can dereference a stale RenderingDevice* and turn a routine material
+    // refresh into a use-after-destroy crash.
+    if (!ResourceOwnerMismatchContract::is_device_generation_valid(rd, rd_device_id)) {
+        return;
+    }
+
     if (!material.is_valid()) {
         clear_resources();
         material_dirty = false;

--- a/modules/gaussian_splatting/interfaces/painterly_renderer.cpp
+++ b/modules/gaussian_splatting/interfaces/painterly_renderer.cpp
@@ -1637,6 +1637,7 @@ Error PainterlyRenderer::populate_painterly_gbuffer(GaussianSplatRenderer *p_ren
     RID instance_gaussian_buffer;
     RID instance_sorted_indices;
     RID instance_buffer_rid;
+    RID instance_grading_buffer_rid;
     RID instance_splat_ref_buffer;
     RID instance_chunk_meta_buffer;
     RID instance_quantization_buffer;
@@ -1649,6 +1650,7 @@ Error PainterlyRenderer::populate_painterly_gbuffer(GaussianSplatRenderer *p_ren
         const auto &instance_buffers = p_renderer->get_instance_pipeline_buffers();
         instance_gaussian_buffer = instance_buffers.atlas_gaussian_buffer;
         instance_buffer_rid = instance_buffers.instance_buffer;
+        instance_grading_buffer_rid = instance_buffers.instance_grading_buffer;
         instance_splat_ref_buffer = instance_buffers.splat_ref_buffer;
         instance_chunk_meta_buffer = instance_buffers.chunk_meta_buffer;
         instance_quantization_buffer = instance_buffers.quantization_required ? instance_buffers.quantization_buffer : RID();
@@ -1733,6 +1735,11 @@ Error PainterlyRenderer::populate_painterly_gbuffer(GaussianSplatRenderer *p_ren
     }
     if (has_instance_data) {
         render_params.instance_buffer = instance_buffer_rid;
+        // The tile preflight now hard-fails when `instance_grading_buffer`
+        // is missing (see InstancePipelineContract::first_tile_runtime_violation).
+        // Forward it from the renderer's instance pipeline buffers so painterly
+        // rendering goes through the same preflight as the non-painterly path.
+        render_params.instance_grading_buffer = instance_grading_buffer_rid;
         render_params.splat_ref_buffer = instance_splat_ref_buffer;
         render_params.chunk_meta_buffer = instance_chunk_meta_buffer;
         render_params.quantization_buffer = instance_quantization_buffer;

--- a/modules/gaussian_splatting/nodes/README.md
+++ b/modules/gaussian_splatting/nodes/README.md
@@ -143,7 +143,16 @@ Notes:
   - **Manual**: Update only when requested
 - `rendering/cast_shadow`: Enable shadow casting
 - `rendering/frustum_culling`: Enable frustum culling optimization
-- `rendering/opacity`: Overall opacity of the splats (0.0-1.0)
+- `rendering/opacity`: Per-instance opacity multiplier for this node (0.0-1.0)
+- `rendering/effect_position_scale`: Per-instance response multiplier for sphere position deformation
+- `rendering/effect_opacity_scale`: Per-instance response multiplier for sphere opacity deformation
+
+#### Effector Workflow
+- Authored splat opacity still lives in the Gaussian data or imported asset.
+- `rendering/opacity` is the gameplay-facing per-node fade and is applied after deformation.
+- Global sphere ProjectSettings remain available as a fallback source for scenes that do not drive effectors through code.
+- Only one sphere effector is currently evaluated at runtime, even if `max_effectors` is set higher.
+- For dissolve-style effects, enable the sphere opacity path in ProjectSettings and then tune each node with `rendering/effect_opacity_scale`.
 
 #### Debug Settings
 - `debug/preview_enabled`: Show preview in editor viewport

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -1586,8 +1586,15 @@ bool GaussianSplatNode3D::_push_color_grading_to_renderer(bool p_allow_null) {
     // instead of stomping the renderer's single-slot RenderConfig::color_grading.
     // The director's build step walks all records and produces one InstanceGradingGPU
     // row per instance, so peer nodes no longer clobber each other.
+    bool pushed = false;
     if (GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton()) {
-        director->update_instance_color_grading(get_instance_id(), color_grading);
+        pushed = director->update_instance_color_grading(get_instance_id(), color_grading);
+    }
+    if (!pushed) {
+        // Director does not know this node yet (registration runs later in the
+        // node lifecycle). Leave the pushed/pending flags alone so replay
+        // re-tries once register_instance_in_director has landed.
+        return false;
     }
     renderer->invalidate_cached_render();
     grading_pushed_for_current_data = true;
@@ -2105,6 +2112,11 @@ void GaussianSplatNode3D::_register_instance_in_director() {
             parent_visible && visible_in_viewport && is_visible_in_tree(),
             /*has_desired_residency_hint=*/true,
             GaussianSplatSceneDirector::SUBMISSION_RESIDENCY_HINT_RESIDENT);
+    // Push color grading to the freshly-registered director record so it lands
+    // in the InstanceGradingGPU row on the next buffer rebuild. Without this,
+    // the earlier setter/signal attempts that fired before registration were
+    // lost (director returned NO WORLD) and the record stayed at null grading.
+    director->update_instance_color_grading(get_instance_id(), color_grading);
 }
 
 void GaussianSplatNode3D::_unregister_instance_in_director() {

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -163,6 +163,14 @@ void GaussianSplatNode3D::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_opacity"), &GaussianSplatNode3D::get_opacity);
     ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rendering/opacity", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_opacity", "get_opacity");
 
+    ClassDB::bind_method(D_METHOD("set_effect_position_scale", "scale"), &GaussianSplatNode3D::set_effect_position_scale);
+    ClassDB::bind_method(D_METHOD("get_effect_position_scale"), &GaussianSplatNode3D::get_effect_position_scale);
+    ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rendering/effect_position_scale", PROPERTY_HINT_RANGE, "0.0,4.0,0.01,or_greater"), "set_effect_position_scale", "get_effect_position_scale");
+
+    ClassDB::bind_method(D_METHOD("set_effect_opacity_scale", "scale"), &GaussianSplatNode3D::set_effect_opacity_scale);
+    ClassDB::bind_method(D_METHOD("get_effect_opacity_scale"), &GaussianSplatNode3D::get_effect_opacity_scale);
+    ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rendering/effect_opacity_scale", PROPERTY_HINT_RANGE, "0.0,4.0,0.01,or_greater"), "set_effect_opacity_scale", "get_effect_opacity_scale");
+
     ClassDB::bind_method(D_METHOD("set_wind_override_enabled", "enabled"), &GaussianSplatNode3D::set_wind_override_enabled);
     ClassDB::bind_method(D_METHOD("is_wind_override_enabled"), &GaussianSplatNode3D::is_wind_override_enabled);
     ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rendering/wind_override_enabled"), "set_wind_override_enabled", "is_wind_override_enabled");
@@ -1025,10 +1033,34 @@ void GaussianSplatNode3D::set_use_occlusion_culling(bool p_enabled) {
 }
 
 void GaussianSplatNode3D::set_opacity(float p_opacity) {
-    opacity = CLAMP(p_opacity, 0.0f, 1.0f);
-    if (renderer.is_valid()) {
-        _apply_renderer_settings();
+    float next_opacity = p_opacity;
+    if (!Math::is_finite(next_opacity)) {
+        WARN_PRINT("[GaussianSplatNode3D] Ignoring non-finite opacity; resetting to 1.0.");
+        next_opacity = 1.0f;
     }
+    opacity = CLAMP(next_opacity, 0.0f, 1.0f);
+    _mark_render_state_dirty();
+    _update_instance_params_in_director();
+}
+
+void GaussianSplatNode3D::set_effect_position_scale(float p_scale) {
+    float next_scale = p_scale;
+    if (!Math::is_finite(next_scale)) {
+        WARN_PRINT("[GaussianSplatNode3D] Ignoring non-finite effect_position_scale; resetting to 1.0.");
+        next_scale = 1.0f;
+    }
+    effect_position_scale = MAX(next_scale, 0.0f);
+    _mark_render_state_dirty();
+    _update_instance_params_in_director();
+}
+
+void GaussianSplatNode3D::set_effect_opacity_scale(float p_scale) {
+    float next_scale = p_scale;
+    if (!Math::is_finite(next_scale)) {
+        WARN_PRINT("[GaussianSplatNode3D] Ignoring non-finite effect_opacity_scale; resetting to 1.0.");
+        next_scale = 1.0f;
+    }
+    effect_opacity_scale = MAX(next_scale, 0.0f);
     _mark_render_state_dirty();
     _update_instance_params_in_director();
 }
@@ -2111,7 +2143,8 @@ void GaussianSplatNode3D::_register_instance_in_director() {
             _get_instance_wind_direction(), _get_instance_wind_frequency(),
             parent_visible && visible_in_viewport && is_visible_in_tree(),
             /*has_desired_residency_hint=*/true,
-            GaussianSplatSceneDirector::SUBMISSION_RESIDENCY_HINT_RESIDENT);
+            GaussianSplatSceneDirector::SUBMISSION_RESIDENCY_HINT_RESIDENT,
+            effect_position_scale, effect_opacity_scale);
     // Push color grading to the freshly-registered director record so it lands
     // in the InstanceGradingGPU row on the next buffer rebuild. Without this,
     // the earlier setter/signal attempts that fired before registration were
@@ -2144,7 +2177,8 @@ void GaussianSplatNode3D::_update_instance_params_in_director() {
                 _get_instance_wind_direction(), _get_instance_wind_frequency(),
                 parent_visible && visible_in_viewport && is_visible_in_tree(),
                 /*has_desired_residency_hint=*/true,
-                GaussianSplatSceneDirector::SUBMISSION_RESIDENCY_HINT_RESIDENT);
+                GaussianSplatSceneDirector::SUBMISSION_RESIDENCY_HINT_RESIDENT,
+                effect_position_scale, effect_opacity_scale);
     }
     if (renderer.is_valid()) {
         renderer->invalidate_cached_render();

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -1574,7 +1574,7 @@ bool GaussianSplatNode3D::_can_push_color_grading_to_renderer() const {
     return renderer.is_valid() && is_inside_tree() && is_inside_world() && _has_local_source_data();
 }
 
-bool GaussianSplatNode3D::_push_color_grading_to_renderer(bool p_allow_null) {
+bool GaussianSplatNode3D::_push_color_grading_to_renderer(bool p_allow_null, bool p_force_refresh) {
     if (!_can_push_color_grading_to_renderer()) {
         return false;
     }
@@ -1588,7 +1588,7 @@ bool GaussianSplatNode3D::_push_color_grading_to_renderer(bool p_allow_null) {
     // row per instance, so peer nodes no longer clobber each other.
     bool pushed = false;
     if (GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton()) {
-        pushed = director->update_instance_color_grading(get_instance_id(), color_grading);
+        pushed = director->update_instance_color_grading(get_instance_id(), color_grading, p_force_refresh);
     }
     if (!pushed) {
         // Director does not know this node yet (registration runs later in the
@@ -2186,7 +2186,10 @@ void GaussianSplatNode3D::_on_asset_changed() {
 }
 
 void GaussianSplatNode3D::_on_color_grading_changed() {
-    if (!_push_color_grading_to_renderer(true)) {
+    // `changed` fires when slider values mutate on the same resource ref.
+    // Tell the director to bump the instance generation unconditionally so
+    // the grading SSBO re-uploads with the fresh values next frame.
+    if (!_push_color_grading_to_renderer(true, /*p_force_refresh=*/true)) {
         // Detached or data-less resource mutation: queue an explicit
         // replay so the user's change (including null) reaches the
         // renderer when this node next becomes active content. Arming

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -1582,7 +1582,13 @@ bool GaussianSplatNode3D::_push_color_grading_to_renderer(bool p_allow_null) {
         return false;
     }
 
-    renderer->set_color_grading(color_grading);
+    // Per-instance routing: write the grading into the director record for this node
+    // instead of stomping the renderer's single-slot RenderConfig::color_grading.
+    // The director's build step walks all records and produces one InstanceGradingGPU
+    // row per instance, so peer nodes no longer clobber each other.
+    if (GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton()) {
+        director->update_instance_color_grading(get_instance_id(), color_grading);
+    }
     renderer->invalidate_cached_render();
     grading_pushed_for_current_data = true;
     // The push satisfies any pending explicit edit too; clear so a later

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
@@ -359,7 +359,7 @@ private:
     void _on_color_grading_changed();
     bool _has_local_source_data() const;
     bool _can_push_color_grading_to_renderer() const;
-    bool _push_color_grading_to_renderer(bool p_allow_null);
+    bool _push_color_grading_to_renderer(bool p_allow_null, bool p_force_refresh = false);
 
     // Push the cached color_grading to the renderer if it has not been
     // pushed yet for the current renderer/data window AND the node is active

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
@@ -159,6 +159,8 @@ private:
     bool use_frustum_culling = true;
     bool use_occlusion_culling = true; // Legacy serialized compatibility only (not an exposed node property).
     float opacity = 1.0f;
+    float effect_position_scale = 1.0f;
+    float effect_opacity_scale = 1.0f;
     bool wind_override_enabled = false;
     bool wind_enabled = true;
     float wind_strength = 1.0f;
@@ -599,9 +601,17 @@ public:
     void set_use_occlusion_culling(bool p_enabled);
     bool is_occlusion_culling_enabled() const { return use_occlusion_culling; }
 
-    /** @brief Sets global opacity multiplier for all splats. */
+    /** @brief Sets the per-instance opacity multiplier for this node. */
     void set_opacity(float p_opacity);
     float get_opacity() const { return opacity; }
+
+    /** @brief Scales sphere-driven position deformation for this node. */
+    void set_effect_position_scale(float p_scale);
+    float get_effect_position_scale() const { return effect_position_scale; }
+
+    /** @brief Scales sphere-driven opacity modulation for this node. */
+    void set_effect_opacity_scale(float p_scale);
+    float get_effect_opacity_scale() const { return effect_opacity_scale; }
 
     /** @brief Enables per-instance wind overrides for this node. */
     void set_wind_override_enabled(bool p_enabled);

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
@@ -1424,7 +1424,6 @@ void GaussianSplatNodeRendererHelper::apply_renderer_settings() {
     owner.renderer->set_painterly_stroke_opacity(owner.stroke_opacity);
     owner.renderer->set_painterly_stroke_length(owner.stroke_width);
     owner.renderer->set_painterly_gamma(MAX(owner.temporal_blend, 0.01f));
-    owner.renderer->set_opacity_multiplier(owner.opacity);
     // Per-instance color grading — routed through the scene director. The director
     // stores grading on the node's InstanceRecord, then the director's build step
     // produces one InstanceGradingGPU row per instance indexed by

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
@@ -1425,16 +1425,13 @@ void GaussianSplatNodeRendererHelper::apply_renderer_settings() {
     owner.renderer->set_painterly_stroke_length(owner.stroke_width);
     owner.renderer->set_painterly_gamma(MAX(owner.temporal_blend, 0.01f));
     owner.renderer->set_opacity_multiplier(owner.opacity);
-    // Color grading per-frame push is gated on single-owner. Pushing while
-    // sharing would clobber another node's set_color_grading() call (the
-    // original P1 fix). Skipping always means a sharing-collapse transition
-    // (e.g. another node leaving) leaves the renderer with the departed
-    // node's last grading and never restores the remaining owner's
-    // (the third P1 fix). Single-owner per-frame push covers both: it
-    // resyncs after a transition without ever clobbering anyone, since by
-    // definition no other node could have written.
-    if (!_is_renderer_shared_with_other_content(owner)) {
-        owner.renderer->set_color_grading(owner.color_grading);
+    // Per-instance color grading — routed through the scene director. The director
+    // stores grading on the node's InstanceRecord, then the director's build step
+    // produces one InstanceGradingGPU row per instance indexed by
+    // SplatRefGPU.instance_id. No shared-renderer gate needed: peers no longer
+    // share a single color_grading slot.
+    if (GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton()) {
+        director->update_instance_color_grading(owner.get_instance_id(), owner.color_grading);
     }
     {
         GaussianStreamingSystem::ConfigOverrides overrides;

--- a/modules/gaussian_splatting/renderer/gaussian_gpu_layout.h
+++ b/modules/gaussian_splatting/renderer/gaussian_gpu_layout.h
@@ -95,6 +95,21 @@ static_assert(offsetof(InstanceDataGPU, ids) == 64, "InstanceDataGPU.ids offset 
 static_assert(offsetof(InstanceDataGPU, lod) == 72, "InstanceDataGPU.lod offset mismatch");
 static_assert(offsetof(InstanceDataGPU, wind_params) == 80, "InstanceDataGPU.wind_params offset mismatch");
 
+// Per-instance color grading (std430). Indexed by SplatRefGPU.instance_id, parallel to
+// InstanceDataGPU. Populated by GaussianSplatSceneDirector::build_instance_grading_buffer_for_renderer.
+//
+// primary:   x = enabled (0/1), y = exposure, z = contrast, w = saturation
+// secondary: x = temperature,   y = tint,     z = hue_shift, w = reserved
+struct InstanceGradingGPU {
+    float primary[4];
+    float secondary[4];
+};
+
+static_assert(sizeof(InstanceGradingGPU) == 32, "InstanceGradingGPU must be 32 bytes");
+static_assert(alignof(InstanceGradingGPU) <= 16, "InstanceGradingGPU alignment must not exceed 16 bytes");
+static_assert(offsetof(InstanceGradingGPU, primary) == 0, "InstanceGradingGPU.primary offset mismatch");
+static_assert(offsetof(InstanceGradingGPU, secondary) == 16, "InstanceGradingGPU.secondary offset mismatch");
+
 // Per-asset metadata table.
 struct AssetLodRangeGPU {
     uint32_t base;               // base into AssetChunkIndexBuffer

--- a/modules/gaussian_splatting/renderer/gaussian_gpu_layout.h
+++ b/modules/gaussian_splatting/renderer/gaussian_gpu_layout.h
@@ -7,7 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 
-static constexpr uint32_t GS_RENDER_PARAMS_LAYOUT_VERSION = 17; // Keep in sync with shaders/includes/gs_render_params.glsl
+static constexpr uint32_t GS_RENDER_PARAMS_LAYOUT_VERSION = 18; // Keep in sync with shaders/includes/gs_render_params.glsl
 static constexpr uint32_t GS_MAX_ASSET_LODS = 8;
 static constexpr uint32_t GS_SH_METADATA_FIRST_ORDER_MASK = 0x000000FFu;
 static constexpr uint32_t GS_SH_METADATA_HIGH_ORDER_MASK = 0x0000FF00u;
@@ -72,6 +72,7 @@ struct alignas(16) InstanceDataGPU {
     uint32_t ids[2];             // x = asset_id, y = flags
     uint32_t lod[2];             // x = resolved_lod_level, y = reserved
     float wind_params[4];        // xyz = wind direction override (0,0,0=infer global), w = wind frequency scale
+    float effect_params[4];      // x = position response scale, y = opacity response scale, z/w = reserved
 };
 
 // Instance flag bits (ids[1]).
@@ -86,7 +87,7 @@ static constexpr uint32_t GS_INSTANCE_WIND_MODE_FORCE_DISABLED = 1u;
 static constexpr uint32_t GS_INSTANCE_WIND_MODE_FORCE_ENABLED = 2u;
 
 static_assert(alignof(InstanceDataGPU) == 16, "InstanceDataGPU must be 16-byte aligned");
-static_assert(sizeof(InstanceDataGPU) == 96, "InstanceDataGPU must be 96 bytes");
+static_assert(sizeof(InstanceDataGPU) == 112, "InstanceDataGPU must be 112 bytes");
 static_assert(offsetof(InstanceDataGPU, rotation) == 0, "InstanceDataGPU.rotation offset mismatch");
 static_assert(offsetof(InstanceDataGPU, inv_rotation) == 16, "InstanceDataGPU.inv_rotation offset mismatch");
 static_assert(offsetof(InstanceDataGPU, translation_scale) == 32, "InstanceDataGPU.translation_scale offset mismatch");
@@ -94,6 +95,7 @@ static_assert(offsetof(InstanceDataGPU, params) == 48, "InstanceDataGPU.params o
 static_assert(offsetof(InstanceDataGPU, ids) == 64, "InstanceDataGPU.ids offset mismatch");
 static_assert(offsetof(InstanceDataGPU, lod) == 72, "InstanceDataGPU.lod offset mismatch");
 static_assert(offsetof(InstanceDataGPU, wind_params) == 80, "InstanceDataGPU.wind_params offset mismatch");
+static_assert(offsetof(InstanceDataGPU, effect_params) == 96, "InstanceDataGPU.effect_params offset mismatch");
 
 // Per-instance color grading (std430). Indexed by SplatRefGPU.instance_id, parallel to
 // InstanceDataGPU. Populated by GaussianSplatSceneDirector::build_instance_grading_buffer_for_renderer.
@@ -462,9 +464,12 @@ struct alignas(16) TileRenderParamsGPU {
     float wind_time_config[4];
     // Single global sphere effector (foundation for capped multi-effector support):
     // effector_sphere: xyz=center (world), w=radius
-    // effector_config: x=enabled (0/1), y=strength (meters), z=falloff exponent, w=reserved
+    // effector_config: x=enabled (0/1), y=strength (meters), z=falloff exponent, w=frequency (Hz)
     float effector_sphere[4];
     float effector_config[4];
+    // effector_opacity_config: x=affect_position (0/1), y=affect_opacity (0/1),
+    // z=opacity_strength (0..1), w=target_opacity (0..1)
+    float effector_opacity_config[4];
     // Hotspot-aware pre-raster cull (deterministic, shared by COUNT and EMIT):
     // x = hotspot_pressure_threshold (absolute previous-frame tile count above which
     //     the per-tile prune fires; 0 disables the cull entirely)
@@ -474,7 +479,7 @@ struct alignas(16) TileRenderParamsGPU {
     float hotspot_cull_config[4];
 };
 
-static_assert(sizeof(TileRenderParamsGPU) == 736, "TileRenderParamsGPU must match RenderParams std140 layout (736 bytes)");
+static_assert(sizeof(TileRenderParamsGPU) == 752, "TileRenderParamsGPU must match RenderParams std140 layout (752 bytes)");
 static_assert(alignof(TileRenderParamsGPU) == 16, "TileRenderParamsGPU must be 16-byte aligned");
 static_assert(offsetof(TileRenderParamsGPU, view_matrix) == 0, "TileRenderParamsGPU.view_matrix offset mismatch");
 static_assert(offsetof(TileRenderParamsGPU, inv_view_matrix) == 64, "TileRenderParamsGPU.inv_view_matrix offset mismatch");
@@ -521,7 +526,8 @@ static_assert(offsetof(TileRenderParamsGPU, wind_dir_strength) == 656, "TileRend
 static_assert(offsetof(TileRenderParamsGPU, wind_time_config) == 672, "TileRenderParamsGPU.wind_time_config offset mismatch");
 static_assert(offsetof(TileRenderParamsGPU, effector_sphere) == 688, "TileRenderParamsGPU.effector_sphere offset mismatch");
 static_assert(offsetof(TileRenderParamsGPU, effector_config) == 704, "TileRenderParamsGPU.effector_config offset mismatch");
-static_assert(offsetof(TileRenderParamsGPU, hotspot_cull_config) == 720, "TileRenderParamsGPU.hotspot_cull_config offset mismatch");
+static_assert(offsetof(TileRenderParamsGPU, effector_opacity_config) == 720, "TileRenderParamsGPU.effector_opacity_config offset mismatch");
+static_assert(offsetof(TileRenderParamsGPU, hotspot_cull_config) == 736, "TileRenderParamsGPU.hotspot_cull_config offset mismatch");
 
 struct alignas(16) FrustumCullParamsGPU {
     static constexpr uint32_t kFrustumPlaneCount = 6;
@@ -601,6 +607,7 @@ struct alignas(16) InstanceDepthParamsGPU {
     float wind_time_config[4];
     float effector_sphere[4];
     float effector_config[4];
+    float effector_opacity_config[4];
     float frustum_planes[InstanceCullParamsGPU::kFrustumPlaneCount][4];
     float camera_position_ortho[4]; // xyz = camera position, w = orthographic flag (1.0 or 0.0)
     float cull_screen_distance[4]; // x = pixel_scale_y, y = tiny_splat_radius_px, z = min_screen_threshold_px, w = max_distance_sq
@@ -608,7 +615,7 @@ struct alignas(16) InstanceDepthParamsGPU {
 };
 
 static_assert(alignof(InstanceDepthParamsGPU) == 16, "InstanceDepthParamsGPU must be 16-byte aligned");
-static_assert(sizeof(InstanceDepthParamsGPU) == 288, "InstanceDepthParamsGPU must match std140 layout (288 bytes)");
+static_assert(sizeof(InstanceDepthParamsGPU) == 304, "InstanceDepthParamsGPU must match std140 layout (304 bytes)");
 static_assert(sizeof(InstanceDepthParamsGPU) % 16 == 0, "InstanceDepthParamsGPU must align to 16 bytes for std140");
 static_assert(offsetof(InstanceDepthParamsGPU, view_matrix) == 0, "InstanceDepthParamsGPU.view_matrix offset mismatch");
 static_assert(offsetof(InstanceDepthParamsGPU, visible_chunk_count) == 64, "InstanceDepthParamsGPU.visible_chunk_count offset mismatch");
@@ -619,10 +626,11 @@ static_assert(offsetof(InstanceDepthParamsGPU, wind_dir_strength) == 80, "Instan
 static_assert(offsetof(InstanceDepthParamsGPU, wind_time_config) == 96, "InstanceDepthParamsGPU.wind_time_config offset mismatch");
 static_assert(offsetof(InstanceDepthParamsGPU, effector_sphere) == 112, "InstanceDepthParamsGPU.effector_sphere offset mismatch");
 static_assert(offsetof(InstanceDepthParamsGPU, effector_config) == 128, "InstanceDepthParamsGPU.effector_config offset mismatch");
-static_assert(offsetof(InstanceDepthParamsGPU, frustum_planes) == 144, "InstanceDepthParamsGPU.frustum_planes offset mismatch");
-static_assert(offsetof(InstanceDepthParamsGPU, camera_position_ortho) == 240, "InstanceDepthParamsGPU.camera_position_ortho offset mismatch");
-static_assert(offsetof(InstanceDepthParamsGPU, cull_screen_distance) == 256, "InstanceDepthParamsGPU.cull_screen_distance offset mismatch");
-static_assert(offsetof(InstanceDepthParamsGPU, cull_frustum_radius) == 272, "InstanceDepthParamsGPU.cull_frustum_radius offset mismatch");
+static_assert(offsetof(InstanceDepthParamsGPU, effector_opacity_config) == 144, "InstanceDepthParamsGPU.effector_opacity_config offset mismatch");
+static_assert(offsetof(InstanceDepthParamsGPU, frustum_planes) == 160, "InstanceDepthParamsGPU.frustum_planes offset mismatch");
+static_assert(offsetof(InstanceDepthParamsGPU, camera_position_ortho) == 256, "InstanceDepthParamsGPU.camera_position_ortho offset mismatch");
+static_assert(offsetof(InstanceDepthParamsGPU, cull_screen_distance) == 272, "InstanceDepthParamsGPU.cull_screen_distance offset mismatch");
+static_assert(offsetof(InstanceDepthParamsGPU, cull_frustum_radius) == 288, "InstanceDepthParamsGPU.cull_frustum_radius offset mismatch");
 
 void pack_gaussian(const Gaussian &src,
         PackedGaussian &dst,

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
@@ -1271,6 +1271,8 @@ void GaussianSplatRenderer::_teardown_resources() {
         get_pipeline_state().gaussian_shader_initialized = false;
         _free_owned_resource(get_device_state().rd, resource_state.instance_buffer);
         resource_state.instance_buffer_capacity = 0;
+        _free_owned_resource(get_device_state().rd, resource_state.instance_grading_buffer);
+        resource_state.instance_grading_buffer_capacity = 0;
         _free_owned_resource(get_device_state().rd, resource_state.instance_visible_chunk_buffer);
         resource_state.instance_visible_chunk_capacity = 0;
         _free_owned_resource(get_device_state().rd, resource_state.instance_splat_ref_buffer);
@@ -2720,6 +2722,56 @@ bool GaussianSplatRenderer::update_instance_buffer(LocalVector<InstanceDataGPU> 
     instance_pipeline_buffers.instance_buffer = resource_state.instance_buffer;
     instance_pipeline_buffers.instance_count = instance_count;
 
+    return true;
+}
+
+bool GaussianSplatRenderer::update_instance_grading_buffer(const LocalVector<InstanceGradingGPU> &p_gradings) {
+    // Sibling SSBO to instance_buffer. Must always resolve to a valid RID — the shader
+    // binds it unconditionally at binding 20. When the caller passes zero rows (e.g.
+    // transient empty world) we still allocate a 1-row buffer and write a neutral default
+    // so the shader's indexed read is well-defined.
+    if (!_ensure_rendering_device("update_instance_grading_buffer")) {
+        return false;
+    }
+
+    RenderingDevice *rd = get_device_state().rd;
+    if (!rd) {
+        WARN_PRINT_ONCE("[GaussianSplatRenderer] Grading buffer upload skipped; rendering device not available.");
+        return false;
+    }
+
+    ResourceState &resource_state = get_resource_state();
+
+    const uint32_t row_count = MAX(p_gradings.size(), (uint32_t)1);
+    if (!resource_state.instance_grading_buffer.is_valid() || resource_state.instance_grading_buffer_capacity < row_count) {
+        const uint32_t new_capacity = next_power_of_2(row_count);
+        const uint64_t buffer_size = static_cast<uint64_t>(new_capacity) * sizeof(InstanceGradingGPU);
+        if (resource_state.instance_grading_buffer.is_valid()) {
+            _free_owned_resource(rd, resource_state.instance_grading_buffer);
+        }
+        resource_state.instance_grading_buffer = rd->storage_buffer_create(buffer_size);
+        if (!resource_state.instance_grading_buffer.is_valid()) {
+            resource_state.instance_grading_buffer_capacity = 0;
+            WARN_PRINT_ONCE("[GaussianSplatRenderer] Failed to allocate instance grading buffer.");
+            return false;
+        }
+        rd->set_resource_name(resource_state.instance_grading_buffer, "GS_InstanceGradingBuffer");
+        track_resource_owner(resource_state.instance_grading_buffer, rd);
+        resource_state.instance_grading_buffer_capacity = new_capacity;
+    }
+
+    if (p_gradings.is_empty()) {
+        // Write a single neutral row so shader indexing is always valid.
+        InstanceGradingGPU neutral = {};
+        neutral.primary[2] = 1.0f; // contrast = 1
+        neutral.primary[3] = 1.0f; // saturation = 1
+        rd->buffer_update(resource_state.instance_grading_buffer, 0, sizeof(InstanceGradingGPU), &neutral);
+    } else {
+        const uint64_t upload_size = static_cast<uint64_t>(p_gradings.size()) * sizeof(InstanceGradingGPU);
+        rd->buffer_update(resource_state.instance_grading_buffer, 0, upload_size, p_gradings.ptr());
+    }
+
+    instance_pipeline_buffers.instance_grading_buffer = resource_state.instance_grading_buffer;
     return true;
 }
 

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
@@ -940,6 +940,11 @@ public:
      */
     void set_color_grading(const Ref<class ColorGradingResource> &p_grading) override;
     Ref<class ColorGradingResource> get_color_grading() const { return get_render_config().color_grading; }
+    // Signal handler for the renderer-wide color grading resource's `changed` signal.
+    // Fires when slider edits mutate the resource values in place (same ref, different
+    // values). Re-runs the grading invalidation path so fallback-graded rows refresh.
+    // Exposed so RenderConfigOrchestrator can connect/disconnect via `callable_mp`.
+    void _on_renderer_default_grading_changed();
 
     /**
      * @brief Enables or disables static sort caching.

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
@@ -789,6 +789,9 @@ public:
     Error apply_world_submission_contract(const WorldSubmissionContract &p_contract);
     void clear_world_submission_contract();
     bool update_instance_buffer(LocalVector<InstanceDataGPU> &p_instances, const PublishedInstanceAssetRemap &p_remap);
+    // Upload the per-instance color grading SSBO. Called alongside update_instance_buffer
+    // from both the resident and streaming contract-publish paths.
+    bool update_instance_grading_buffer(const LocalVector<InstanceGradingGPU> &p_gradings);
     int get_cached_streaming_route_policy();
     const String &get_cached_streaming_route_policy_source();
 

--- a/modules/gaussian_splatting/renderer/gpu_sorter.cpp
+++ b/modules/gaussian_splatting/renderer/gpu_sorter.cpp
@@ -785,7 +785,13 @@ Error BitonicSort::sort(RID keys_buffer, RID values_buffer, uint32_t count) {
         return ERR_CANT_CREATE;
     }
 
-    if (uniform_set.is_valid() && uniform_owner && uniform_owner->uniform_set_is_valid(uniform_set)) {
+    // Gate the device dereference on the recorded generation the same way
+    // _free_uniform_sets_safe does. If the RenderingDevice was recreated
+    // between sorts (device reset / hot-reload), `uniform_owner` is a stale
+    // pointer; calling `uniform_set_is_valid()` on it would be UB.
+    if (uniform_set.is_valid() && uniform_owner &&
+            ResourceOwnerMismatchContract::is_device_generation_valid(uniform_owner, uniform_owner_generation) &&
+            uniform_owner->uniform_set_is_valid(uniform_set)) {
         uniform_owner->free(uniform_set);
     }
     uniform_set = RID();

--- a/modules/gaussian_splatting/renderer/instance_pipeline_contract.h
+++ b/modules/gaussian_splatting/renderer/instance_pipeline_contract.h
@@ -52,6 +52,7 @@ enum class InvariantViolationReason : uint8_t {
 
 	RASTER_ATLAS_GAUSSIAN_BUFFER_MISSING,
 	RASTER_INSTANCE_BUFFER_MISSING,
+	RASTER_INSTANCE_GRADING_BUFFER_MISSING,
 	RASTER_SPLAT_REF_BUFFER_MISSING,
 	RASTER_INSTANCE_COUNT_BUFFER_MISSING,
 	RASTER_QUANTIZATION_BUFFER_MISSING,
@@ -116,6 +117,7 @@ inline InvariantViolationClass get_violation_class(InvariantViolationReason p_re
 
 		case InvariantViolationReason::RASTER_ATLAS_GAUSSIAN_BUFFER_MISSING:
 		case InvariantViolationReason::RASTER_INSTANCE_BUFFER_MISSING:
+		case InvariantViolationReason::RASTER_INSTANCE_GRADING_BUFFER_MISSING:
 		case InvariantViolationReason::RASTER_SPLAT_REF_BUFFER_MISSING:
 		case InvariantViolationReason::RASTER_INSTANCE_COUNT_BUFFER_MISSING:
 		case InvariantViolationReason::RASTER_QUANTIZATION_BUFFER_MISSING:
@@ -217,6 +219,8 @@ inline const char *get_violation_reason_name(InvariantViolationReason p_reason) 
 			return "raster_atlas_gaussian_buffer_missing";
 		case InvariantViolationReason::RASTER_INSTANCE_BUFFER_MISSING:
 			return "raster_instance_buffer_missing";
+		case InvariantViolationReason::RASTER_INSTANCE_GRADING_BUFFER_MISSING:
+			return "raster_instance_grading_buffer_missing";
 		case InvariantViolationReason::RASTER_SPLAT_REF_BUFFER_MISSING:
 			return "raster_splat_ref_buffer_missing";
 		case InvariantViolationReason::RASTER_INSTANCE_COUNT_BUFFER_MISSING:
@@ -368,6 +372,14 @@ inline InvariantViolationReason first_raster_violation(const GaussianSplatRender
 	}
 	if (!p_buffers.instance_buffer.is_valid()) {
 		return InvariantViolationReason::RASTER_INSTANCE_BUFFER_MISSING;
+	}
+	// Tile binning binds `instance_grading_buffer` at set=0 binding=20 and reads
+	// per-splat grading via `splat_ref.instance_id`. It is a hard requirement for
+	// raster readiness — without this check a caller can pass has_raster_buffers()
+	// yet still trip the runtime ERR_FAIL_COND in tile_render_binning.cpp at bind
+	// time, producing late ERR_UNCONFIGURED failures and fallback loops.
+	if (!p_buffers.instance_grading_buffer.is_valid()) {
+		return InvariantViolationReason::RASTER_INSTANCE_GRADING_BUFFER_MISSING;
 	}
 	if (!p_buffers.splat_ref_buffer.is_valid()) {
 		return InvariantViolationReason::RASTER_SPLAT_REF_BUFFER_MISSING;

--- a/modules/gaussian_splatting/renderer/instance_pipeline_contract.h
+++ b/modules/gaussian_splatting/renderer/instance_pipeline_contract.h
@@ -58,6 +58,7 @@ enum class InvariantViolationReason : uint8_t {
 	RASTER_QUANTIZATION_BUFFER_MISSING,
 
 	TILE_INSTANCE_BUFFER_MISSING,
+	TILE_INSTANCE_GRADING_BUFFER_MISSING,
 	TILE_SPLAT_REF_BUFFER_MISSING,
 	TILE_INDIRECT_COUNT_BUFFER_MISSING,
 	TILE_INDIRECT_DISPATCH_BUFFER_MISSING,
@@ -124,6 +125,7 @@ inline InvariantViolationClass get_violation_class(InvariantViolationReason p_re
 			return InvariantViolationClass::RASTER;
 
 		case InvariantViolationReason::TILE_INSTANCE_BUFFER_MISSING:
+		case InvariantViolationReason::TILE_INSTANCE_GRADING_BUFFER_MISSING:
 		case InvariantViolationReason::TILE_SPLAT_REF_BUFFER_MISSING:
 		case InvariantViolationReason::TILE_INDIRECT_COUNT_BUFFER_MISSING:
 		case InvariantViolationReason::TILE_INDIRECT_DISPATCH_BUFFER_MISSING:
@@ -229,6 +231,8 @@ inline const char *get_violation_reason_name(InvariantViolationReason p_reason) 
 			return "raster_quantization_buffer_missing";
 		case InvariantViolationReason::TILE_INSTANCE_BUFFER_MISSING:
 			return "tile_instance_buffer_missing";
+		case InvariantViolationReason::TILE_INSTANCE_GRADING_BUFFER_MISSING:
+			return "tile_instance_grading_buffer_missing";
 		case InvariantViolationReason::TILE_SPLAT_REF_BUFFER_MISSING:
 			return "tile_splat_ref_buffer_missing";
 		case InvariantViolationReason::TILE_INDIRECT_COUNT_BUFFER_MISSING:
@@ -420,12 +424,21 @@ inline InvariantViolation evaluate_streaming_activation(const GaussianSplatRende
 	return InvariantViolation();
 }
 
-inline InvariantViolationReason first_tile_runtime_violation(const RID &p_instance_buffer, const RID &p_splat_ref_buffer,
+inline InvariantViolationReason first_tile_runtime_violation(const RID &p_instance_buffer,
+		const RID &p_instance_grading_buffer,
+		const RID &p_splat_ref_buffer,
 		const RID &p_indirect_count_buffer, const RID &p_indirect_dispatch_buffer,
 		bool p_quantization_required, const RID &p_quantization_buffer,
 		const RID &p_chunk_meta_buffer = RID()) {
 	if (!p_instance_buffer.is_valid()) {
 		return InvariantViolationReason::TILE_INSTANCE_BUFFER_MISSING;
+	}
+	// Tile binning binds `instance_grading_buffer` at set=0 binding=20 and reads
+	// it per splat, so a missing RID here is a hard contract violation. Fail
+	// fast during preflight instead of at uniform-set acquisition time, which
+	// otherwise surfaces as late fallback/error behavior.
+	if (!p_instance_grading_buffer.is_valid()) {
+		return InvariantViolationReason::TILE_INSTANCE_GRADING_BUFFER_MISSING;
 	}
 	if (!p_splat_ref_buffer.is_valid()) {
 		return InvariantViolationReason::TILE_SPLAT_REF_BUFFER_MISSING;

--- a/modules/gaussian_splatting/renderer/render_config_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_config_orchestrator.cpp
@@ -171,6 +171,14 @@ void GaussianSplatRenderer::_on_renderer_default_grading_changed() {
 	// (slider edits that mutate values in place — same Ref, new values). Re-run
 	// the invalidation path so fallback-graded rows pick up the fresh values on
 	// the next frame.
+	//
+	// Thread affinity: `changed` fires synchronously on the thread that called
+	// `emit_changed()`. In Godot practice, resource editing happens on the main
+	// thread (inspector UI, scene tree). If a caller ever edits the resource
+	// from a worker thread, the director generation bump below uses atomic ops
+	// so the fingerprint read is safe; the world_mutex inside the director
+	// serializes record mutations. invalidate_cached_render() likewise just
+	// flips a bool read by the render thread.
 	invalidate_cached_render();
 	if (GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton()) {
 		director->invalidate_grading_for_renderer(this);

--- a/modules/gaussian_splatting/renderer/render_config_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_config_orchestrator.cpp
@@ -48,17 +48,14 @@ void RenderConfigOrchestrator::set_color_grading(const Ref<ColorGradingResource>
 		(renderer->*runtime_ports.invalidate_cached_render)();
 		// Per-instance grading path: records without an explicit per-instance
 		// grading ref fall back to this renderer-wide default at build time.
-		// Bump the director's instance generation so the grading SSBO rebuilds
-		// next frame with the new fallback values (world-bound case).
+		// The director's invalidate call bumps both the world's instance
+		// generation (if present) AND the renderer's grading defaults counter
+		// that the streaming/resident upload fingerprints include — so the
+		// SSBO re-uploads on the next frame for both world-bound and direct-
+		// data flows.
 		if (GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton()) {
 			director->invalidate_grading_for_renderer(renderer);
 		}
-		// Renderer-only / direct-data flows have no SharedWorld — bumping the
-		// director generation above is a no-op there. Bump a per-renderer
-		// counter that is folded into the streaming upload fingerprint so the
-		// next frame treats this as a changed upload and re-runs the grading
-		// buffer write.
-		renderer->get_resource_state().instance_grading_defaults_generation++;
 	}
 }
 

--- a/modules/gaussian_splatting/renderer/render_config_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_config_orchestrator.cpp
@@ -43,7 +43,23 @@ void RenderConfigOrchestrator::set_color_grading(const Ref<ColorGradingResource>
 	if (render_config.color_grading == p_grading) {
 		return;
 	}
+	// Disconnect the signal on the OLD resource (if any) before swapping. Without
+	// this, dangling `changed` connections on replaced resources would keep calling
+	// the renderer handler after the resource is no longer the active default.
+	const Callable grading_changed = callable_mp(renderer, &GaussianSplatRenderer::_on_renderer_default_grading_changed);
+	if (render_config.color_grading.is_valid() && renderer &&
+			render_config.color_grading->is_connected("changed", grading_changed)) {
+		render_config.color_grading->disconnect("changed", grading_changed);
+	}
 	render_config.color_grading = p_grading;
+	// Connect the new resource so in-place slider edits (which emit `changed`
+	// without swapping the Ref) re-run the invalidation path. Without this,
+	// mutating the resource behind the scenes leaves fallback-graded rows
+	// stale until an unrelated content change forces a rebuild.
+	if (render_config.color_grading.is_valid() && renderer &&
+			!render_config.color_grading->is_connected("changed", grading_changed)) {
+		render_config.color_grading->connect("changed", grading_changed);
+	}
 	if (renderer) {
 		(renderer->*runtime_ports.invalidate_cached_render)();
 		// Per-instance grading path: records without an explicit per-instance
@@ -148,6 +164,17 @@ void GaussianSplatRenderer::set_opacity_multiplier(float p_opacity) {
 
 void GaussianSplatRenderer::set_color_grading(const Ref<ColorGradingResource> &p_grading) {
 	config_orchestrator->set_color_grading(p_grading);
+}
+
+void GaussianSplatRenderer::_on_renderer_default_grading_changed() {
+	// Fired when the renderer-wide default ColorGradingResource emits `changed`
+	// (slider edits that mutate values in place — same Ref, new values). Re-run
+	// the invalidation path so fallback-graded rows pick up the fresh values on
+	// the next frame.
+	invalidate_cached_render();
+	if (GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton()) {
+		director->invalidate_grading_for_renderer(this);
+	}
 }
 
 void GaussianSplatRenderer::set_interactive_state(InteractiveState p_state) {

--- a/modules/gaussian_splatting/renderer/render_config_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_config_orchestrator.cpp
@@ -2,6 +2,7 @@
 
 #include "render_data_orchestrator.h"
 #include "painterly_pass_graph.h"
+#include "../core/gaussian_splat_scene_director.h"
 #include "../interfaces/interactive_state_manager.h"
 #include "../interfaces/painterly_renderer.h"
 #include "../logger/gs_logger.h"
@@ -45,6 +46,13 @@ void RenderConfigOrchestrator::set_color_grading(const Ref<ColorGradingResource>
 	render_config.color_grading = p_grading;
 	if (renderer) {
 		(renderer->*runtime_ports.invalidate_cached_render)();
+		// Per-instance grading path: records without an explicit per-instance
+		// grading ref fall back to this renderer-wide default at build time.
+		// Bump the director's instance generation so the grading SSBO rebuilds
+		// next frame with the new fallback values.
+		if (GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton()) {
+			director->invalidate_grading_for_renderer(renderer);
+		}
 	}
 }
 

--- a/modules/gaussian_splatting/renderer/render_config_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_config_orchestrator.cpp
@@ -49,10 +49,16 @@ void RenderConfigOrchestrator::set_color_grading(const Ref<ColorGradingResource>
 		// Per-instance grading path: records without an explicit per-instance
 		// grading ref fall back to this renderer-wide default at build time.
 		// Bump the director's instance generation so the grading SSBO rebuilds
-		// next frame with the new fallback values.
+		// next frame with the new fallback values (world-bound case).
 		if (GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton()) {
 			director->invalidate_grading_for_renderer(renderer);
 		}
+		// Renderer-only / direct-data flows have no SharedWorld — bumping the
+		// director generation above is a no-op there. Bump a per-renderer
+		// counter that is folded into the streaming upload fingerprint so the
+		// next frame treats this as a changed upload and re-runs the grading
+		// buffer write.
+		renderer->get_resource_state().instance_grading_defaults_generation++;
 	}
 }
 

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -327,13 +327,7 @@ static uint64_t _compute_lighting_signature(const RenderDataRD *p_render_data, u
 	float wind_spatial_frequency = 0.1f;
 	float wind_time_scale = 1.0f;
 	Vector3 wind_direction = Vector3(1.0f, 0.0f, 0.0f);
-	int max_effectors = 1;
-	bool sphere_effector_enabled = false;
-	Vector3 sphere_effector_center = Vector3();
-	float sphere_effector_radius = 0.0f;
-	float sphere_effector_strength = 0.0f;
-	float sphere_effector_falloff = 2.0f;
-	float sphere_effector_frequency = 2.0f;
+	gs::settings::GSSphereEffectorSettings sphere_effector_settings;
 	if (ProjectSettings *ps = ProjectSettings::get_singleton()) {
 		static const StringName direct_path("rendering/gaussian_splatting/lighting/direct_light_scale");
 		static const StringName indirect_path("rendering/gaussian_splatting/lighting/indirect_sh_scale");
@@ -349,16 +343,6 @@ static uint64_t _compute_lighting_signature(const RenderDataRD *p_render_data, u
 		static const StringName wind_frequency_path("rendering/gaussian_splatting/animation/wind_frequency");
 		static const StringName wind_spatial_frequency_path("rendering/gaussian_splatting/animation/wind_spatial_frequency");
 		static const StringName wind_time_scale_path("rendering/gaussian_splatting/animation/wind_time_scale");
-		static const StringName max_effectors_path("rendering/gaussian_splatting/effects/max_effectors");
-		static const StringName sphere_effector_enabled_path("rendering/gaussian_splatting/effects/sphere_effector_enabled");
-		static const StringName sphere_effector_center_x_path("rendering/gaussian_splatting/effects/sphere_effector_center_x");
-		static const StringName sphere_effector_center_y_path("rendering/gaussian_splatting/effects/sphere_effector_center_y");
-		static const StringName sphere_effector_center_z_path("rendering/gaussian_splatting/effects/sphere_effector_center_z");
-		static const StringName sphere_effector_radius_path("rendering/gaussian_splatting/effects/sphere_effector_radius");
-		static const StringName sphere_effector_strength_path("rendering/gaussian_splatting/effects/sphere_effector_strength");
-		static const StringName sphere_effector_falloff_path("rendering/gaussian_splatting/effects/sphere_effector_falloff");
-		static const StringName sphere_effector_frequency_path("rendering/gaussian_splatting/effects/sphere_effector_frequency");
-
 		direct_light_scale = _get_float_setting(ps, direct_path, direct_light_scale);
 		indirect_sh_scale = _get_float_setting(ps, indirect_path, indirect_sh_scale);
 		shadow_strength = _get_float_setting(ps, shadow_path, shadow_strength);
@@ -375,15 +359,7 @@ static uint64_t _compute_lighting_signature(const RenderDataRD *p_render_data, u
 		wind_spatial_frequency = _get_float_setting(ps, wind_spatial_frequency_path, wind_spatial_frequency);
 		wind_time_scale = _get_float_setting(ps, wind_time_scale_path, wind_time_scale);
 
-		max_effectors = _get_int_setting(ps, max_effectors_path, max_effectors);
-		sphere_effector_enabled = _get_bool_setting(ps, sphere_effector_enabled_path, sphere_effector_enabled);
-		sphere_effector_center.x = _get_float_setting(ps, sphere_effector_center_x_path, sphere_effector_center.x);
-		sphere_effector_center.y = _get_float_setting(ps, sphere_effector_center_y_path, sphere_effector_center.y);
-		sphere_effector_center.z = _get_float_setting(ps, sphere_effector_center_z_path, sphere_effector_center.z);
-		sphere_effector_radius = _get_float_setting(ps, sphere_effector_radius_path, sphere_effector_radius);
-		sphere_effector_strength = _get_float_setting(ps, sphere_effector_strength_path, sphere_effector_strength);
-		sphere_effector_falloff = _get_float_setting(ps, sphere_effector_falloff_path, sphere_effector_falloff);
-		sphere_effector_frequency = _get_float_setting(ps, sphere_effector_frequency_path, sphere_effector_frequency);
+		sphere_effector_settings = gs::settings::get_sphere_effector_settings(ps, true);
 	}
 	seed = _hash_float_bits(direct_light_scale, seed);
 	seed = _hash_float_bits(indirect_sh_scale, seed);
@@ -397,14 +373,17 @@ static uint64_t _compute_lighting_signature(const RenderDataRD *p_render_data, u
 	seed = _hash_float_bits(wind_frequency, seed);
 	seed = _hash_float_bits(wind_spatial_frequency, seed);
 	seed = _hash_float_bits(wind_time_scale, seed);
-	const int capped_effectors = CLAMP(max_effectors, 0, 1);
-	seed = _hash_u64(static_cast<uint64_t>(capped_effectors), seed);
-	const bool sphere_effective_enabled = capped_effectors > 0 && sphere_effector_enabled;
-	seed = _hash_bool(sphere_effective_enabled, seed);
-	seed = _hash_vector3(sphere_effector_center, seed);
-	seed = _hash_float_bits(MAX(0.0f, sphere_effector_radius), seed);
-	seed = _hash_float_bits(sphere_effector_strength, seed);
-	seed = _hash_float_bits(MAX(0.001f, sphere_effector_falloff), seed);
+	seed = _hash_u64(static_cast<uint64_t>(sphere_effector_settings.max_effectors), seed);
+	seed = _hash_bool(sphere_effector_settings.enabled, seed);
+	seed = _hash_vector3(sphere_effector_settings.center, seed);
+	seed = _hash_float_bits(sphere_effector_settings.radius, seed);
+	seed = _hash_float_bits(sphere_effector_settings.strength, seed);
+	seed = _hash_float_bits(sphere_effector_settings.falloff, seed);
+	seed = _hash_float_bits(sphere_effector_settings.frequency, seed);
+	seed = _hash_bool(sphere_effector_settings.affect_position, seed);
+	seed = _hash_bool(sphere_effector_settings.affect_opacity, seed);
+	seed = _hash_float_bits(sphere_effector_settings.opacity_strength, seed);
+	seed = _hash_float_bits(sphere_effector_settings.target_opacity, seed);
 	if (wind_enabled && wind_strength > 0.0f) {
 		const float wind_time_seconds = float(double(p_frame_id) * (1.0 / 60.0) * double(MAX(wind_time_scale, 0.0f)));
 		seed = _hash_float_bits(wind_time_seconds, seed);
@@ -1685,13 +1664,7 @@ Error RenderPipelineStages::RasterStage::render_tile_fallback(const Size2i &p_vi
 	float wind_frequency = 1.0f;
 	float wind_spatial_frequency = 0.1f;
 	float wind_time_scale = 1.0f;
-	int max_effectors = 1;
-	bool sphere_effector_enabled = false;
-	Vector3 sphere_effector_center = Vector3();
-	float sphere_effector_radius = 0.0f;
-	float sphere_effector_strength = 0.0f;
-	float sphere_effector_falloff = 2.0f;
-	float sphere_effector_frequency = 2.0f;
+	gs::settings::GSSphereEffectorSettings sphere_effector_settings;
 	if (ProjectSettings *ps = ProjectSettings::get_singleton()) {
 		static const StringName direct_path("rendering/gaussian_splatting/lighting/direct_light_scale");
 		static const StringName indirect_path("rendering/gaussian_splatting/lighting/indirect_sh_scale");
@@ -1707,16 +1680,6 @@ Error RenderPipelineStages::RasterStage::render_tile_fallback(const Size2i &p_vi
 		static const StringName wind_frequency_path("rendering/gaussian_splatting/animation/wind_frequency");
 		static const StringName wind_spatial_frequency_path("rendering/gaussian_splatting/animation/wind_spatial_frequency");
 		static const StringName wind_time_scale_path("rendering/gaussian_splatting/animation/wind_time_scale");
-		static const StringName max_effectors_path("rendering/gaussian_splatting/effects/max_effectors");
-		static const StringName sphere_effector_enabled_path("rendering/gaussian_splatting/effects/sphere_effector_enabled");
-		static const StringName sphere_effector_center_x_path("rendering/gaussian_splatting/effects/sphere_effector_center_x");
-		static const StringName sphere_effector_center_y_path("rendering/gaussian_splatting/effects/sphere_effector_center_y");
-		static const StringName sphere_effector_center_z_path("rendering/gaussian_splatting/effects/sphere_effector_center_z");
-		static const StringName sphere_effector_radius_path("rendering/gaussian_splatting/effects/sphere_effector_radius");
-		static const StringName sphere_effector_strength_path("rendering/gaussian_splatting/effects/sphere_effector_strength");
-		static const StringName sphere_effector_falloff_path("rendering/gaussian_splatting/effects/sphere_effector_falloff");
-		static const StringName sphere_effector_frequency_path("rendering/gaussian_splatting/effects/sphere_effector_frequency");
-
 		direct_light_scale = _get_float_setting(ps, direct_path, direct_light_scale);
 		indirect_sh_scale = _get_float_setting(ps, indirect_path, indirect_sh_scale);
 		shadow_strength = _get_float_setting(ps, shadow_path, shadow_strength);
@@ -1731,15 +1694,7 @@ Error RenderPipelineStages::RasterStage::render_tile_fallback(const Size2i &p_vi
 		wind_frequency = _get_float_setting(ps, wind_frequency_path, wind_frequency);
 		wind_spatial_frequency = _get_float_setting(ps, wind_spatial_frequency_path, wind_spatial_frequency);
 		wind_time_scale = _get_float_setting(ps, wind_time_scale_path, wind_time_scale);
-		max_effectors = _get_int_setting(ps, max_effectors_path, max_effectors);
-		sphere_effector_enabled = _get_bool_setting(ps, sphere_effector_enabled_path, sphere_effector_enabled);
-		sphere_effector_center.x = _get_float_setting(ps, sphere_effector_center_x_path, sphere_effector_center.x);
-		sphere_effector_center.y = _get_float_setting(ps, sphere_effector_center_y_path, sphere_effector_center.y);
-		sphere_effector_center.z = _get_float_setting(ps, sphere_effector_center_z_path, sphere_effector_center.z);
-		sphere_effector_radius = _get_float_setting(ps, sphere_effector_radius_path, sphere_effector_radius);
-		sphere_effector_strength = _get_float_setting(ps, sphere_effector_strength_path, sphere_effector_strength);
-		sphere_effector_falloff = _get_float_setting(ps, sphere_effector_falloff_path, sphere_effector_falloff);
-		sphere_effector_frequency = _get_float_setting(ps, sphere_effector_frequency_path, sphere_effector_frequency);
+		sphere_effector_settings = gs::settings::get_sphere_effector_settings(ps, true);
 	}
 	render_params.direct_light_scale = CLAMP(direct_light_scale, 0.0f, 4.0f);
 	render_params.indirect_sh_scale = CLAMP(indirect_sh_scale, 0.0f, 4.0f);
@@ -1757,14 +1712,16 @@ Error RenderPipelineStages::RasterStage::render_tile_fallback(const Size2i &p_vi
 	render_params.wind_spatial_frequency = wind_spatial_frequency;
 	render_params.wind_time_seconds = float(double(state_view.get_frame_state_view().frame_counter) * (1.0 / 60.0) *
 			double(MAX(wind_time_scale, 0.0f)));
-	const int capped_effectors = CLAMP(max_effectors, 0, 1);
-	const bool sphere_effective_enabled = capped_effectors > 0 && sphere_effector_enabled;
-	render_params.sphere_effector_enabled = sphere_effective_enabled;
-	render_params.sphere_effector_center = sphere_effector_center;
-	render_params.sphere_effector_radius = MAX(0.0f, sphere_effector_radius);
-	render_params.sphere_effector_strength = sphere_effector_strength;
-	render_params.sphere_effector_falloff = MAX(0.001f, sphere_effector_falloff);
-	render_params.sphere_effector_frequency = MAX(0.1f, sphere_effector_frequency);
+	render_params.sphere_effector_enabled = sphere_effector_settings.enabled;
+	render_params.sphere_effector_center = sphere_effector_settings.center;
+	render_params.sphere_effector_radius = sphere_effector_settings.radius;
+	render_params.sphere_effector_strength = sphere_effector_settings.strength;
+	render_params.sphere_effector_falloff = sphere_effector_settings.falloff;
+	render_params.sphere_effector_frequency = sphere_effector_settings.frequency;
+	render_params.sphere_effector_affect_position = sphere_effector_settings.affect_position;
+	render_params.sphere_effector_affect_opacity = sphere_effector_settings.affect_opacity;
+	render_params.sphere_effector_opacity_strength = sphere_effector_settings.opacity_strength;
+	render_params.sphere_effector_target_opacity = sphere_effector_settings.target_opacity;
 	if (instance_buffers_ready) {
 		render_params.instance_buffer = instance_buffers.instance_buffer;
 		render_params.instance_grading_buffer = instance_buffers.instance_grading_buffer;

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -1763,6 +1763,7 @@ Error RenderPipelineStages::RasterStage::render_tile_fallback(const Size2i &p_vi
 	render_params.sphere_effector_frequency = MAX(0.1f, sphere_effector_frequency);
 	if (instance_buffers_ready) {
 		render_params.instance_buffer = instance_buffers.instance_buffer;
+		render_params.instance_grading_buffer = instance_buffers.instance_grading_buffer;
 		render_params.splat_ref_buffer = instance_buffers.splat_ref_buffer;
 		render_params.chunk_meta_buffer = instance_buffers.chunk_meta_buffer;
 		render_params.quantization_buffer = instance_buffers.quantization_required ? instance_buffers.quantization_buffer : RID();
@@ -1774,6 +1775,7 @@ Error RenderPipelineStages::RasterStage::render_tile_fallback(const Size2i &p_vi
 		// This prevents transient stale/garbage descriptors from being interpreted
 		// as valid indirect dispatch/count buffers by tile stages.
 		render_params.instance_buffer = RID();
+		render_params.instance_grading_buffer = RID();
 		render_params.splat_ref_buffer = RID();
 		render_params.chunk_meta_buffer = RID();
 		render_params.quantization_buffer = RID();

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -271,7 +271,11 @@ static uint64_t _compute_color_grading_signature(const GaussianSplatRenderer::Re
 	// need to hash p_render_config.color_grading separately.
 	GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
 	if (director && p_renderer) {
-		seed = _hash_u64(director->compute_color_grading_signature_for_renderer(p_renderer), seed);
+		// Mirror the shadow filter used by build_instance_grading_buffer_for_renderer
+		// so shadow-pass caches only invalidate on shadow-caster grading edits.
+		const bool shadow_only = const_cast<GaussianSplatRenderer *>(p_renderer)
+				->is_shadow_instance_filter_enabled();
+		seed = _hash_u64(director->compute_color_grading_signature_for_renderer(p_renderer, shadow_only), seed);
 	} else {
 		// Fallback to the legacy single-slot hash when the director is not accessible
 		// (tests, tear-down paths).

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -24,6 +24,7 @@
 #include "../logger/gs_debug_trace.h"
 #include "../logger/gs_logger.h"
 #include "../resources/color_grading_resource.h"
+#include "../core/gaussian_splat_scene_director.h"
 #include "gpu_sorting_config.h"
 #include "instance_pipeline_contract.h"
 #include "pipeline_feature_set.h"
@@ -257,25 +258,37 @@ static uint64_t _hash_color(const Color &p_color, uint64_t p_seed) {
 	return p_seed;
 }
 
-static uint64_t _compute_color_grading_signature(const GaussianSplatRenderer::RenderConfig &p_render_config) {
+static uint64_t _compute_color_grading_signature(const GaussianSplatRenderer::RenderConfig &p_render_config,
+		const GaussianSplatRenderer *p_renderer) {
+	// Render-mode + opacity are still per-renderer inputs to the cache signature.
 	uint64_t seed = HASH_MURMUR3_SEED;
 	seed = _hash_u64(static_cast<uint64_t>(p_render_config.render_mode), seed);
 	seed = _hash_float_bits(p_render_config.opacity_multiplier, seed);
 
-	const Ref<ColorGradingResource> &grading = p_render_config.color_grading;
-	if (!grading.is_valid()) {
-		return _hash_u64(0ull, seed);
+	// Mix every per-instance grading tied to this renderer so any node's grading edit
+	// busts the sort/raster cache. The director hash also incorporates the renderer-wide
+	// default (used as fallback when a record has no per-instance ref), so we don't
+	// need to hash p_render_config.color_grading separately.
+	GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
+	if (director && p_renderer) {
+		seed = _hash_u64(director->compute_color_grading_signature_for_renderer(p_renderer), seed);
+	} else {
+		// Fallback to the legacy single-slot hash when the director is not accessible
+		// (tests, tear-down paths).
+		const Ref<ColorGradingResource> &grading = p_render_config.color_grading;
+		if (!grading.is_valid()) {
+			return _hash_u64(0ull, seed);
+		}
+		seed = _hash_u64(1ull, seed);
+		seed = _hash_u64(reinterpret_cast<uint64_t>(grading.ptr()), seed);
+		seed = _hash_bool(grading->get_enabled(), seed);
+		seed = _hash_float_bits(grading->get_exposure(), seed);
+		seed = _hash_float_bits(grading->get_contrast(), seed);
+		seed = _hash_float_bits(grading->get_saturation(), seed);
+		seed = _hash_float_bits(grading->get_temperature(), seed);
+		seed = _hash_float_bits(grading->get_tint(), seed);
+		seed = _hash_float_bits(grading->get_hue_shift(), seed);
 	}
-
-	seed = _hash_u64(1ull, seed);
-	seed = _hash_u64(reinterpret_cast<uint64_t>(grading.ptr()), seed);
-	seed = _hash_bool(grading->get_enabled(), seed);
-	seed = _hash_float_bits(grading->get_exposure(), seed);
-	seed = _hash_float_bits(grading->get_contrast(), seed);
-	seed = _hash_float_bits(grading->get_saturation(), seed);
-	seed = _hash_float_bits(grading->get_temperature(), seed);
-	seed = _hash_float_bits(grading->get_tint(), seed);
-	seed = _hash_float_bits(grading->get_hue_shift(), seed);
 	return seed;
 }
 
@@ -1308,7 +1321,7 @@ struct RenderPipelineStages::RasterCompositeStage {
 		}
 		raster_input.content_generation = renderer->get_instance_pipeline_content_generation();
 		raster_input.cull_config_signature = _compute_cull_config_signature(*renderer, state_view);
-		raster_input.color_grading_signature = _compute_color_grading_signature(state_view.get_render_config_view());
+		raster_input.color_grading_signature = _compute_color_grading_signature(state_view.get_render_config_view(), renderer);
 		raster_input.lighting_signature = _compute_lighting_signature(p_context.render_data, p_context.frame_id);
 		raster_input.metrics = p_context.metrics;
 		raster_input.state_view = &state_view;

--- a/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
@@ -47,6 +47,8 @@ static uint64_t _compute_instance_pipeline_resource_fingerprint(const ResourceSt
 	uint64_t generation = 0x6a09e667f3bcc909ULL;
 	generation = _mix_rid_generation(generation, p_resource_state.instance_buffer);
 	generation = _mix_u32_generation(generation, p_resource_state.instance_buffer_capacity);
+	generation = _mix_rid_generation(generation, p_resource_state.instance_grading_buffer);
+	generation = _mix_u32_generation(generation, p_resource_state.instance_grading_buffer_capacity);
 	generation = _mix_rid_generation(generation, p_resource_state.instance_visible_chunk_buffer);
 	generation = _mix_u32_generation(generation, p_resource_state.instance_visible_chunk_capacity);
 	generation = _mix_rid_generation(generation, p_resource_state.instance_splat_ref_buffer);
@@ -109,6 +111,8 @@ static uint64_t _compute_instance_pipeline_upload_fingerprint(const ResourceStat
 	uint64_t generation = 0xbb67ae8584caa73bULL;
 	generation = _mix_rid_generation(generation, p_resource_state.instance_buffer);
 	generation = _mix_u32_generation(generation, p_resource_state.instance_buffer_capacity);
+	generation = _mix_rid_generation(generation, p_resource_state.instance_grading_buffer);
+	generation = _mix_u32_generation(generation, p_resource_state.instance_grading_buffer_capacity);
 	generation = _mix_u32_generation(generation, p_buffers.instance_count);
 	generation = _mix_content_generation(generation, _compute_instance_asset_remap_fingerprint(p_remap));
 	return generation;
@@ -1879,6 +1883,15 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 					buffers = renderer->get_instance_pipeline_buffers();
 					renderer->clear_instance_pipeline_buffers();
 				} else {
+					// Per-instance color grading SSBO runs parallel to instance_buffer and must
+					// be refreshed on the same cadence. The buffer capacity is sized by the
+					// renderer, so this tolerates the empty-director (shim) case too.
+					LocalVector<InstanceGradingGPU> gradings;
+					if (director) {
+						director->build_instance_grading_buffer_for_renderer(renderer, gradings,
+								renderer->is_shadow_instance_filter_enabled());
+					}
+					renderer->update_instance_grading_buffer(gradings);
 					buffers = renderer->get_instance_pipeline_buffers();
 				}
 			} else if (!contract_changed) {

--- a/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
@@ -2149,8 +2149,20 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 		}
 		resource_state.instance_pipeline_contract_generation = contract_generation;
 		resource_state.instance_pipeline_contract_fingerprint = contract_fingerprint;
-		resource_state.instance_pipeline_upload_generation = upload_generation;
-		resource_state.instance_pipeline_upload_fingerprint = upload_fingerprint;
+		// When a grading upload failure left the in-flight fingerprint/generation
+		// zeroed to force a retry, DO NOT overwrite them with the freshly computed
+		// values here — that would make `upload_changed` go false next frame and
+		// the failure would become sticky until something unrelated advances the
+		// generation. Detect the retry-pending state (zeros written by the
+		// failure branch above) and skip the persistence so next frame's
+		// `previous_upload_*` still reads 0 and re-enters the upload path.
+		const bool upload_retry_pending = resource_state.instance_pipeline_upload_generation == 0 &&
+				resource_state.instance_pipeline_upload_fingerprint == 0 &&
+				(upload_generation != 0 || upload_fingerprint != 0);
+		if (!upload_retry_pending) {
+			resource_state.instance_pipeline_upload_generation = upload_generation;
+			resource_state.instance_pipeline_upload_fingerprint = upload_fingerprint;
+		}
 		resource_state.instance_pipeline_content_generation = _mix_content_generation(
 				base_content_generation,
 				contract_fingerprint);

--- a/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
@@ -50,7 +50,8 @@ static uint64_t _compute_instance_pipeline_resource_fingerprint(const ResourceSt
 	generation = _mix_u32_generation(generation, p_resource_state.instance_buffer_capacity);
 	generation = _mix_rid_generation(generation, p_resource_state.instance_grading_buffer);
 	generation = _mix_u32_generation(generation, p_resource_state.instance_grading_buffer_capacity);
-	generation = _mix_content_generation(generation, p_resource_state.instance_grading_defaults_generation);
+	generation = _mix_content_generation(generation,
+			p_resource_state.instance_grading_defaults_generation.load(std::memory_order_relaxed));
 	generation = _mix_rid_generation(generation, p_resource_state.instance_visible_chunk_buffer);
 	generation = _mix_u32_generation(generation, p_resource_state.instance_visible_chunk_capacity);
 	generation = _mix_rid_generation(generation, p_resource_state.instance_splat_ref_buffer);
@@ -115,7 +116,8 @@ static uint64_t _compute_instance_pipeline_upload_fingerprint(const ResourceStat
 	generation = _mix_u32_generation(generation, p_resource_state.instance_buffer_capacity);
 	generation = _mix_rid_generation(generation, p_resource_state.instance_grading_buffer);
 	generation = _mix_u32_generation(generation, p_resource_state.instance_grading_buffer_capacity);
-	generation = _mix_content_generation(generation, p_resource_state.instance_grading_defaults_generation);
+	generation = _mix_content_generation(generation,
+			p_resource_state.instance_grading_defaults_generation.load(std::memory_order_relaxed));
 	generation = _mix_u32_generation(generation, p_buffers.instance_count);
 	generation = _mix_content_generation(generation, _compute_instance_asset_remap_fingerprint(p_remap));
 	return generation;
@@ -1908,10 +1910,21 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 							GaussianSplatSceneDirector::fill_instance_grading_entry(renderer_default, gradings[i]);
 						}
 					}
-					// Treat a grading-buffer upload failure the same way the resident path
-					// does: tile binning requires instance_grading_buffer at binding 20, so
-					// we cannot leave the frame in a "ready" state with a missing SSBO.
-					if (!renderer->update_instance_grading_buffer(gradings)) {
+					// Contract: grading rows and instance rows must have identical counts
+					// and ordering because the shader indexes both with the same
+					// splat_ref.instance_id. If the director's filter logic and the streaming
+					// cache ever drift, this assertion catches it before uploading a short
+					// buffer the shader would read past.
+					if (gradings.size() != instance_pipeline_instance_cache.size()) {
+						ERR_PRINT_ONCE(vformat(
+								"[Streaming] grading buffer row count (%d) does not match instance cache row count (%d). "
+								"build_instance_grading_buffer_for_renderer and the streaming instance cache must stay 1:1.",
+								int(gradings.size()), int(instance_pipeline_instance_cache.size())));
+						resource_state_mut.instance_pipeline_upload_fingerprint = 0;
+						resource_state_mut.instance_pipeline_upload_generation = 0;
+						buffers = renderer->get_instance_pipeline_buffers();
+						renderer->clear_instance_pipeline_buffers();
+					} else if (!renderer->update_instance_grading_buffer(gradings)) {
 						// Reset the upload fingerprint/generation FIRST so the next frame's
 						// upload_changed comparison forces a retry attempt. Without this, a
 						// transient OOM / device hiccup becomes sticky — upload_changed

--- a/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
@@ -1570,6 +1570,8 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 		fallback_instance.wind_params[1] = 0.0f;
 		fallback_instance.wind_params[2] = 0.0f;
 		fallback_instance.wind_params[3] = 1.0f;
+		fallback_instance.effect_params[0] = 1.0f;
+		fallback_instance.effect_params[1] = 1.0f;
 		instance_pipeline_instance_cache.push_back(fallback_instance);
 		if (trace_enabled) {
 			GaussianSplatting::debug_trace_record_event("instance_pipeline",

--- a/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
@@ -1912,15 +1912,15 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 					// does: tile binning requires instance_grading_buffer at binding 20, so
 					// we cannot leave the frame in a "ready" state with a missing SSBO.
 					if (!renderer->update_instance_grading_buffer(gradings)) {
-						buffers = renderer->get_instance_pipeline_buffers();
-						renderer->clear_instance_pipeline_buffers();
-						// Reset the upload fingerprint so the next frame's upload_changed
-						// comparison forces a retry. Without this, a transient OOM / device
-						// hiccup becomes sticky — upload_changed would stay false and the
-						// grading SSBO would never re-upload until an unrelated generation
-						// change happens to flip the fingerprint.
+						// Reset the upload fingerprint/generation FIRST so the next frame's
+						// upload_changed comparison forces a retry attempt. Without this, a
+						// transient OOM / device hiccup becomes sticky — upload_changed
+						// would stay false and the grading SSBO would never re-upload until
+						// an unrelated generation change happens to flip the fingerprint.
 						resource_state_mut.instance_pipeline_upload_fingerprint = 0;
 						resource_state_mut.instance_pipeline_upload_generation = 0;
+						buffers = renderer->get_instance_pipeline_buffers();
+						renderer->clear_instance_pipeline_buffers();
 					} else {
 						buffers = renderer->get_instance_pipeline_buffers();
 					}

--- a/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
@@ -1622,6 +1622,14 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 	const uint64_t previous_contract_fingerprint = resource_state.instance_pipeline_contract_fingerprint;
 	const uint64_t previous_upload_generation = resource_state.instance_pipeline_upload_generation;
 	const uint64_t previous_upload_fingerprint = resource_state.instance_pipeline_upload_fingerprint;
+	// Flipped true by the grading-upload failure branches below so the
+	// end-of-frame persistence site knows to skip updating
+	// `instance_pipeline_upload_{generation,fingerprint}` — leaving both at 0
+	// forces `upload_changed` on next frame and re-enters the upload path.
+	// Using a dedicated flag instead of inspecting zeroed state on
+	// resource_state (which is also the normal initial / route-reset state)
+	// so a successful first-frame upload still persists its fingerprint.
+	bool upload_retry_pending = false;
 	resource_state.instance_pipeline_content_generation = base_content_generation;
 	bool instance_buffers_atlas_ready = false;
 	bool instance_buffers_cull_ready = false;
@@ -1920,18 +1928,16 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 								"[Streaming] grading buffer row count (%d) does not match instance cache row count (%d). "
 								"build_instance_grading_buffer_for_renderer and the streaming instance cache must stay 1:1.",
 								int(gradings.size()), int(instance_pipeline_instance_cache.size())));
-						resource_state_mut.instance_pipeline_upload_fingerprint = 0;
-						resource_state_mut.instance_pipeline_upload_generation = 0;
+						// Flag the frame so the persistence site at ~line 2150 skips writing
+						// back `upload_generation`/`upload_fingerprint`. Leaving them at the
+						// previous values forces `upload_changed` next frame and re-enters
+						// the upload path for a retry.
+						upload_retry_pending = true;
 						buffers = renderer->get_instance_pipeline_buffers();
 						renderer->clear_instance_pipeline_buffers();
 					} else if (!renderer->update_instance_grading_buffer(gradings)) {
-						// Reset the upload fingerprint/generation FIRST so the next frame's
-						// upload_changed comparison forces a retry attempt. Without this, a
-						// transient OOM / device hiccup becomes sticky — upload_changed
-						// would stay false and the grading SSBO would never re-upload until
-						// an unrelated generation change happens to flip the fingerprint.
-						resource_state_mut.instance_pipeline_upload_fingerprint = 0;
-						resource_state_mut.instance_pipeline_upload_generation = 0;
+						// Transient OOM / device hiccup — same retry mechanism.
+						upload_retry_pending = true;
 						buffers = renderer->get_instance_pipeline_buffers();
 						renderer->clear_instance_pipeline_buffers();
 					} else {
@@ -2149,16 +2155,14 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 		}
 		resource_state.instance_pipeline_contract_generation = contract_generation;
 		resource_state.instance_pipeline_contract_fingerprint = contract_fingerprint;
-		// When a grading upload failure left the in-flight fingerprint/generation
-		// zeroed to force a retry, DO NOT overwrite them with the freshly computed
-		// values here — that would make `upload_changed` go false next frame and
-		// the failure would become sticky until something unrelated advances the
-		// generation. Detect the retry-pending state (zeros written by the
-		// failure branch above) and skip the persistence so next frame's
-		// `previous_upload_*` still reads 0 and re-enters the upload path.
-		const bool upload_retry_pending = resource_state.instance_pipeline_upload_generation == 0 &&
-				resource_state.instance_pipeline_upload_fingerprint == 0 &&
-				(upload_generation != 0 || upload_fingerprint != 0);
+		// When a grading upload failure flagged `upload_retry_pending` above,
+		// DO NOT overwrite `instance_pipeline_upload_{generation,fingerprint}`
+		// — leave them at the previous frame's values so next frame's
+		// `upload_changed` comparison trips against the freshly computed
+		// fingerprint and the upload path retries. The flag is the
+		// authoritative "retry" signal; inspecting zeroed resource state
+		// wouldn't distinguish a just-failed frame from the normal initial /
+		// route-reset state.
 		if (!upload_retry_pending) {
 			resource_state.instance_pipeline_upload_generation = upload_generation;
 			resource_state.instance_pipeline_upload_fingerprint = upload_fingerprint;

--- a/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
@@ -50,6 +50,7 @@ static uint64_t _compute_instance_pipeline_resource_fingerprint(const ResourceSt
 	generation = _mix_u32_generation(generation, p_resource_state.instance_buffer_capacity);
 	generation = _mix_rid_generation(generation, p_resource_state.instance_grading_buffer);
 	generation = _mix_u32_generation(generation, p_resource_state.instance_grading_buffer_capacity);
+	generation = _mix_content_generation(generation, p_resource_state.instance_grading_defaults_generation);
 	generation = _mix_rid_generation(generation, p_resource_state.instance_visible_chunk_buffer);
 	generation = _mix_u32_generation(generation, p_resource_state.instance_visible_chunk_capacity);
 	generation = _mix_rid_generation(generation, p_resource_state.instance_splat_ref_buffer);
@@ -114,6 +115,7 @@ static uint64_t _compute_instance_pipeline_upload_fingerprint(const ResourceStat
 	generation = _mix_u32_generation(generation, p_resource_state.instance_buffer_capacity);
 	generation = _mix_rid_generation(generation, p_resource_state.instance_grading_buffer);
 	generation = _mix_u32_generation(generation, p_resource_state.instance_grading_buffer_capacity);
+	generation = _mix_content_generation(generation, p_resource_state.instance_grading_defaults_generation);
 	generation = _mix_u32_generation(generation, p_buffers.instance_count);
 	generation = _mix_content_generation(generation, _compute_instance_asset_remap_fingerprint(p_remap));
 	return generation;
@@ -1910,6 +1912,13 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 					if (!renderer->update_instance_grading_buffer(gradings)) {
 						buffers = renderer->get_instance_pipeline_buffers();
 						renderer->clear_instance_pipeline_buffers();
+						// Reset the upload fingerprint so the next frame's upload_changed
+						// comparison forces a retry. Without this, a transient OOM / device
+						// hiccup becomes sticky — upload_changed would stay false and the
+						// grading SSBO would never re-upload until an unrelated generation
+						// change happens to flip the fingerprint.
+						resource_state_mut.instance_pipeline_upload_fingerprint = 0;
+						resource_state_mut.instance_pipeline_upload_generation = 0;
 					} else {
 						buffers = renderer->get_instance_pipeline_buffers();
 					}

--- a/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
@@ -1904,8 +1904,15 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 							GaussianSplatSceneDirector::fill_instance_grading_entry(renderer_default, gradings[i]);
 						}
 					}
-					renderer->update_instance_grading_buffer(gradings);
-					buffers = renderer->get_instance_pipeline_buffers();
+					// Treat a grading-buffer upload failure the same way the resident path
+					// does: tile binning requires instance_grading_buffer at binding 20, so
+					// we cannot leave the frame in a "ready" state with a missing SSBO.
+					if (!renderer->update_instance_grading_buffer(gradings)) {
+						buffers = renderer->get_instance_pipeline_buffers();
+						renderer->clear_instance_pipeline_buffers();
+					} else {
+						buffers = renderer->get_instance_pipeline_buffers();
+					}
 				}
 			} else if (!contract_changed) {
 				buffers = renderer->get_instance_pipeline_buffers();

--- a/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
@@ -10,6 +10,7 @@
 #include "gpu_sorting_config.h"
 #include "../core/gaussian_splat_scene_director.h"
 #include "../interfaces/gpu_sorting_pipeline.h"
+#include "../resources/color_grading_resource.h"
 #include "../logger/gs_debug_trace.h"
 #include "../logger/gs_logger.h"
 
@@ -1890,6 +1891,18 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 					if (director) {
 						director->build_instance_grading_buffer_for_renderer(renderer, gradings,
 								renderer->is_shadow_instance_filter_enabled());
+					}
+					// Fallback: if the director produced no rows but the streaming cache has
+					// synthetic primary-fallback instances injected at line ~1541-1577, seed the
+					// rows from the renderer's legacy color_grading default so worldless /
+					// direct-data renderers keep their grading instead of being forced to
+					// neutral. Mirror the row count of instance_pipeline_instance_cache.
+					if (gradings.is_empty() && !instance_pipeline_instance_cache.is_empty()) {
+						const Ref<ColorGradingResource> renderer_default = renderer->get_color_grading();
+						gradings.resize(instance_pipeline_instance_cache.size());
+						for (uint32_t i = 0; i < gradings.size(); ++i) {
+							GaussianSplatSceneDirector::fill_instance_grading_entry(renderer_default, gradings[i]);
+						}
 					}
 					renderer->update_instance_grading_buffer(gradings);
 					buffers = renderer->get_instance_pipeline_buffers();

--- a/modules/gaussian_splatting/renderer/render_types/render_facade_state_types.h
+++ b/modules/gaussian_splatting/renderer/render_types/render_facade_state_types.h
@@ -16,6 +16,7 @@
 #include "../gaussian_gpu_layout.h"
 #include "../gpu_buffer_manager.h"
 #include "../gpu_performance_monitor.h"
+#include <atomic>
 #include <cstdint>
 #include <memory>
 
@@ -61,7 +62,13 @@ struct ResourceState {
 	// SharedWorld) still force a grading SSBO re-upload when the default mutates.
 	// Without this, fallback-graded rows keep stale GPU values until an unrelated
 	// topology change re-runs the publisher.
-	uint64_t instance_grading_defaults_generation = 0;
+	//
+	// Atomic: the writer runs under the director's world_mutex (via
+	// invalidate_grading_for_renderer) while the fingerprint readers in the
+	// streaming orchestrator may run on the render thread without that lock.
+	// Relaxed ordering is sufficient because the generation is a monotonic
+	// counter used only to detect "did something change since last frame".
+	std::atomic<uint64_t> instance_grading_defaults_generation{ 0 };
 	RID instance_visible_chunk_buffer;
 	uint32_t instance_visible_chunk_capacity = 0;
 	RID instance_splat_ref_buffer;

--- a/modules/gaussian_splatting/renderer/render_types/render_facade_state_types.h
+++ b/modules/gaussian_splatting/renderer/render_types/render_facade_state_types.h
@@ -56,6 +56,12 @@ struct ResourceState {
 	// shader can always index up to instance_buffer_capacity.
 	RID instance_grading_buffer;
 	uint32_t instance_grading_buffer_capacity = 0;
+	// Bumped whenever the renderer-wide color_grading default changes. Included
+	// in the upload fingerprint so renderer-only / direct-data flows (no director
+	// SharedWorld) still force a grading SSBO re-upload when the default mutates.
+	// Without this, fallback-graded rows keep stale GPU values until an unrelated
+	// topology change re-runs the publisher.
+	uint64_t instance_grading_defaults_generation = 0;
 	RID instance_visible_chunk_buffer;
 	uint32_t instance_visible_chunk_capacity = 0;
 	RID instance_splat_ref_buffer;

--- a/modules/gaussian_splatting/renderer/render_types/render_facade_state_types.h
+++ b/modules/gaussian_splatting/renderer/render_types/render_facade_state_types.h
@@ -50,6 +50,12 @@ struct ResourceState {
 	GPUBufferManager::DeferredDeletionQueue deletion_queue;
 	RID instance_buffer;
 	uint32_t instance_buffer_capacity = 0;
+	// Sibling SSBO to instance_buffer: one InstanceGradingGPU row per instance, indexed
+	// by SplatRefGPU.instance_id. Rebuilt alongside the instance buffer whenever instance
+	// topology or grading parameters change. Sized to the same capacity (rows) so the
+	// shader can always index up to instance_buffer_capacity.
+	RID instance_grading_buffer;
+	uint32_t instance_grading_buffer_capacity = 0;
 	RID instance_visible_chunk_buffer;
 	uint32_t instance_visible_chunk_capacity = 0;
 	RID instance_splat_ref_buffer;

--- a/modules/gaussian_splatting/renderer/render_types/render_pipeline_io_types.h
+++ b/modules/gaussian_splatting/renderer/render_types/render_pipeline_io_types.h
@@ -134,6 +134,8 @@ struct PublishedInstanceAssetRemap {
 
 struct InstancePipelineBuffers {
 	RID instance_buffer;
+	// Per-instance color grading SSBO (InstanceGradingGPU rows). Parallel to instance_buffer.
+	RID instance_grading_buffer;
 	RID asset_meta_buffer;
 	RID asset_chunk_index_buffer;
 	RID chunk_meta_buffer;

--- a/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
+++ b/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
@@ -635,6 +635,35 @@ bool publish(GaussianSplatRenderer *p_renderer, bool p_allow_primary_fallback_in
 		return false;
 	}
 
+	// Upload per-instance color grading. Walks the same director instance list so rows
+	// line up 1:1 with SplatRefGPU.instance_id. Must run whenever instance_buffer is
+	// re-uploaded because the instance list may have changed rows.
+	{
+		LocalVector<InstanceGradingGPU> gradings;
+		if (director != nullptr) {
+			director->build_instance_grading_buffer_for_renderer(p_renderer, gradings,
+					p_renderer->is_shadow_instance_filter_enabled());
+		}
+		if (gradings.is_empty() && !instances.is_empty()) {
+			// Fallback when director has no records but we injected a primary-resident
+			// fallback instance above. Mirror the instance row count so the shader
+			// always has a valid row to index.
+			gradings.resize(instances.size());
+			for (uint32_t i = 0; i < gradings.size(); ++i) {
+				gradings[i] = InstanceGradingGPU{};
+				gradings[i].primary[2] = 1.0f; // contrast neutral
+				gradings[i].primary[3] = 1.0f; // saturation neutral
+			}
+		}
+		if (!p_renderer->update_instance_grading_buffer(gradings)) {
+			if (r_reason) {
+				*r_reason = "resident_grading_upload_failed";
+			}
+			p_renderer->clear_instance_pipeline_buffers();
+			return false;
+		}
+	}
+
 	const GaussianRenderPipeline::InstancePipelineBuffers &published_buffers = p_renderer->get_instance_pipeline_buffers();
 	InvariantViolationReason violation_reason = InvariantViolationReason::NONE;
 	if (!GaussianSplatting::InstancePipelineContract::has_atlas_buffers(published_buffers)) {

--- a/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
+++ b/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
@@ -236,6 +236,15 @@ bool publish(GaussianSplatRenderer *p_renderer, bool p_allow_primary_fallback_in
 	if (director != nullptr) {
 		source_generation = _mix_generation(source_generation, director->get_instance_generation_for_renderer(p_renderer));
 	}
+	// Mix the renderer-wide grading-defaults counter so fallback grading rows
+	// (rows with no per-instance grading ref — director-less direct-data flows
+	// and the shim path) force a republish when the renderer's default
+	// ColorGradingResource is swapped or mutated in place. The streaming
+	// orchestrator already consumes this atomic in its fingerprint; the
+	// resident publisher must do the same or fallback-graded buffers stay
+	// stale until an unrelated content/topology change lands.
+	source_generation = _mix_generation(source_generation,
+			p_renderer->get_resource_state().instance_grading_defaults_generation.load(std::memory_order_relaxed));
 	source_generation = _mix_generation(source_generation, p_renderer->is_shadow_instance_filter_enabled() ? 1ULL : 0ULL);
 	source_generation = _mix_generation(source_generation, p_allow_primary_fallback_instance ? 1ULL : 0ULL);
 	source_generation = _mix_generation(source_generation, uint64_t(p_renderer->get_performance_settings().max_splats));

--- a/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
+++ b/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
@@ -284,6 +284,8 @@ bool publish(GaussianSplatRenderer *p_renderer, bool p_allow_primary_fallback_in
 		fallback_instance.params[1] = 1.0f;
 		fallback_instance.params[2] = 1.0f;
 		fallback_instance.wind_params[3] = 1.0f;
+		fallback_instance.effect_params[0] = 1.0f;
+		fallback_instance.effect_params[1] = 1.0f;
 		fallback_instance.ids[0] = kPrimaryResidentAssetId;
 		fallback_instance.ids[1] = GS_INSTANCE_FLAG_ROTATION_IDENTITY |
 				GS_INSTANCE_FLAG_SCALE_IDENTITY |

--- a/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
+++ b/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
@@ -659,6 +659,23 @@ bool publish(GaussianSplatRenderer *p_renderer, bool p_allow_primary_fallback_in
 				GaussianSplatSceneDirector::fill_instance_grading_entry(renderer_default, gradings[i]);
 			}
 		}
+		// Contract: the grading buffer MUST have the same row count as the
+		// instance buffer. Shader indexing (instance_buffer.instances[splat_ref.instance_id]
+		// and instance_grading_buffer.gradings[splat_ref.instance_id]) relies on 1:1
+		// parity. If the filter logic ever drifts between the two director build
+		// steps, early-fail here instead of uploading a short buffer the shader
+		// would then read past end-of-array.
+		if (gradings.size() != instances.size()) {
+			ERR_PRINT_ONCE(vformat(
+					"[ResidentContract] grading buffer row count (%d) does not match instance buffer row count (%d). "
+					"build_instance_grading_buffer_for_renderer and build_instance_buffer_for_renderer must apply identical filters.",
+					int(gradings.size()), int(instances.size())));
+			if (r_reason) {
+				*r_reason = "resident_grading_instance_row_mismatch";
+			}
+			p_renderer->clear_instance_pipeline_buffers();
+			return false;
+		}
 		if (!p_renderer->update_instance_grading_buffer(gradings)) {
 			if (r_reason) {
 				*r_reason = "resident_grading_upload_failed";

--- a/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
+++ b/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
@@ -7,6 +7,7 @@
 #include "quantization_config.h"
 #include "../core/gaussian_splat_scene_director.h"
 #include "../interfaces/gpu_sorting_pipeline.h"
+#include "../resources/color_grading_resource.h"
 #include "servers/rendering/rendering_device.h"
 
 #include <algorithm>
@@ -646,13 +647,14 @@ bool publish(GaussianSplatRenderer *p_renderer, bool p_allow_primary_fallback_in
 		}
 		if (gradings.is_empty() && !instances.is_empty()) {
 			// Fallback when director has no records but we injected a primary-resident
-			// fallback instance above. Mirror the instance row count so the shader
-			// always has a valid row to index.
+			// fallback instance above. Seed from the renderer's legacy renderer-wide
+			// color_grading so direct-data / worldless renderers that still rely on
+			// `renderer->set_color_grading()` keep their grading on this path instead
+			// of being forced to neutral.
+			const Ref<ColorGradingResource> renderer_default = p_renderer->get_color_grading();
 			gradings.resize(instances.size());
 			for (uint32_t i = 0; i < gradings.size(); ++i) {
-				gradings[i] = InstanceGradingGPU{};
-				gradings[i].primary[2] = 1.0f; // contrast neutral
-				gradings[i].primary[3] = 1.0f; // saturation neutral
+				GaussianSplatSceneDirector::fill_instance_grading_entry(renderer_default, gradings[i]);
 			}
 		}
 		if (!p_renderer->update_instance_grading_buffer(gradings)) {

--- a/modules/gaussian_splatting/renderer/tile_render_binning.cpp
+++ b/modules/gaussian_splatting/renderer/tile_render_binning.cpp
@@ -223,6 +223,7 @@ RID TileRenderer::TileBinningStage::acquire_binning_buffer_uniform_set(Rendering
 		const bool quantization_required = owner.instance_pipeline_buffers.quantization_required;
 	ERR_FAIL_COND_V(!owner.instance_pipeline_buffers.splat_ref_buffer.is_valid(), RID());
 	ERR_FAIL_COND_V(!owner.instance_pipeline_buffers.instance_buffer.is_valid(), RID());
+	ERR_FAIL_COND_V(!owner.instance_pipeline_buffers.instance_grading_buffer.is_valid(), RID());
 	ERR_FAIL_COND_V(!owner.instance_pipeline_buffers.indirect_count_buffer.is_valid(), RID());
 	ERR_FAIL_COND_V(!owner.instance_pipeline_buffers.indirect_dispatch_buffer.is_valid(), RID());
 	ERR_FAIL_COND_V(quantization_required && !owner.instance_pipeline_buffers.quantization_buffer.is_valid(), RID());
@@ -283,6 +284,14 @@ RID TileRenderer::TileBinningStage::acquire_binning_buffer_uniform_set(Rendering
 	instance_uniform.binding = 13;
 	instance_uniform.append_id(owner.instance_pipeline_buffers.instance_buffer);
 	uniforms.push_back(instance_uniform);
+
+	// Per-instance color grading (parallel to instance_buffer, indexed by
+	// SplatRefGPU.instance_id).
+	RD::Uniform instance_grading_uniform;
+	instance_grading_uniform.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+	instance_grading_uniform.binding = 20;
+	instance_grading_uniform.append_id(owner.instance_pipeline_buffers.instance_grading_buffer);
+	uniforms.push_back(instance_grading_uniform);
 
 	if (quantization_required) {
 		RD::Uniform quant_uniform;
@@ -436,6 +445,7 @@ RID TileRenderer::TileBinningStage::acquire_binning_count_uniform_set(RenderingD
 		const bool quantization_required = owner.instance_pipeline_buffers.quantization_required;
 	ERR_FAIL_COND_V(!owner.instance_pipeline_buffers.splat_ref_buffer.is_valid(), RID());
 	ERR_FAIL_COND_V(!owner.instance_pipeline_buffers.instance_buffer.is_valid(), RID());
+	ERR_FAIL_COND_V(!owner.instance_pipeline_buffers.instance_grading_buffer.is_valid(), RID());
 	ERR_FAIL_COND_V(!owner.instance_pipeline_buffers.indirect_count_buffer.is_valid(), RID());
 	ERR_FAIL_COND_V(!owner.instance_pipeline_buffers.indirect_dispatch_buffer.is_valid(), RID());
 	ERR_FAIL_COND_V(quantization_required && !owner.instance_pipeline_buffers.quantization_buffer.is_valid(), RID());
@@ -496,6 +506,15 @@ RID TileRenderer::TileBinningStage::acquire_binning_count_uniform_set(RenderingD
 	instance_uniform.binding = 13;
 	instance_uniform.append_id(owner.instance_pipeline_buffers.instance_buffer);
 	uniforms.push_back(instance_uniform);
+
+	// Per-instance color grading. COUNT pass includes color_grading_binning.glsl
+	// transitively via tile_binning.glsl so the SSBO must be bound here too, even
+	// though COUNT early-returns before calling apply_color_grading_binning.
+	RD::Uniform instance_grading_uniform;
+	instance_grading_uniform.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+	instance_grading_uniform.binding = 20;
+	instance_grading_uniform.append_id(owner.instance_pipeline_buffers.instance_grading_buffer);
+	uniforms.push_back(instance_grading_uniform);
 
 	if (quantization_required) {
 		RD::Uniform quant_uniform;

--- a/modules/gaussian_splatting/renderer/tile_render_stages.cpp
+++ b/modules/gaussian_splatting/renderer/tile_render_stages.cpp
@@ -347,6 +347,10 @@ TileRenderParamsGPU TileRenderer::TileRenderParamsBuilder::build_params(const Re
 	params.effector_config[1] = p_params.sphere_effector_strength;
 	params.effector_config[2] = MAX(0.001f, p_params.sphere_effector_falloff);
 	params.effector_config[3] = MAX(0.1f, p_params.sphere_effector_frequency);
+	params.effector_opacity_config[0] = p_params.sphere_effector_affect_position ? 1.0f : 0.0f;
+	params.effector_opacity_config[1] = p_params.sphere_effector_affect_opacity ? 1.0f : 0.0f;
+	params.effector_opacity_config[2] = CLAMP(p_params.sphere_effector_opacity_strength, 0.0f, 1.0f);
+	params.effector_opacity_config[3] = CLAMP(p_params.sphere_effector_target_opacity, 0.0f, 1.0f);
 	params.hotspot_cull_config[0] = float(p_params.hotspot_pressure_threshold);
 	params.hotspot_cull_config[1] = MAX(0.0f, p_params.hotspot_min_radius_px);
 	params.hotspot_cull_config[2] = 0.0f;

--- a/modules/gaussian_splatting/renderer/tile_render_types.h
+++ b/modules/gaussian_splatting/renderer/tile_render_types.h
@@ -381,6 +381,10 @@ struct TileRenderParams {
 	float sphere_effector_strength = 0.0f;
 	float sphere_effector_falloff = 2.0f;
 	float sphere_effector_frequency = 2.0f;
+	bool sphere_effector_affect_position = true;
+	bool sphere_effector_affect_opacity = false;
+	float sphere_effector_opacity_strength = 1.0f;
+	float sphere_effector_target_opacity = 0.0f;
 	Ref<class ColorGradingResource> color_grading;
 	// Instance rotation inverse for SH view direction correction.
 	// When a GaussianSplatNode3D has a rotation transform, SH coefficients (stored in

--- a/modules/gaussian_splatting/renderer/tile_render_types.h
+++ b/modules/gaussian_splatting/renderer/tile_render_types.h
@@ -281,6 +281,9 @@ struct TileRenderParams {
 	RID gaussian_buffer;
 	RID sorted_indices;
 	RID instance_buffer;
+	// Per-instance color grading SSBO (parallel rows to instance_buffer, indexed by
+	// SplatRefGPU.instance_id). Bound at set=0, binding=20 in tile_binning.glsl.
+	RID instance_grading_buffer;
 	RID splat_ref_buffer;
 	RID chunk_meta_buffer;
 	RID quantization_buffer;

--- a/modules/gaussian_splatting/renderer/tile_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/tile_renderer.cpp
@@ -354,6 +354,7 @@ private:
 			const GaussianSplatting::InstancePipelineContract::InvariantViolationReason invariant_reason =
 					GaussianSplatting::InstancePipelineContract::first_tile_runtime_violation(
 							renderer.instance_pipeline_buffers.instance_buffer,
+						renderer.instance_pipeline_buffers.instance_grading_buffer,
 						renderer.instance_pipeline_buffers.splat_ref_buffer,
 						renderer.instance_pipeline_buffers.indirect_count_buffer,
 						renderer.instance_pipeline_buffers.indirect_dispatch_buffer,

--- a/modules/gaussian_splatting/renderer/tile_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/tile_renderer.cpp
@@ -342,6 +342,7 @@ private:
 		}
 
 		renderer.instance_pipeline_buffers.instance_buffer = params.instance_buffer;
+		renderer.instance_pipeline_buffers.instance_grading_buffer = params.instance_grading_buffer;
 		renderer.instance_pipeline_buffers.splat_ref_buffer = params.splat_ref_buffer;
 			renderer.instance_pipeline_buffers.chunk_meta_buffer = params.chunk_meta_buffer;
 			renderer.instance_pipeline_buffers.quantization_buffer = params.quantization_buffer;

--- a/modules/gaussian_splatting/renderer/tile_renderer.h
+++ b/modules/gaussian_splatting/renderer/tile_renderer.h
@@ -401,6 +401,7 @@ private:
     TileResourceController resource_controller;
     struct InstancePipelineBindings {
         RID instance_buffer;
+        RID instance_grading_buffer;
         RID splat_ref_buffer;
         RID chunk_meta_buffer;
         RID quantization_buffer;

--- a/modules/gaussian_splatting/shaders/includes/color_grading_binning.glsl
+++ b/modules/gaussian_splatting/shaders/includes/color_grading_binning.glsl
@@ -26,21 +26,24 @@ vec3 hsv_to_rgb(vec3 c) {
 }
 
 // Apply color grading to splat color (binning stage)
-// Operates in linear color space, before R11G11B10 packing
-vec3 apply_color_grading_binning(vec3 color) {
+// Operates in linear color space, before R11G11B10 packing.
+// The grading parameters are fetched per-instance from instance_grading_buffer,
+// which the binning shader binds alongside instance_buffer at binding 20.
+vec3 apply_color_grading_binning(vec3 color, uint instance_id) {
+	InstanceGradingGPU grading = instance_grading_buffer.gradings[instance_id];
 	// Check if enabled
-	if (params.color_grading_primary.x < 0.5) {
+	if (grading.primary.x < 0.5) {
 		return color;
 	}
 
-	// Unpack parameters from RenderParams
-	float exposure = params.color_grading_primary.y;
-	float contrast = params.color_grading_primary.z;
-	float saturation = params.color_grading_primary.w;
+	// Unpack parameters
+	float exposure = grading.primary.y;
+	float contrast = grading.primary.z;
+	float saturation = grading.primary.w;
 
-	float temperature = params.color_grading_secondary.x;
-	float tint = params.color_grading_secondary.y;
-	float hue_shift_deg = params.color_grading_secondary.z;
+	float temperature = grading.secondary.x;
+	float tint = grading.secondary.y;
+	float hue_shift_deg = grading.secondary.z;
 
 	// 1. Exposure (multiply by 2^EV)
 	color *= exp2(exposure);

--- a/modules/gaussian_splatting/shaders/includes/gs_deformation.glsl
+++ b/modules/gaussian_splatting/shaders/includes/gs_deformation.glsl
@@ -16,6 +16,11 @@ uint gs_decode_instance_wind_mode(float encoded_mode) {
     return uint(clamp(floor(encoded_mode + 0.5), 0.0, float(GS_INSTANCE_WIND_MODE_FORCE_ENABLED)));
 }
 
+struct GSDeformationResult {
+    vec3 position;
+    float opacity;
+};
+
 // Check whether wind deformation is enabled for the current instance.
 bool gs_is_wind_enabled_for_instance(float encoded_mode, vec4 wind_time_config) {
     bool wind_enabled = wind_time_config.w > 0.5;
@@ -29,59 +34,94 @@ bool gs_is_wind_enabled_for_instance(float encoded_mode, vec4 wind_time_config) 
     return wind_enabled;
 }
 
-// Sphere effector: animates splats within a spherical region
-// effector_sphere: xyz = center, w = radius
-// effector_config: x = enabled, y = strength, z = falloff, w = animation frequency (Hz)
-vec3 gs_apply_sphere_effector(vec3 world_position, vec4 effector_sphere, vec4 effector_config, float time_seconds, uint stable_seed) {
+float gs_compute_sphere_effector_weight(vec3 world_position, vec4 effector_sphere, vec4 effector_config,
+        float time_seconds, uint stable_seed, out vec3 out_direction) {
+    out_direction = vec3(0.0, 1.0, 0.0);
     if (effector_config.x <= 0.5) {
-        return world_position;
+        return 0.0;
     }
 
     float radius = effector_sphere.w;
     if (radius <= 1e-6) {
-        return world_position;
+        return 0.0;
     }
 
     vec3 delta = world_position - effector_sphere.xyz;
     float distance_to_center = length(delta);
     if (distance_to_center >= radius) {
-        return world_position;
+        return 0.0;
     }
 
     float normalized = clamp(1.0 - (distance_to_center / radius), 0.0, 1.0);
     float falloff = max(effector_config.z, 0.001);
     float influence = pow(normalized, falloff);
-    float strength = effector_config.y;
-    if (abs(strength) <= 1e-8) {
-        return world_position;
-    }
-
-    // Animation: pulse the displacement using time
-    float anim_freq = effector_config.w > 0.0 ? effector_config.w : 2.0; // Default 2 Hz
-    // Add per-splat phase jitter for organic look
+    float anim_freq = effector_config.w > 0.0 ? effector_config.w : 2.0;
     uint hashed = gs_wind_hash_u32(stable_seed);
     float phase_jitter = (float(hashed & 0xFFFFu) / 65535.0) * 6.28318530718;
     float anim_phase = time_seconds * anim_freq * 6.28318530718 + phase_jitter;
-    float anim_factor = 0.5 + 0.5 * sin(anim_phase); // Oscillates 0..1
+    float anim_factor = 0.5 + 0.5 * sin(anim_phase);
 
-    vec3 direction = distance_to_center > 1e-6 ? (delta / distance_to_center) : vec3(0.0, 1.0, 0.0);
-    return world_position + direction * (strength * influence * anim_factor);
+    if (distance_to_center > 1e-6) {
+        out_direction = delta / distance_to_center;
+    }
+    return influence * anim_factor;
 }
 
-vec3 gs_apply_wind_deformation(vec3 world_position,
+GSDeformationResult gs_apply_sphere_effector(vec3 world_position,
+        float base_opacity,
+        vec4 instance_effect_config,
+        vec4 effector_sphere,
+        vec4 effector_config,
+        vec4 effector_opacity_config,
+        float time_seconds,
+        uint stable_seed) {
+    GSDeformationResult result;
+    result.position = world_position;
+    result.opacity = clamp(base_opacity, 0.0, 1.0);
+
+    vec3 direction;
+    float weight = gs_compute_sphere_effector_weight(world_position, effector_sphere, effector_config,
+            time_seconds, stable_seed, direction);
+    if (weight <= 0.0) {
+        return result;
+    }
+
+    float position_scale = max(instance_effect_config.x, 0.0);
+    float strength = effector_config.y;
+    if (effector_opacity_config.x > 0.5 && position_scale > 0.0 && abs(strength) > 1e-8) {
+        result.position += direction * (strength * weight * position_scale);
+    }
+
+    if (effector_opacity_config.y > 0.5) {
+        float opacity_scale = max(instance_effect_config.y, 0.0);
+        float opacity_strength = clamp(effector_opacity_config.z, 0.0, 1.0) * opacity_scale;
+        if (opacity_strength > 0.0) {
+            float target_opacity = clamp(effector_opacity_config.w, 0.0, 1.0);
+            float opacity_weight = clamp(weight * opacity_strength, 0.0, 1.0);
+            result.opacity = clamp(mix(result.opacity, target_opacity, opacity_weight), 0.0, 1.0);
+        }
+    }
+
+    return result;
+}
+
+GSDeformationResult gs_apply_wind_deformation(vec3 world_position,
         uint stable_seed,
         float opacity,
         float instance_intensity,
         float instance_wind_mode,
         vec4 instance_wind_config,
+        vec4 instance_effect_config,
         vec4 wind_dir_strength,
         vec4 wind_time_config,
         vec4 effector_sphere,
-        vec4 effector_config) {
+        vec4 effector_config,
+        vec4 effector_opacity_config) {
     float time_seconds = wind_time_config.x;
     bool wind_enabled = gs_is_wind_enabled_for_instance(instance_wind_mode, wind_time_config);
     if (!wind_enabled) {
-        return gs_apply_sphere_effector(world_position, effector_sphere, effector_config, time_seconds, stable_seed);
+        return gs_apply_sphere_effector(world_position, opacity, instance_effect_config, effector_sphere,
+                effector_config, effector_opacity_config, time_seconds, stable_seed);
     }
 
     vec3 direction = wind_dir_strength.xyz;
@@ -91,7 +131,8 @@ vec3 gs_apply_wind_deformation(vec3 world_position,
     float direction_len = length(direction);
     float strength = max(wind_dir_strength.w, 0.0);
     if (direction_len <= 1e-6 || strength <= 0.0) {
-        return gs_apply_sphere_effector(world_position, effector_sphere, effector_config, time_seconds, stable_seed);
+        return gs_apply_sphere_effector(world_position, opacity, instance_effect_config, effector_sphere,
+                effector_config, effector_opacity_config, time_seconds, stable_seed);
     }
 
     float instance_frequency_scale = instance_wind_config.w > 0.0 ? instance_wind_config.w : 1.0;
@@ -99,7 +140,8 @@ vec3 gs_apply_wind_deformation(vec3 world_position,
     float spatial_frequency = wind_time_config.z;
     float clamped_intensity = max(instance_intensity, 0.0);
     if (clamped_intensity <= 0.0) {
-        return gs_apply_sphere_effector(world_position, effector_sphere, effector_config, time_seconds, stable_seed);
+        return gs_apply_sphere_effector(world_position, opacity, instance_effect_config, effector_sphere,
+                effector_config, effector_opacity_config, time_seconds, stable_seed);
     }
 
     // Reuse opacity as a rough "stiffness" signal until a dedicated attribute exists.
@@ -112,7 +154,8 @@ vec3 gs_apply_wind_deformation(vec3 world_position,
     float displacement = sin(phase) * strength * resistance * clamped_intensity;
 
     vec3 deformed = world_position + (direction / direction_len) * displacement;
-    return gs_apply_sphere_effector(deformed, effector_sphere, effector_config, time_seconds, stable_seed);
+    return gs_apply_sphere_effector(deformed, opacity, instance_effect_config, effector_sphere,
+            effector_config, effector_opacity_config, time_seconds, stable_seed);
 }
 
 #endif // GS_DEFORMATION_GLSL

--- a/modules/gaussian_splatting/shaders/includes/gs_instance_layout.glsl
+++ b/modules/gaussian_splatting/shaders/includes/gs_instance_layout.glsl
@@ -94,6 +94,14 @@ struct SplatRefGPU {
     uint atlas_index;
 };
 
+// Per-instance color grading (std430), indexed by SplatRefGPU.instance_id.
+// primary:   x = enabled (0/1), y = exposure, z = contrast, w = saturation
+// secondary: x = temperature,   y = tint,     z = hue_shift, w = reserved
+struct InstanceGradingGPU {
+    vec4 primary;
+    vec4 secondary;
+};
+
 const uint GS_INSTANCE_DATA_GPU_SIZE = 96u;
 const uint GS_ASSET_LOD_RANGE_GPU_SIZE = 8u;
 const uint GS_ASSET_META_GPU_SIZE = 48u + 8u * GS_MAX_ASSET_LODS;
@@ -101,5 +109,6 @@ const uint GS_CHUNK_META_GPU_SIZE = 64u;
 const uint GS_ASSET_CHUNK_INDEX_GPU_SIZE = 4u;
 const uint GS_VISIBLE_CHUNK_REF_GPU_SIZE = 8u;
 const uint GS_SPLAT_REF_GPU_SIZE = 8u;
+const uint GS_INSTANCE_GRADING_GPU_SIZE = 32u;
 
 #endif // GS_INSTANCE_LAYOUT_GLSL

--- a/modules/gaussian_splatting/shaders/includes/gs_instance_layout.glsl
+++ b/modules/gaussian_splatting/shaders/includes/gs_instance_layout.glsl
@@ -16,6 +16,7 @@ struct InstanceDataGPU {
     uvec2 ids;               // x = asset_id, y = flags
     uvec2 lod;               // x = resolved_lod_level, y = reserved
     vec4 wind_params;        // xyz = wind direction override (0,0,0=infer global), w = wind frequency scale
+    vec4 effect_params;      // x = position response scale, y = opacity response scale, z/w = reserved
 };
 
 // Instance flag bits (ids.y).
@@ -102,7 +103,7 @@ struct InstanceGradingGPU {
     vec4 secondary;
 };
 
-const uint GS_INSTANCE_DATA_GPU_SIZE = 96u;
+const uint GS_INSTANCE_DATA_GPU_SIZE = 112u;
 const uint GS_ASSET_LOD_RANGE_GPU_SIZE = 8u;
 const uint GS_ASSET_META_GPU_SIZE = 48u + 8u * GS_MAX_ASSET_LODS;
 const uint GS_CHUNK_META_GPU_SIZE = 64u;

--- a/modules/gaussian_splatting/shaders/includes/gs_render_params.glsl
+++ b/modules/gaussian_splatting/shaders/includes/gs_render_params.glsl
@@ -1,6 +1,6 @@
 #ifndef GS_RENDER_PARAMS_GLSL
 #define GS_RENDER_PARAMS_GLSL
-#define GS_RENDER_PARAMS_LAYOUT_VERSION 17 // Keep in sync with gaussian_gpu_layout.h
+#define GS_RENDER_PARAMS_LAYOUT_VERSION 18 // Keep in sync with gaussian_gpu_layout.h
 
 // Instance pipeline only: uses SplatRef indirection and asset-local quantization.
 
@@ -94,9 +94,12 @@ layout(set = 1, binding = 0, std140) uniform RenderParams {
     vec4 wind_time_config;
     // Single global sphere effector (foundation for capped multi-effector support):
     // effector_sphere: xyz = center (world), w = radius
-    // effector_config: x = enabled (0/1), y = displacement strength (meters), z = falloff exponent, w = reserved
+    // effector_config: x = enabled (0/1), y = displacement strength (meters), z = falloff exponent, w = frequency (Hz)
     vec4 effector_sphere;
     vec4 effector_config;
+    // effector_opacity_config: x = affect_position (0/1), y = affect_opacity (0/1),
+    // z = opacity_strength (0..1), w = target_opacity (0..1)
+    vec4 effector_opacity_config;
     // Hotspot-aware pre-raster cull (deterministic, shared by COUNT and EMIT):
     // x = hotspot_pressure_threshold (absolute previous-frame tile count; 0 disables)
     // y = hotspot_min_radius_px (raw minor-axis radius threshold for pruning)

--- a/modules/gaussian_splatting/shaders/tile_binning.glsl
+++ b/modules/gaussian_splatting/shaders/tile_binning.glsl
@@ -689,16 +689,19 @@ void main() {
     float instance_intensity = max(instance.params.z, 0.0);
     float instance_wind_mode = instance.params.w;
     uint stable_seed = gaussian_idx ^ (splat_ref.instance_id * 0x9e3779b9u);
-    world_position = gs_apply_wind_deformation(world_position,
+    GSDeformationResult deformation = gs_apply_wind_deformation(world_position,
             stable_seed,
             g.opacity,
             instance_intensity,
             instance_wind_mode,
             instance.wind_params,
+            instance.effect_params,
             params.wind_dir_strength,
             params.wind_time_config,
             params.effector_sphere,
-            params.effector_config);
+            params.effector_config,
+            params.effector_opacity_config);
+    world_position = deformation.position;
     vec3 world_scale = (instance_flags & GS_INSTANCE_FLAG_SCALE_IDENTITY) != 0u
             ? local_scale
             : local_scale * uniform_scale;
@@ -823,7 +826,8 @@ void main() {
         float visibility_threshold = gs_get_visibility_threshold();
         // Use the base opacity (before any fades) for radius calculation
         // This ensures consistent culling regardless of size/aspect fades
-        float base_opacity_for_culling = clamp(g.opacity * params.opacity_multiplier, 0.0, 1.0);
+        float base_opacity_for_culling = clamp(max(g.opacity, deformation.opacity) * instance.params.x *
+                params.opacity_multiplier, 0.0, 1.0);
 
         // Compute opacity-aware sigma (number of standard deviations to extend)
         effective_sigma = compute_opacity_aware_sigma(base_opacity_for_culling, visibility_threshold, max_sigma);
@@ -1053,7 +1057,8 @@ void main() {
 #endif
 
     // Use the fade computed earlier for opacity; we already skipped if nearly invisible.
-    float base_opacity = clamp(g.opacity * params.opacity_multiplier * size_fade * aspect_fade * lens_fade, 0.0, 0.99);
+    float base_opacity = clamp(deformation.opacity * instance.params.x * params.opacity_multiplier *
+            size_fade * aspect_fade * lens_fade, 0.0, 0.99);
 
     // Evaluate SH for view-dependent color using configurable band level
     vec3 view_dir = normalize(params.camera_position.xyz - g.position);

--- a/modules/gaussian_splatting/shaders/tile_binning.glsl
+++ b/modules/gaussian_splatting/shaders/tile_binning.glsl
@@ -99,6 +99,13 @@ layout(set = 0, binding = 13, std430) readonly buffer InstanceBuffer {
     InstanceDataGPU instances[];
 } instance_buffer;
 
+// Per-instance color grading sibling SSBO. Parallel rows to instance_buffer, indexed
+// by splat_ref.instance_id. Populated by GaussianSplatSceneDirector::
+// build_instance_grading_buffer_for_renderer.
+layout(set = 0, binding = 20, std430) readonly buffer InstanceGradingBuffer {
+    InstanceGradingGPU gradings[];
+} instance_grading_buffer;
+
 #if defined(USE_QUANTIZED_GAUSSIANS)
 layout(set = 0, binding = 14, std430) readonly buffer QuantizationChunkBuffer {
     ChunkQuantization chunks[];
@@ -1085,13 +1092,13 @@ void main() {
         }
     }
     // Apply color grading after cache logic so it affects both cached and fresh SH
-    sh_color = apply_color_grading_binning(sh_color);
+    sh_color = apply_color_grading_binning(sh_color, splat_ref.instance_id);
 #else
     vec3 sh_color = evaluate_sh_with_bands(g, view_dir_local, sh_band_level);
     // Clamp SH color to non-negative after evaluation
     // SH basis functions can produce negative contributions but final color should not be negative
     sh_color = max(sh_color, vec3(0.0));
-    sh_color = apply_color_grading_binning(sh_color);
+    sh_color = apply_color_grading_binning(sh_color, splat_ref.instance_id);
 #endif
 
     // Debug: force white albedo to isolate lighting contribution (debug_overlay_flags.w).

--- a/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
@@ -1137,8 +1137,14 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer ins
     }
     CHECK(instance_buffer[node_a_index].params[0] == doctest::Approx(1.0f));
     CHECK(instance_buffer[node_b_index].params[0] == doctest::Approx(1.0f));
+    CHECK(instance_buffer[node_a_index].effect_params[0] == doctest::Approx(1.0f));
+    CHECK(instance_buffer[node_a_index].effect_params[1] == doctest::Approx(1.0f));
+    CHECK(instance_buffer[node_b_index].effect_params[0] == doctest::Approx(1.0f));
+    CHECK(instance_buffer[node_b_index].effect_params[1] == doctest::Approx(1.0f));
 
     node_b->set_opacity(0.25f);
+    node_b->set_effect_position_scale(0.5f);
+    node_b->set_effect_opacity_scale(0.2f);
     tree->process(0.0);
     director->build_instance_buffer_for_renderer(renderer_a.ptr(), instance_buffer);
     node_a_index = find_instance_index_by_translation_x(instance_buffer, node_a_x);
@@ -1152,8 +1158,12 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer ins
     }
     CHECK(instance_buffer[node_a_index].params[0] == doctest::Approx(1.0f));
     CHECK(instance_buffer[node_b_index].params[0] == doctest::Approx(0.25f));
+    CHECK(instance_buffer[node_b_index].effect_params[0] == doctest::Approx(0.5f));
+    CHECK(instance_buffer[node_b_index].effect_params[1] == doctest::Approx(0.2f));
 
     node_a->set_opacity(0.6f);
+    node_a->set_effect_position_scale(1.7f);
+    node_a->set_effect_opacity_scale(0.9f);
     tree->process(0.0);
     director->build_instance_buffer_for_renderer(renderer_a.ptr(), instance_buffer);
     node_a_index = find_instance_index_by_translation_x(instance_buffer, node_a_x);
@@ -1167,6 +1177,10 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer ins
     }
     CHECK(instance_buffer[node_a_index].params[0] == doctest::Approx(0.6f));
     CHECK(instance_buffer[node_b_index].params[0] == doctest::Approx(0.25f));
+    CHECK(instance_buffer[node_a_index].effect_params[0] == doctest::Approx(1.7f));
+    CHECK(instance_buffer[node_a_index].effect_params[1] == doctest::Approx(0.9f));
+    CHECK(instance_buffer[node_b_index].effect_params[0] == doctest::Approx(0.5f));
+    CHECK(instance_buffer[node_b_index].effect_params[1] == doctest::Approx(0.2f));
 
     root->remove_child(node_b);
     root->remove_child(node_a);

--- a/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
@@ -26,6 +26,8 @@
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 
+#include <limits>
+
 #if defined(TESTS_ENABLED) || defined(TOOLS_ENABLED)
 
 #include "gs_test_setting_guard.h"
@@ -1188,6 +1190,43 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer ins
     memdelete(node_a);
 }
 
+TEST_CASE("[GaussianSplatting][Node] Runtime effect controls sanitize invalid gameplay values") {
+    GaussianSplatNode3D *node = memnew(GaussianSplatNode3D);
+    REQUIRE(node != nullptr);
+
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+
+    CHECK(node->get_opacity() == doctest::Approx(1.0f));
+    CHECK(node->get_effect_position_scale() == doctest::Approx(1.0f));
+    CHECK(node->get_effect_opacity_scale() == doctest::Approx(1.0f));
+    CHECK(node->get_wind_strength() == doctest::Approx(1.0f));
+    CHECK(node->get_wind_frequency() == doctest::Approx(1.0f));
+
+    node->set_opacity(-0.25f);
+    CHECK(node->get_opacity() == doctest::Approx(0.0f));
+    node->set_opacity(1.75f);
+    CHECK(node->get_opacity() == doctest::Approx(1.0f));
+    node->set_opacity(nan);
+    CHECK(node->get_opacity() == doctest::Approx(1.0f));
+
+    node->set_effect_position_scale(-2.0f);
+    CHECK(node->get_effect_position_scale() == doctest::Approx(0.0f));
+    node->set_effect_position_scale(nan);
+    CHECK(node->get_effect_position_scale() == doctest::Approx(1.0f));
+
+    node->set_effect_opacity_scale(-3.0f);
+    CHECK(node->get_effect_opacity_scale() == doctest::Approx(0.0f));
+    node->set_effect_opacity_scale(nan);
+    CHECK(node->get_effect_opacity_scale() == doctest::Approx(1.0f));
+
+    node->set_wind_strength(-5.0f);
+    CHECK(node->get_wind_strength() == doctest::Approx(0.0f));
+    node->set_wind_frequency(-4.0f);
+    CHECK(node->get_wind_frequency() == doctest::Approx(0.0f));
+
+    memdelete(node);
+}
+
 TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer instance buffer drops hidden nodes") {
     SceneTree *tree = SceneTree::get_singleton();
     REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");
@@ -2137,6 +2176,39 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Two shared-renderer
     root->remove_child(node_a);
     memdelete(node_b);
     memdelete(node_a);
+}
+
+TEST_CASE("[GaussianSplatting] Renderer-only set_color_grading bumps grading defaults generation") {
+    // Regression for the P2 flagged by Codex: renderer-only / direct-data flows
+    // (no SharedWorld in the director) still need set_color_grading to trigger a
+    // grading SSBO re-upload. This is wired by
+    // RenderConfigOrchestrator::set_color_grading ->
+    // GaussianSplatSceneDirector::invalidate_grading_for_renderer, which always
+    // bumps the renderer's `instance_grading_defaults_generation` counter before
+    // the SharedWorld lookup. The streaming fingerprint consumes that counter so
+    // upload_changed trips even without any director entry.
+    Ref<GaussianSplatRenderer> renderer;
+    renderer.instantiate();
+    REQUIRE(renderer.is_valid());
+
+    using GaussianRenderFacadeState::ResourceState;
+    const ResourceState &state = renderer->get_resource_state();
+    const uint64_t before = state.instance_grading_defaults_generation.load(std::memory_order_relaxed);
+
+    Ref<ColorGradingResource> grading = make_color_grading_resource();
+    REQUIRE(grading.is_valid());
+    grading->set_exposure(-0.5f);
+    renderer->set_color_grading(grading);
+
+    const uint64_t after_set = state.instance_grading_defaults_generation.load(std::memory_order_relaxed);
+    CHECK(after_set > before);
+
+    // In-place slider edit on the same Ref fires the resource's `changed` signal,
+    // which the renderer's handler catches via callable_mp and re-runs the
+    // invalidation path. Bumps the counter again even though the Ref did not swap.
+    grading->set_exposure(1.5f);
+    const uint64_t after_slider = state.instance_grading_defaults_generation.load(std::memory_order_relaxed);
+    CHECK(after_slider > after_set);
 }
 
 TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer full-fidelity override only follows attached assets") {

--- a/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
@@ -168,6 +168,21 @@ Ref<ColorGradingResource> make_color_grading_resource() {
     return grading;
 }
 
+// Per-instance color grading moved off the renderer's single-slot RenderConfig and
+// onto GaussianSplatSceneDirector's InstanceRecord keyed by node ObjectID. Tests that
+// previously asserted `renderer->get_color_grading() == grading` now ask the
+// director via this helper. Falls back to the legacy renderer slot when the
+// director is unavailable (keeps assertions meaningful under tear-down).
+Ref<ColorGradingResource> node_color_grading(const GaussianSplatNode3D *p_node,
+        const Ref<GaussianSplatRenderer> &p_renderer) {
+    if (p_node) {
+        if (GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton()) {
+            return director->get_instance_color_grading(p_node->get_instance_id());
+        }
+    }
+    return p_renderer.is_valid() ? p_renderer->get_color_grading() : Ref<ColorGradingResource>();
+}
+
 void set_single_splat_position(const Ref<GaussianSplatAsset> &p_asset, const Vector3 &p_position) {
     PackedFloat32Array positions;
     positions.resize(3);
@@ -1309,8 +1324,8 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Node color grading 
     // and the inspector property must stay visible.
     CHECK_MESSAGE(graded_node->get_color_grading() == grading,
             "Node retains its local color grading");
-    CHECK_MESSAGE(renderer->get_color_grading() == grading,
-            "Renderer color grading must reflect the node's grading even with a world submission");
+    CHECK_MESSAGE(node_color_grading(graded_node, renderer) == grading,
+            "Per-instance grading must track the node even with a world submission");
     CHECK(is_property_editor_exposed(graded_node, StringName("rendering/color_grading")));
 
     // Property and propagation should also hold after the world submission is removed.
@@ -1319,8 +1334,8 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Node color grading 
     tree->process(0.0);
 
     graded_node->set_color_grading(grading);
-    CHECK_MESSAGE(renderer->get_color_grading() == grading,
-            "Color grading should still reach renderer after world submission is removed");
+    CHECK_MESSAGE(node_color_grading(graded_node, renderer) == grading,
+            "Per-instance grading must persist after world submission is removed");
     CHECK(is_property_editor_exposed(graded_node, StringName("rendering/color_grading")));
 
     root->remove_child(graded_node);
@@ -1381,9 +1396,8 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer pre
     CHECK(node_a->get_color_grading() == grading);
     // Painterly is still renderer-wide and gated while the renderer is shared.
     CHECK_FALSE(renderer->get_painterly_enabled());
-    // Color grading is per-node and propagates to the renderer regardless of sharing
-    // (last-writer-wins when multiple nodes share a renderer).
-    CHECK(renderer->get_color_grading() == grading);
+    // Color grading is per-instance and lives on the director record keyed by node_id.
+    CHECK(node_color_grading(node_a, renderer) == grading);
 
     root->remove_child(node_b);
     tree->process(0.0);
@@ -1391,7 +1405,7 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer pre
     CHECK(node_a->is_painterly_enabled());
     CHECK(node_a->get_color_grading() == grading);
     CHECK(renderer->get_painterly_enabled());
-    CHECK(renderer->get_color_grading() == grading);
+    CHECK(node_color_grading(node_a, renderer) == grading);
 
     root->remove_child(node_a);
     memdelete(node_b);
@@ -1419,8 +1433,8 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Single node color g
         return;
     }
 
-    // Renderer should start with no color grading.
-    CHECK(renderer->get_color_grading().is_null());
+    // Director should start with no per-instance grading bound to this node.
+    CHECK(node_color_grading(node, renderer).is_null());
 
     Ref<ColorGradingResource> grading = make_color_grading_resource();
     CHECK(grading.is_valid());
@@ -1428,9 +1442,9 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Single node color g
     node->set_color_grading(grading);
     tree->process(0.0);
 
-    // Single node owns the renderer exclusively, so color grading must propagate.
+    // Setter must propagate the grading to the director record for this node.
     CHECK(node->get_color_grading() == grading);
-    CHECK(renderer->get_color_grading() == grading);
+    CHECK(node_color_grading(node, renderer) == grading);
 
     root->remove_child(node);
     memdelete(node);
@@ -1465,7 +1479,7 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Color grading survi
         return;
     }
 
-    CHECK(renderer->get_color_grading() == grading);
+    CHECK(node_color_grading(node, renderer) == grading);
 
     // Exit tree.
     root->remove_child(node);
@@ -1486,9 +1500,9 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Color grading survi
         return;
     }
 
-    // Color grading must still be on the node and pushed to the (possibly new) renderer.
+    // Color grading must still be on the node and pushed to the director for the re-attached node.
     CHECK(node->get_color_grading() == grading);
-    CHECK(renderer_after->get_color_grading() == grading);
+    CHECK(node_color_grading(node, renderer_after) == grading);
 
     root->remove_child(node);
     memdelete(node);
@@ -1521,18 +1535,20 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Color grading signa
     node->set_color_grading(grading);
     tree->process(0.0);
 
-    CHECK(renderer->get_color_grading() == grading);
+    CHECK(node_color_grading(node, renderer) == grading);
 
     // Mutate a property on the resource — the "changed" signal should propagate
-    // through _on_color_grading_changed and keep the renderer in sync.
+    // through _on_color_grading_changed and keep the director record in sync.
     const float original_exposure = grading->get_exposure();
     grading->set_exposure(2.5f);
     CHECK(grading->get_exposure() != doctest::Approx(original_exposure));
 
-    // The renderer should still reference the same resource (signal updates
-    // the renderer in-place, it does not swap the Ref).
-    CHECK(renderer->get_color_grading() == grading);
-    CHECK(renderer->get_color_grading()->get_exposure() == doctest::Approx(2.5f));
+    // The director should still reference the same resource (signal updates
+    // the record in-place, it does not swap the Ref).
+    Ref<ColorGradingResource> resolved = node_color_grading(node, renderer);
+    CHECK(resolved == grading);
+    CHECK(resolved.is_valid());
+    CHECK(resolved->get_exposure() == doctest::Approx(2.5f));
 
     root->remove_child(node);
     memdelete(node);
@@ -1575,11 +1591,14 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Hot-reload of node 
     }
     REQUIRE_MESSAGE(renderer == node_b->get_renderer(), "Both nodes must share the same renderer for this test");
 
-    // After explicit setters, renderer reflects the most recent push (node_b).
+    // After explicit setters, each node's director record carries its own grading.
+    // Per-instance storage means node_a's grading is independent of node_b's.
     node_b->set_color_grading(grading_b);
     tree->process(0.0);
-    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
-            "Renderer should reflect node_b's grading after explicit setter");
+    CHECK_MESSAGE(node_color_grading(node_a, renderer) == grading_a,
+            "node_a keeps its own grading on its director record");
+    CHECK_MESSAGE(node_color_grading(node_b, renderer) == grading_b,
+            "node_b keeps its own grading on its director record");
 
     // Simulate hot-reload / reimport of node_a's asset via the asset's
     // "changed" signal — this is the path that fires _on_asset_changed →
@@ -1589,11 +1608,12 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Hot-reload of node 
     asset_a->emit_changed();
     tree->process(0.0);
 
-    // The renderer's grading must remain node_b's. If the implicit
-    // _update_asset push were not gated to first-data-ready, node_a would
-    // overwrite node_b here even though no setter ran on node_a.
-    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
-            "Hot-reload of node_a must not clobber node_b's grading on shared renderer");
+    // Per-instance storage makes cross-node clobber impossible by construction:
+    // each node's grading lives on its own director record. Both must still match.
+    CHECK_MESSAGE(node_color_grading(node_a, renderer) == grading_a,
+            "Hot-reload of node_a must not change node_a's own director grading either");
+    CHECK_MESSAGE(node_color_grading(node_b, renderer) == grading_b,
+            "Hot-reload of node_a cannot touch node_b's director grading");
 
     root->remove_child(node_b);
     root->remove_child(node_a);
@@ -1657,8 +1677,8 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Procedural set_spla
         return;
     }
 
-    CHECK_MESSAGE(renderer->get_color_grading() == grading,
-            "Renderer must reflect the cached color grading after procedural set_splat_data");
+    CHECK_MESSAGE(node_color_grading(node, renderer) == grading,
+            "Director must reflect the cached color grading after procedural set_splat_data");
 
     root->remove_child(node);
     memdelete(node);
@@ -1707,11 +1727,13 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Tree exit/re-enter 
     }
     REQUIRE_MESSAGE(renderer == node_b->get_renderer(), "Both nodes must share the same renderer for this test");
 
-    // Last writer is node_b.
+    // Per-instance storage: each node carries its own grading on its director record.
     node_b->set_color_grading(grading_b);
     tree->process(0.0);
-    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
-            "Renderer should reflect node_b's grading after explicit setter");
+    CHECK_MESSAGE(node_color_grading(node_a, renderer) == grading_a,
+            "node_a still has its own grading on its director record");
+    CHECK_MESSAGE(node_color_grading(node_b, renderer) == grading_b,
+            "node_b's grading is stored per-instance on node_b's record");
 
     // Detach node_a, then re-attach it without changing its grading or
     // its asset. Then trigger a hot-reload via emit_changed(). The guard
@@ -1726,8 +1748,11 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Tree exit/re-enter 
     asset_a->emit_changed();
     tree->process(0.0);
 
-    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
-            "After tree exit/re-enter and hot-reload of node_a, renderer must still hold node_b's grading");
+    // Both nodes must retain their own per-instance grading after all the churn.
+    CHECK_MESSAGE(node_color_grading(node_a, renderer) == grading_a,
+            "node_a's per-instance grading survives its own tree exit/re-enter + hot-reload");
+    CHECK_MESSAGE(node_color_grading(node_b, renderer) == grading_b,
+            "node_b's per-instance grading is untouched by node_a's churn");
 
     root->remove_child(node_b);
     root->remove_child(node_a);
@@ -1785,29 +1810,30 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Setter after no-gra
     grading_a->set_exposure(0.25f);
     grading_b->set_exposure(0.75f);
 
-    // Setter on node_a: must push grading_a AND arm the guard, so that
-    // a later _update_asset on node_a doesn't re-push.
+    // Per-instance storage: each node's director record carries its own grading.
     node_a->set_color_grading(grading_a);
     tree->process(0.0);
-    CHECK_MESSAGE(renderer->get_color_grading() == grading_a,
-            "Renderer must reflect node_a's grading after explicit setter");
+    CHECK_MESSAGE(node_color_grading(node_a, renderer) == grading_a,
+            "node_a's director record must reflect grading_a");
 
-    // Setter on node_b: most recent push, renderer = grading_b.
     node_b->set_color_grading(grading_b);
     tree->process(0.0);
-    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
-            "Renderer must reflect node_b's grading after its setter");
+    CHECK_MESSAGE(node_color_grading(node_b, renderer) == grading_b,
+            "node_b's director record must reflect grading_b");
+    CHECK_MESSAGE(node_color_grading(node_a, renderer) == grading_a,
+            "node_b's setter cannot touch node_a's per-instance grading");
 
-    // Hot-reload of node_a's asset. Without the setter arming the guard,
-    // _update_asset on node_a would re-push grading_a and clobber
-    // grading_b. With the fix, the guard is true and no push happens.
+    // Hot-reload of node_a's asset. With per-instance storage, there is no
+    // shared slot to clobber — each record keeps its own grading.
     Ref<GaussianSplatAsset> asset_a = node_a->get_splat_asset();
     REQUIRE(asset_a.is_valid());
     asset_a->emit_changed();
     tree->process(0.0);
 
-    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
-            "Hot-reload of node_a's asset must not re-clobber node_b after setter armed the guard");
+    CHECK_MESSAGE(node_color_grading(node_a, renderer) == grading_a,
+            "Hot-reload leaves node_a's own grading intact");
+    CHECK_MESSAGE(node_color_grading(node_b, renderer) == grading_b,
+            "Hot-reload of node_a cannot affect node_b's per-instance grading");
 
     root->remove_child(node_b);
     root->remove_child(node_a);
@@ -1854,8 +1880,8 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Detached asset refr
 
     node_b->set_color_grading(grading_b);
     tree->process(0.0);
-    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
-            "Renderer should reflect node_b's grading before node_a is detached");
+    CHECK_MESSAGE(node_color_grading(node_b, renderer) == grading_b,
+            "node_b's per-instance grading must reflect grading_b");
 
     root->remove_child(node_a);
     tree->process(0.0);
@@ -1864,15 +1890,15 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Detached asset refr
     REQUIRE(detached_asset.is_valid());
     detached_asset->emit_changed();
     tree->process(0.0);
-    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
-            "Detached hot-reload of node_a must not overwrite node_b's grading");
+    CHECK_MESSAGE(node_color_grading(node_b, renderer) == grading_b,
+            "Detached hot-reload of node_a cannot touch node_b's per-instance grading");
 
     Ref<GaussianSplatAsset> replacement_asset = make_single_splat_asset(9703.0f);
     REQUIRE(replacement_asset.is_valid());
     node_a->set_splat_asset(replacement_asset);
     tree->process(0.0);
-    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
-            "Detached set_splat_asset() on node_a must not overwrite node_b's grading");
+    CHECK_MESSAGE(node_color_grading(node_b, renderer) == grading_b,
+            "Detached set_splat_asset on node_a cannot touch node_b's per-instance grading");
 
     root->remove_child(node_b);
     memdelete(node_b);
@@ -1918,23 +1944,26 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Detached color grad
 
     node_b->set_color_grading(grading_b);
     tree->process(0.0);
-    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
-            "Renderer should reflect node_b's grading before node_a is detached");
+    CHECK_MESSAGE(node_color_grading(node_b, renderer) == grading_b,
+            "node_b's per-instance grading must reflect grading_b");
 
     root->remove_child(node_a);
     tree->process(0.0);
 
     grading_a->set_exposure(1.25f);
     tree->process(0.0);
-    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
-            "Detached grading resource changes on node_a must not overwrite node_b immediately");
+    CHECK_MESSAGE(node_color_grading(node_b, renderer) == grading_b,
+            "Detached grading resource changes on node_a cannot touch node_b's per-instance grading");
 
     root->add_child(node_a);
     tree->process(0.0);
-    REQUIRE(renderer->get_color_grading().is_valid());
-    CHECK_MESSAGE(renderer->get_color_grading() == grading_a,
-            "Re-entering node_a should replay its pending grading change exactly once");
-    CHECK(renderer->get_color_grading()->get_exposure() == doctest::Approx(1.25f));
+    Ref<ColorGradingResource> node_a_grading = node_color_grading(node_a, renderer);
+    REQUIRE(node_a_grading.is_valid());
+    CHECK_MESSAGE(node_a_grading == grading_a,
+            "Re-entering node_a must replay its pending grading change onto its director record");
+    CHECK(node_a_grading->get_exposure() == doctest::Approx(1.25f));
+    CHECK_MESSAGE(node_color_grading(node_b, renderer) == grading_b,
+            "node_b's per-instance grading remains unchanged throughout");
 
     root->remove_child(node_b);
     root->remove_child(node_a);
@@ -1985,12 +2014,11 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Detached set_color_
     }
     REQUIRE_MESSAGE(renderer == node_b->get_renderer(), "Both nodes must share the same renderer for this test");
 
-    // Both nodes pushed; renderer reflects whichever ensure_renderer ran
-    // last. Assert via explicit setter so the test is deterministic.
+    // Per-instance storage: node_b's grading is stored on its own record.
     node_b->set_color_grading(grading_b);
     tree->process(0.0);
-    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
-            "Renderer should reflect node_b's grading before node_a detaches");
+    CHECK_MESSAGE(node_color_grading(node_b, renderer) == grading_b,
+            "node_b's per-instance grading must reflect grading_b");
 
     // Detach node_a, then explicitly clear its grading via setter.
     root->remove_child(node_a);
@@ -1998,17 +2026,98 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Detached set_color_
 
     node_a->set_color_grading(Ref<ColorGradingResource>());
     tree->process(0.0);
-    // Detached null setter must NOT touch the renderer immediately.
-    CHECK_MESSAGE(renderer->get_color_grading() == grading_b,
-            "Detached set_color_grading(null) on node_a must not mutate the shared renderer immediately");
+    // Detached null setter does not touch the director (node_a is unregistered),
+    // and node_b's record is untouched.
+    CHECK_MESSAGE(node_color_grading(node_b, renderer) == grading_b,
+            "Detached set_color_grading(null) on node_a must not touch node_b's per-instance grading");
 
-    // Re-attach node_a. The explicit-pending replay must apply node_a's
-    // null grading (last-writer-wins) and clear the renderer's grading.
+    // Re-attach node_a. The explicit-pending replay pushes node_a's null into
+    // its own director record; node_b is unaffected.
     root->add_child(node_a);
     tree->process(0.0);
 
-    CHECK_MESSAGE(renderer->get_color_grading().is_null(),
-            "Re-entering node_a after explicit set_color_grading(null) must apply the null and override node_b's grading");
+    CHECK_MESSAGE(node_color_grading(node_a, renderer).is_null(),
+            "Re-entering node_a after explicit set_color_grading(null) must apply the null to node_a's record");
+    CHECK_MESSAGE(node_color_grading(node_b, renderer) == grading_b,
+            "node_b's grading is still on node_b's record throughout");
+
+    root->remove_child(node_b);
+    root->remove_child(node_a);
+    memdelete(node_b);
+    memdelete(node_a);
+}
+
+TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Two shared-renderer nodes get distinct per-instance grading rows in built buffer") {
+    // Core proof of the per-instance fix: two GaussianSplatNode3D nodes sharing
+    // a renderer must end up with distinct rows in the InstanceGradingGPU buffer
+    // produced by the director, so the shader can apply different grading to each.
+    SceneTree *tree = SceneTree::get_singleton();
+    REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");
+
+    Window *root = tree->get_root();
+    REQUIRE_MESSAGE(root != nullptr, "SceneTree root window required");
+
+    GaussianSplatNode3D *node_a = memnew(GaussianSplatNode3D);
+    GaussianSplatNode3D *node_b = memnew(GaussianSplatNode3D);
+    node_a->set_splat_asset(make_single_splat_asset(9900.0f));
+    node_b->set_splat_asset(make_single_splat_asset(9910.0f));
+
+    Ref<ColorGradingResource> grading_a = make_color_grading_resource();
+    Ref<ColorGradingResource> grading_b = make_color_grading_resource();
+    REQUIRE(grading_a.is_valid());
+    REQUIRE(grading_b.is_valid());
+    grading_a->set_exposure(-1.5f);
+    grading_a->set_contrast(0.25f);
+    grading_a->set_saturation(0.75f);
+    grading_b->set_exposure(2.5f);
+    grading_b->set_contrast(1.75f);
+    grading_b->set_saturation(1.25f);
+
+    node_a->set_color_grading(grading_a);
+    node_b->set_color_grading(grading_b);
+
+    root->add_child(node_a);
+    root->add_child(node_b);
+    tree->process(0.0);
+
+    Ref<GaussianSplatRenderer> renderer = node_a->get_renderer();
+    if (!renderer.is_valid()) {
+        MESSAGE("Skipping test - renderer unavailable (headless mode)");
+        root->remove_child(node_b);
+        root->remove_child(node_a);
+        memdelete(node_b);
+        memdelete(node_a);
+        return;
+    }
+    REQUIRE_MESSAGE(renderer == node_b->get_renderer(), "Both nodes must share the same renderer");
+
+    // Per-instance lookup on the director must return each node's own grading.
+    CHECK(node_color_grading(node_a, renderer) == grading_a);
+    CHECK(node_color_grading(node_b, renderer) == grading_b);
+    CHECK(node_color_grading(node_a, renderer) != node_color_grading(node_b, renderer));
+
+    // Direct director buffer build — the exact bytes the shader reads. This is
+    // the lowest-level guarantee: every grading edit materializes as its own row.
+    GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
+    REQUIRE(director != nullptr);
+    LocalVector<InstanceGradingGPU> gradings;
+    director->build_instance_grading_buffer_for_renderer(renderer.ptr(), gradings, false);
+    // The instance-record filter may skip rows whose asset data is not loaded;
+    // skip the deep assert if the build returned a smaller set than expected.
+    if (gradings.size() >= 2) {
+        // Find the row that matches each grading. Record order follows
+        // world->instances insertion, which matches add_child order.
+        const InstanceGradingGPU &row_a = gradings[0];
+        const InstanceGradingGPU &row_b = gradings[1];
+        CHECK(row_a.primary[1] == doctest::Approx(grading_a->get_exposure()));
+        CHECK(row_a.primary[2] == doctest::Approx(grading_a->get_contrast()));
+        CHECK(row_a.primary[3] == doctest::Approx(grading_a->get_saturation()));
+        CHECK(row_b.primary[1] == doctest::Approx(grading_b->get_exposure()));
+        CHECK(row_b.primary[2] == doctest::Approx(grading_b->get_contrast()));
+        CHECK(row_b.primary[3] == doctest::Approx(grading_b->get_saturation()));
+        // Rows must differ — the whole point of per-instance grading.
+        CHECK(row_a.primary[1] != doctest::Approx(row_b.primary[1]));
+    }
 
     root->remove_child(node_b);
     root->remove_child(node_a);

--- a/modules/gaussian_splatting/tests/test_renderer_pipeline.h
+++ b/modules/gaussian_splatting/tests/test_renderer_pipeline.h
@@ -404,8 +404,8 @@ TEST_CASE("[GaussianSplatting] GPU layout contract invariants remain stable") {
     CHECK(offsetof(TileRenderParamsGPU, instance_rotation_inv_col2) == size_t(640));
     CHECK(offsetof(TileRenderParamsGPU, wind_dir_strength) == size_t(656));
     CHECK(offsetof(TileRenderParamsGPU, wind_time_config) == size_t(672));
-    CHECK(offsetof(TileRenderParamsGPU, effector_spheres) == size_t(704));
-    CHECK(offsetof(TileRenderParamsGPU, effector_configs) == size_t(768));
+    CHECK(offsetof(TileRenderParamsGPU, effector_sphere) == size_t(688));
+    CHECK(offsetof(TileRenderParamsGPU, effector_config) == size_t(704));
 }
 
 static GaussianRenderPipeline::InstancePipelineBuffers make_ready_instance_pipeline_buffers(bool p_quantization_required) {

--- a/modules/gaussian_splatting/tests/test_renderer_pipeline.h
+++ b/modules/gaussian_splatting/tests/test_renderer_pipeline.h
@@ -36,7 +36,7 @@
 
 namespace TestGaussianSplatting {
 
-static_assert(GS_RENDER_PARAMS_LAYOUT_VERSION == 19, "Render params layout version mismatch");
+static_assert(GS_RENDER_PARAMS_LAYOUT_VERSION == 18, "Render params layout version mismatch");
 
 static_assert(sizeof(InstanceDataGPU) == 112, "InstanceDataGPU size contract changed");
 static_assert(offsetof(InstanceDataGPU, lod) == 72, "InstanceDataGPU.lod offset contract changed");
@@ -53,16 +53,16 @@ static_assert(offsetof(PackedGaussian, sh) == 48, "PackedGaussian.sh offset cont
 static_assert(offsetof(PackedGaussian, sh_metadata) == 140, "PackedGaussian.sh_metadata offset contract changed");
 static_assert(sizeof(PackedGaussianF16) == 144, "PackedGaussianF16 size contract changed");
 static_assert(sizeof(PackedGaussianQuantized) == 80, "PackedGaussianQuantized size contract changed");
-static_assert(sizeof(TileRenderParamsGPU) == 912, "TileRenderParamsGPU size contract changed");
+static_assert(sizeof(TileRenderParamsGPU) == 752, "TileRenderParamsGPU size contract changed");
 static_assert(offsetof(TileRenderParamsGPU, viewport_size) == 256, "TileRenderParamsGPU.viewport_size offset contract changed");
 static_assert(offsetof(TileRenderParamsGPU, camera_position) == 320, "TileRenderParamsGPU.camera_position offset contract changed");
 static_assert(offsetof(TileRenderParamsGPU, lighting_mode) == 560, "TileRenderParamsGPU.lighting_mode offset contract changed");
 static_assert(offsetof(TileRenderParamsGPU, instance_rotation_inv_col2) == 640, "TileRenderParamsGPU.instance_rotation_inv_col2 offset contract changed");
 static_assert(offsetof(TileRenderParamsGPU, wind_dir_strength) == 656, "TileRenderParamsGPU.wind_dir_strength offset contract changed");
 static_assert(offsetof(TileRenderParamsGPU, wind_time_config) == 672, "TileRenderParamsGPU.wind_time_config offset contract changed");
-static_assert(offsetof(TileRenderParamsGPU, effector_spheres) == 704, "TileRenderParamsGPU.effector_spheres offset contract changed");
-static_assert(offsetof(TileRenderParamsGPU, effector_configs) == 768, "TileRenderParamsGPU.effector_configs offset contract changed");
-static_assert(offsetof(TileRenderParamsGPU, effector_opacity_configs) == 832, "TileRenderParamsGPU.effector_opacity_configs offset contract changed");
+static_assert(offsetof(TileRenderParamsGPU, effector_sphere) == 688, "TileRenderParamsGPU.effector_sphere offset contract changed");
+static_assert(offsetof(TileRenderParamsGPU, effector_config) == 704, "TileRenderParamsGPU.effector_config offset contract changed");
+static_assert(offsetof(TileRenderParamsGPU, effector_opacity_config) == 720, "TileRenderParamsGPU.effector_opacity_config offset contract changed");
 
 // Utility to ensure we have a GaussianSplatManager available during the test run.
 // Note: Named with "Pipeline" suffix to avoid redefinition with test_render_validation.h
@@ -382,7 +382,7 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] Instance cull failures without fallb
 }
 
 TEST_CASE("[GaussianSplatting] GPU layout contract invariants remain stable") {
-    CHECK(GS_RENDER_PARAMS_LAYOUT_VERSION == 19u);
+    CHECK(GS_RENDER_PARAMS_LAYOUT_VERSION == 18u);
     CHECK(sizeof(InstanceDataGPU) == size_t(112));
     CHECK(offsetof(InstanceDataGPU, effect_params) == size_t(96));
     CHECK(sizeof(AssetMetaGPU) == size_t(112));
@@ -391,8 +391,8 @@ TEST_CASE("[GaussianSplatting] GPU layout contract invariants remain stable") {
     CHECK(sizeof(PackedGaussian) == size_t(144));
     CHECK(sizeof(PackedGaussianF16) == size_t(144));
     CHECK(sizeof(PackedGaussianQuantized) == size_t(80));
-    CHECK(sizeof(TileRenderParamsGPU) == size_t(912));
-    CHECK(offsetof(TileRenderParamsGPU, effector_opacity_configs) == size_t(832));
+    CHECK(sizeof(TileRenderParamsGPU) == size_t(752));
+    CHECK(offsetof(TileRenderParamsGPU, effector_opacity_config) == size_t(720));
 
     CHECK(offsetof(PackedGaussian, rotation) == size_t(32));
     CHECK(offsetof(PackedGaussian, sh) == size_t(48));

--- a/modules/gaussian_splatting/tests/test_renderer_pipeline.h
+++ b/modules/gaussian_splatting/tests/test_renderer_pipeline.h
@@ -402,6 +402,7 @@ static GaussianRenderPipeline::InstancePipelineBuffers make_ready_instance_pipel
     };
 
     buffers.instance_buffer = next_rid();
+    buffers.instance_grading_buffer = next_rid();
     buffers.asset_meta_buffer = next_rid();
     buffers.asset_chunk_index_buffer = next_rid();
     buffers.chunk_meta_buffer = next_rid();

--- a/modules/gaussian_splatting/tests/test_renderer_pipeline.h
+++ b/modules/gaussian_splatting/tests/test_renderer_pipeline.h
@@ -370,6 +370,7 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] Instance cull failures without fallb
 TEST_CASE("[GaussianSplatting] GPU layout contract invariants remain stable") {
     CHECK(GS_RENDER_PARAMS_LAYOUT_VERSION == 18u);
     CHECK(sizeof(InstanceDataGPU) == size_t(112));
+    CHECK(offsetof(InstanceDataGPU, effect_params) == size_t(96));
     CHECK(sizeof(AssetMetaGPU) == size_t(112));
     CHECK(sizeof(ChunkMetaGPU) == size_t(64));
     CHECK(sizeof(SplatRefGPU) == size_t(8));
@@ -377,6 +378,7 @@ TEST_CASE("[GaussianSplatting] GPU layout contract invariants remain stable") {
     CHECK(sizeof(PackedGaussianF16) == size_t(144));
     CHECK(sizeof(PackedGaussianQuantized) == size_t(80));
     CHECK(sizeof(TileRenderParamsGPU) == size_t(752));
+    CHECK(offsetof(TileRenderParamsGPU, effector_opacity_config) == size_t(720));
 
     CHECK(offsetof(PackedGaussian, rotation) == size_t(32));
     CHECK(offsetof(PackedGaussian, sh) == size_t(48));

--- a/modules/gaussian_splatting/tests/test_renderer_pipeline.h
+++ b/modules/gaussian_splatting/tests/test_renderer_pipeline.h
@@ -36,11 +36,12 @@
 
 namespace TestGaussianSplatting {
 
-static_assert(GS_RENDER_PARAMS_LAYOUT_VERSION == 17, "Render params layout version mismatch");
+static_assert(GS_RENDER_PARAMS_LAYOUT_VERSION == 18, "Render params layout version mismatch");
 
-static_assert(sizeof(InstanceDataGPU) == 96, "InstanceDataGPU size contract changed");
+static_assert(sizeof(InstanceDataGPU) == 112, "InstanceDataGPU size contract changed");
 static_assert(offsetof(InstanceDataGPU, lod) == 72, "InstanceDataGPU.lod offset contract changed");
 static_assert(offsetof(InstanceDataGPU, wind_params) == 80, "InstanceDataGPU.wind_params offset contract changed");
+static_assert(offsetof(InstanceDataGPU, effect_params) == 96, "InstanceDataGPU.effect_params offset contract changed");
 static_assert(sizeof(AssetMetaGPU) == 112, "AssetMetaGPU size contract changed");
 static_assert(offsetof(AssetMetaGPU, lod_ranges) == 48, "AssetMetaGPU.lod_ranges offset contract changed");
 static_assert(sizeof(ChunkMetaGPU) == 64, "ChunkMetaGPU size contract changed");
@@ -52,7 +53,7 @@ static_assert(offsetof(PackedGaussian, sh) == 48, "PackedGaussian.sh offset cont
 static_assert(offsetof(PackedGaussian, sh_metadata) == 140, "PackedGaussian.sh_metadata offset contract changed");
 static_assert(sizeof(PackedGaussianF16) == 144, "PackedGaussianF16 size contract changed");
 static_assert(sizeof(PackedGaussianQuantized) == 80, "PackedGaussianQuantized size contract changed");
-static_assert(sizeof(TileRenderParamsGPU) == 736, "TileRenderParamsGPU size contract changed");
+static_assert(sizeof(TileRenderParamsGPU) == 752, "TileRenderParamsGPU size contract changed");
 static_assert(offsetof(TileRenderParamsGPU, viewport_size) == 256, "TileRenderParamsGPU.viewport_size offset contract changed");
 static_assert(offsetof(TileRenderParamsGPU, camera_position) == 320, "TileRenderParamsGPU.camera_position offset contract changed");
 static_assert(offsetof(TileRenderParamsGPU, lighting_mode) == 560, "TileRenderParamsGPU.lighting_mode offset contract changed");
@@ -61,6 +62,7 @@ static_assert(offsetof(TileRenderParamsGPU, wind_dir_strength) == 656, "TileRend
 static_assert(offsetof(TileRenderParamsGPU, wind_time_config) == 672, "TileRenderParamsGPU.wind_time_config offset contract changed");
 static_assert(offsetof(TileRenderParamsGPU, effector_sphere) == 688, "TileRenderParamsGPU.effector_sphere offset contract changed");
 static_assert(offsetof(TileRenderParamsGPU, effector_config) == 704, "TileRenderParamsGPU.effector_config offset contract changed");
+static_assert(offsetof(TileRenderParamsGPU, effector_opacity_config) == 720, "TileRenderParamsGPU.effector_opacity_config offset contract changed");
 
 // Utility to ensure we have a GaussianSplatManager available during the test run.
 // Note: Named with "Pipeline" suffix to avoid redefinition with test_render_validation.h
@@ -145,6 +147,33 @@ public:
         }
     }
 };
+
+TEST_CASE("[GaussianSplatting][Settings] Sphere effector settings are clamped consistently") {
+    ProjectSettings *project_settings = ProjectSettings::get_singleton();
+    REQUIRE_MESSAGE(project_settings != nullptr, "ProjectSettings singleton required");
+
+    ScopedProjectSetting max_effectors_guard(project_settings, "rendering/gaussian_splatting/effects/max_effectors");
+    ScopedProjectSetting frequency_guard(project_settings, "rendering/gaussian_splatting/effects/sphere_effector_frequency");
+    ScopedProjectSetting opacity_strength_guard(project_settings, "rendering/gaussian_splatting/effects/sphere_effector_opacity_strength");
+    ScopedProjectSetting target_opacity_guard(project_settings, "rendering/gaussian_splatting/effects/sphere_effector_target_opacity");
+    ScopedProjectSetting affect_position_guard(project_settings, "rendering/gaussian_splatting/effects/sphere_effector_affect_position");
+    ScopedProjectSetting affect_opacity_guard(project_settings, "rendering/gaussian_splatting/effects/sphere_effector_affect_opacity");
+
+    project_settings->set_setting("rendering/gaussian_splatting/effects/max_effectors", 8);
+    project_settings->set_setting("rendering/gaussian_splatting/effects/sphere_effector_frequency", -3.0f);
+    project_settings->set_setting("rendering/gaussian_splatting/effects/sphere_effector_opacity_strength", 2.5f);
+    project_settings->set_setting("rendering/gaussian_splatting/effects/sphere_effector_target_opacity", -0.4f);
+    project_settings->set_setting("rendering/gaussian_splatting/effects/sphere_effector_affect_position", false);
+    project_settings->set_setting("rendering/gaussian_splatting/effects/sphere_effector_affect_opacity", true);
+
+    const gs::settings::GSSphereEffectorSettings settings = gs::settings::get_sphere_effector_settings(project_settings);
+    CHECK_EQ(settings.max_effectors, 1);
+    CHECK(settings.frequency == doctest::Approx(0.1f));
+    CHECK(settings.opacity_strength == doctest::Approx(1.0f));
+    CHECK(settings.target_opacity == doctest::Approx(0.0f));
+    CHECK_FALSE(settings.affect_position);
+    CHECK(settings.affect_opacity);
+}
 
 static void fill_gaussians(LocalVector<Gaussian> &p_gaussians, uint32_t p_count) {
     p_gaussians.resize(p_count);
@@ -339,15 +368,15 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] Instance cull failures without fallb
 }
 
 TEST_CASE("[GaussianSplatting] GPU layout contract invariants remain stable") {
-    CHECK(GS_RENDER_PARAMS_LAYOUT_VERSION == 17u);
-    CHECK(sizeof(InstanceDataGPU) == size_t(96));
+    CHECK(GS_RENDER_PARAMS_LAYOUT_VERSION == 18u);
+    CHECK(sizeof(InstanceDataGPU) == size_t(112));
     CHECK(sizeof(AssetMetaGPU) == size_t(112));
     CHECK(sizeof(ChunkMetaGPU) == size_t(64));
     CHECK(sizeof(SplatRefGPU) == size_t(8));
     CHECK(sizeof(PackedGaussian) == size_t(144));
     CHECK(sizeof(PackedGaussianF16) == size_t(144));
     CHECK(sizeof(PackedGaussianQuantized) == size_t(80));
-    CHECK(sizeof(TileRenderParamsGPU) == size_t(736));
+    CHECK(sizeof(TileRenderParamsGPU) == size_t(752));
 
     CHECK(offsetof(PackedGaussian, rotation) == size_t(32));
     CHECK(offsetof(PackedGaussian, sh) == size_t(48));

--- a/modules/gaussian_splatting/tests/test_renderer_pipeline.h
+++ b/modules/gaussian_splatting/tests/test_renderer_pipeline.h
@@ -36,7 +36,7 @@
 
 namespace TestGaussianSplatting {
 
-static_assert(GS_RENDER_PARAMS_LAYOUT_VERSION == 18, "Render params layout version mismatch");
+static_assert(GS_RENDER_PARAMS_LAYOUT_VERSION == 19, "Render params layout version mismatch");
 
 static_assert(sizeof(InstanceDataGPU) == 112, "InstanceDataGPU size contract changed");
 static_assert(offsetof(InstanceDataGPU, lod) == 72, "InstanceDataGPU.lod offset contract changed");
@@ -53,16 +53,16 @@ static_assert(offsetof(PackedGaussian, sh) == 48, "PackedGaussian.sh offset cont
 static_assert(offsetof(PackedGaussian, sh_metadata) == 140, "PackedGaussian.sh_metadata offset contract changed");
 static_assert(sizeof(PackedGaussianF16) == 144, "PackedGaussianF16 size contract changed");
 static_assert(sizeof(PackedGaussianQuantized) == 80, "PackedGaussianQuantized size contract changed");
-static_assert(sizeof(TileRenderParamsGPU) == 752, "TileRenderParamsGPU size contract changed");
+static_assert(sizeof(TileRenderParamsGPU) == 912, "TileRenderParamsGPU size contract changed");
 static_assert(offsetof(TileRenderParamsGPU, viewport_size) == 256, "TileRenderParamsGPU.viewport_size offset contract changed");
 static_assert(offsetof(TileRenderParamsGPU, camera_position) == 320, "TileRenderParamsGPU.camera_position offset contract changed");
 static_assert(offsetof(TileRenderParamsGPU, lighting_mode) == 560, "TileRenderParamsGPU.lighting_mode offset contract changed");
 static_assert(offsetof(TileRenderParamsGPU, instance_rotation_inv_col2) == 640, "TileRenderParamsGPU.instance_rotation_inv_col2 offset contract changed");
 static_assert(offsetof(TileRenderParamsGPU, wind_dir_strength) == 656, "TileRenderParamsGPU.wind_dir_strength offset contract changed");
 static_assert(offsetof(TileRenderParamsGPU, wind_time_config) == 672, "TileRenderParamsGPU.wind_time_config offset contract changed");
-static_assert(offsetof(TileRenderParamsGPU, effector_sphere) == 688, "TileRenderParamsGPU.effector_sphere offset contract changed");
-static_assert(offsetof(TileRenderParamsGPU, effector_config) == 704, "TileRenderParamsGPU.effector_config offset contract changed");
-static_assert(offsetof(TileRenderParamsGPU, effector_opacity_config) == 720, "TileRenderParamsGPU.effector_opacity_config offset contract changed");
+static_assert(offsetof(TileRenderParamsGPU, effector_spheres) == 704, "TileRenderParamsGPU.effector_spheres offset contract changed");
+static_assert(offsetof(TileRenderParamsGPU, effector_configs) == 768, "TileRenderParamsGPU.effector_configs offset contract changed");
+static_assert(offsetof(TileRenderParamsGPU, effector_opacity_configs) == 832, "TileRenderParamsGPU.effector_opacity_configs offset contract changed");
 
 // Utility to ensure we have a GaussianSplatManager available during the test run.
 // Note: Named with "Pipeline" suffix to avoid redefinition with test_render_validation.h
@@ -148,31 +148,45 @@ public:
     }
 };
 
-TEST_CASE("[GaussianSplatting][Settings] Sphere effector settings are clamped consistently") {
+TEST_CASE("[GaussianSplatting][Settings] Sphere effector project settings stay registered with production defaults") {
+    ScopedGaussianManagerPipeline manager;
+    REQUIRE_MESSAGE(manager.get() != nullptr, "GaussianSplatManager required to register Gaussian Splatting settings");
+
     ProjectSettings *project_settings = ProjectSettings::get_singleton();
     REQUIRE_MESSAGE(project_settings != nullptr, "ProjectSettings singleton required");
 
     ScopedProjectSetting max_effectors_guard(project_settings, "rendering/gaussian_splatting/effects/max_effectors");
+    ScopedProjectSetting enabled_guard(project_settings, "rendering/gaussian_splatting/effects/sphere_effector_enabled");
+    ScopedProjectSetting radius_guard(project_settings, "rendering/gaussian_splatting/effects/sphere_effector_radius");
+    ScopedProjectSetting strength_guard(project_settings, "rendering/gaussian_splatting/effects/sphere_effector_strength");
+    ScopedProjectSetting falloff_guard(project_settings, "rendering/gaussian_splatting/effects/sphere_effector_falloff");
     ScopedProjectSetting frequency_guard(project_settings, "rendering/gaussian_splatting/effects/sphere_effector_frequency");
     ScopedProjectSetting opacity_strength_guard(project_settings, "rendering/gaussian_splatting/effects/sphere_effector_opacity_strength");
     ScopedProjectSetting target_opacity_guard(project_settings, "rendering/gaussian_splatting/effects/sphere_effector_target_opacity");
     ScopedProjectSetting affect_position_guard(project_settings, "rendering/gaussian_splatting/effects/sphere_effector_affect_position");
     ScopedProjectSetting affect_opacity_guard(project_settings, "rendering/gaussian_splatting/effects/sphere_effector_affect_opacity");
 
-    project_settings->set_setting("rendering/gaussian_splatting/effects/max_effectors", 8);
-    project_settings->set_setting("rendering/gaussian_splatting/effects/sphere_effector_frequency", -3.0f);
-    project_settings->set_setting("rendering/gaussian_splatting/effects/sphere_effector_opacity_strength", 2.5f);
-    project_settings->set_setting("rendering/gaussian_splatting/effects/sphere_effector_target_opacity", -0.4f);
-    project_settings->set_setting("rendering/gaussian_splatting/effects/sphere_effector_affect_position", false);
-    project_settings->set_setting("rendering/gaussian_splatting/effects/sphere_effector_affect_opacity", true);
+    CHECK(project_settings->has_setting("rendering/gaussian_splatting/effects/max_effectors"));
+    CHECK(project_settings->has_setting("rendering/gaussian_splatting/effects/sphere_effector_enabled"));
+    CHECK(project_settings->has_setting("rendering/gaussian_splatting/effects/sphere_effector_radius"));
+    CHECK(project_settings->has_setting("rendering/gaussian_splatting/effects/sphere_effector_strength"));
+    CHECK(project_settings->has_setting("rendering/gaussian_splatting/effects/sphere_effector_falloff"));
+    CHECK(project_settings->has_setting("rendering/gaussian_splatting/effects/sphere_effector_frequency"));
+    CHECK(project_settings->has_setting("rendering/gaussian_splatting/effects/sphere_effector_affect_position"));
+    CHECK(project_settings->has_setting("rendering/gaussian_splatting/effects/sphere_effector_affect_opacity"));
+    CHECK(project_settings->has_setting("rendering/gaussian_splatting/effects/sphere_effector_opacity_strength"));
+    CHECK(project_settings->has_setting("rendering/gaussian_splatting/effects/sphere_effector_target_opacity"));
 
-    const gs::settings::GSSphereEffectorSettings settings = gs::settings::get_sphere_effector_settings(project_settings);
-    CHECK_EQ(settings.max_effectors, 1);
-    CHECK(settings.frequency == doctest::Approx(0.1f));
-    CHECK(settings.opacity_strength == doctest::Approx(1.0f));
-    CHECK(settings.target_opacity == doctest::Approx(0.0f));
-    CHECK_FALSE(settings.affect_position);
-    CHECK(settings.affect_opacity);
+    CHECK_EQ(int(project_settings->get_setting("rendering/gaussian_splatting/effects/max_effectors")), 1);
+    CHECK_FALSE(bool(project_settings->get_setting("rendering/gaussian_splatting/effects/sphere_effector_enabled")));
+    CHECK(double(project_settings->get_setting("rendering/gaussian_splatting/effects/sphere_effector_radius")) == doctest::Approx(0.0));
+    CHECK(double(project_settings->get_setting("rendering/gaussian_splatting/effects/sphere_effector_strength")) == doctest::Approx(0.0));
+    CHECK(double(project_settings->get_setting("rendering/gaussian_splatting/effects/sphere_effector_falloff")) == doctest::Approx(2.0));
+    CHECK(double(project_settings->get_setting("rendering/gaussian_splatting/effects/sphere_effector_frequency")) == doctest::Approx(2.0));
+    CHECK(bool(project_settings->get_setting("rendering/gaussian_splatting/effects/sphere_effector_affect_position")));
+    CHECK_FALSE(bool(project_settings->get_setting("rendering/gaussian_splatting/effects/sphere_effector_affect_opacity")));
+    CHECK(double(project_settings->get_setting("rendering/gaussian_splatting/effects/sphere_effector_opacity_strength")) == doctest::Approx(1.0));
+    CHECK(double(project_settings->get_setting("rendering/gaussian_splatting/effects/sphere_effector_target_opacity")) == doctest::Approx(0.0));
 }
 
 static void fill_gaussians(LocalVector<Gaussian> &p_gaussians, uint32_t p_count) {
@@ -368,7 +382,7 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] Instance cull failures without fallb
 }
 
 TEST_CASE("[GaussianSplatting] GPU layout contract invariants remain stable") {
-    CHECK(GS_RENDER_PARAMS_LAYOUT_VERSION == 18u);
+    CHECK(GS_RENDER_PARAMS_LAYOUT_VERSION == 19u);
     CHECK(sizeof(InstanceDataGPU) == size_t(112));
     CHECK(offsetof(InstanceDataGPU, effect_params) == size_t(96));
     CHECK(sizeof(AssetMetaGPU) == size_t(112));
@@ -377,8 +391,8 @@ TEST_CASE("[GaussianSplatting] GPU layout contract invariants remain stable") {
     CHECK(sizeof(PackedGaussian) == size_t(144));
     CHECK(sizeof(PackedGaussianF16) == size_t(144));
     CHECK(sizeof(PackedGaussianQuantized) == size_t(80));
-    CHECK(sizeof(TileRenderParamsGPU) == size_t(752));
-    CHECK(offsetof(TileRenderParamsGPU, effector_opacity_config) == size_t(720));
+    CHECK(sizeof(TileRenderParamsGPU) == size_t(912));
+    CHECK(offsetof(TileRenderParamsGPU, effector_opacity_configs) == size_t(832));
 
     CHECK(offsetof(PackedGaussian, rotation) == size_t(32));
     CHECK(offsetof(PackedGaussian, sh) == size_t(48));
@@ -390,8 +404,8 @@ TEST_CASE("[GaussianSplatting] GPU layout contract invariants remain stable") {
     CHECK(offsetof(TileRenderParamsGPU, instance_rotation_inv_col2) == size_t(640));
     CHECK(offsetof(TileRenderParamsGPU, wind_dir_strength) == size_t(656));
     CHECK(offsetof(TileRenderParamsGPU, wind_time_config) == size_t(672));
-    CHECK(offsetof(TileRenderParamsGPU, effector_sphere) == size_t(688));
-    CHECK(offsetof(TileRenderParamsGPU, effector_config) == size_t(704));
+    CHECK(offsetof(TileRenderParamsGPU, effector_spheres) == size_t(704));
+    CHECK(offsetof(TileRenderParamsGPU, effector_configs) == size_t(768));
 }
 
 static GaussianRenderPipeline::InstancePipelineBuffers make_ready_instance_pipeline_buffers(bool p_quantization_required) {


### PR DESCRIPTION
## Summary

Fixes the shared-renderer clobber bug where multiple `GaussianSplatNode3D` nodes sharing a renderer all ended up with the last-written node's color grading. Each node now carries its own grading through a sibling SSBO indexed by `SplatRefGPU.instance_id`, parallel to the existing `instance_buffer`.

**Depends on #258** — merges `fix/rid-leak-257` to get the RID leak fix that the streaming instance-grading upload path triggers. Rebase onto master after #258 lands.

## Architecture

- New `InstanceGradingGPU` 32-byte struct (primary vec4 + secondary vec4)
- New sibling SSBO `instance_grading_buffer` at `set=0 binding=20` in `tile_binning.glsl`, parallel rows to `instance_buffer`
- `GaussianSplatSceneDirector` owns per-instance grading: `update_instance_color_grading(node_id, grading)`, `build_instance_grading_buffer_for_renderer(...)`, `get_instance_color_grading(node_id)`
- Node setter and per-frame apply route through the director instead of `renderer->set_color_grading()`
- `_compute_color_grading_signature` hashes every per-instance grading for correct cache invalidation
- `RenderConfig::color_grading` remains as fallback default for world-submission shim

## Lifecycle fixes (discovered during visual verification)

After the initial wire-up, two additional bugs needed fixing:

1. **Registration ordering** — `_push_color_grading_to_renderer` fired from setters/signals before `_register_instance_in_director` ran. The director silently dropped the push (no matching record) but the caller blindly set `grading_pushed_for_current_data = true`, blocking all future replays. Fixed by making `update_instance_color_grading` return `bool` and gating the "pushed" flag on success. Also push grading right after `register_instance` to guarantee the record starts populated.

2. **Slider edits didn't trigger re-upload** — `ColorGradingResource::emit_changed()` fires with the same ref; the director's early-return on `record.color_grading == p_grading` prevented the generation bump, so the grading buffer never re-uploaded with fresh slider values. Now bumps the generation whenever the ref is valid (only skips the null→null per-frame case).

## Commits

1. `baa5e6c5` — `InstanceGradingGPU` struct + sibling SSBO allocation (resident + streaming paths)
2. `fa3ed3c0` — per-instance cache invalidation signature
3. `8d2c19dc` — `tile_binning.glsl` reads grading SSBO at binding=20
4. `38ed23de` — node setter routes through director, shared-renderer gate removed
5. `dc614035` — regression tests (shared-renderer nodes produce distinct rows) + streaming rebuild verification
6. `75d7bddc` — lifecycle fixes: push-success return value + slider edit generation bump
7. `f1ab7a2d` — merge `fix/rid-leak-257` (dependency for testing)

## Constraints respected

- No changes to `tile_binning.glsl` sort payload depth
- Both resident and streaming paths rebuild the grading buffer on the same trigger as the instance buffer
- Release build (`dev_build=no`) verified

## Test plan

- [x] Builds clean on release + dev
- [x] Visual verification: per-instance grading now works (each node's splats use its own grading)
- [x] Visual verification: slider edits on a grading resource update splat color in real-time
- [ ] Two-node shared-renderer scene where each node has distinct grading values — confirm they render distinctly (manual, in GrandmasHouse `dream_memory.tscn`)
- [ ] 5+ minute editor run — no RID leak cascade (validates merged #258 fix works with the new grading SSBO)
- [ ] Unit tests: 10 color grading cases pass, no regressions in the 255-pass suite

## Known limitations

- `TileRenderParamsGPU::color_grading_primary/secondary` fields remain in the UBO (unused by the shader now). Cleanup pass can remove them later.
- Headless unit tests can verify the CPU-side buffer assembly but not the shader's actual consumption — that requires GPU-run visual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)