### PR TITLE
gaussian_splatting: add runtime opacity effector controls

### DIFF
--- a/docs/api/gaussian_splat_node3d.md
+++ b/docs/api/gaussian_splat_node3d.md
@@ -212,8 +212,29 @@ Use `GaussianSplatNode3D` to render Gaussian splat assets or procedural splat ar
       <td><code>rendering/effect_opacity_scale</code></td>
       <td><code>float</code></td>
       <td><code>set_effect_opacity_scale</code>, <code>get_effect_opacity_scale</code></td>
-      <td>Scales how strongly this node responds to sphere opacity deformation.</td>
+      <td>Scales how strongly this node responds to sphere opacity deformation. Runtime opacity diagnostics stay inactive when this scale is <code>0.0</code>, the node base opacity is <code>0.0</code>, or the matched effector target is neutral.</td>
       <td><code>modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp</code></td>
+    </tr>
+    <tr>
+      <td><code>rendering/scene_effectors_enabled</code></td>
+      <td><code>bool</code></td>
+      <td><code>set_scene_effectors_enabled</code>, <code>is_scene_effectors_enabled</code></td>
+      <td>Master opt-in for scene-authored sphere effectors. When disabled, all scene-effector runtime diagnostics report inactive.</td>
+      <td><code>modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp:183</code></td>
+    </tr>
+    <tr>
+      <td><code>rendering/scene_effector_layer_mask</code></td>
+      <td><code>int</code></td>
+      <td><code>set_scene_effector_layer_mask</code>, <code>get_scene_effector_layer_mask</code></td>
+      <td>Bitmask filter for matching scene effectors. <code>0</code> disables all matches for this node.</td>
+      <td><code>modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp:187</code></td>
+    </tr>
+    <tr>
+      <td><code>rendering/scene_effector_scope_root</code></td>
+      <td><code>NodePath</code></td>
+      <td><code>set_scene_effector_scope_root</code>, <code>get_scene_effector_scope_root</code></td>
+      <td>Optional node-side scope narrowing. The path must resolve to this node or one of its ancestors.</td>
+      <td><code>modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp:194</code></td>
     </tr>
     <tr>
       <td><code>rendering/wind_override_enabled</code></td>
@@ -352,14 +373,17 @@ The current branch exposes a scene-driven-plus-per-node workflow for gameplay ef
 - `SphereEffector3D` is the primary authoring surface for sphere deformation and dissolve effects.
 - `rendering/effect_position_scale` and `rendering/effect_opacity_scale` let each `GaussianSplatNode3D` partially follow, fully follow, or effectively ignore matched scene effectors.
 - `rendering/scene_effectors_enabled`, `rendering/scene_effector_layer_mask`, and `rendering/scene_effector_scope_root` control whether this node participates in scene effectors and which ones may match.
+- `rendering/scene_effector_scope_root` is a node-side narrowing filter, not an opt-in to arbitrary world effectors. It must resolve to this node or one of its ancestors, and only effectors with the same resolved scope root will match.
 - `rendering/opacity` remains the direct per-node gameplay fade, while scene-effector opacity modulation multiplies on top for dissolve or degeneration effects.
 - `get_last_matched_scene_effector_count()`, `is_scene_effector_position_active()`, and `is_scene_effector_opacity_active()` expose the current runtime match state for gameplay and debugging.
+- `get_statistics()` mirrors those diagnostics under `matched_scene_effectors`, `scene_effector_position_active`, and `scene_effector_opacity_active`.
+- `get_configuration_warnings()` warns about inert scene-effector setups such as both response scales at `0.0`, scene-effector layer mask `0`, opacity modulation with base opacity `0.0`, or an invalid scope root path.
 
 Practical recipes:
 
 - Wind-only: disable `rendering/scene_effectors_enabled` or set both per-node effect scales to `0.0`.
 - Sphere position-only: enable a `SphereEffector3D`, keep `rendering/effect_position_scale > 0.0`, and set `rendering/effect_opacity_scale = 0.0`.
-- Sphere opacity-only dissolve or fade: enable `SphereEffector3D.affect_opacity`, set `SphereEffector3D.target_opacity`, set `rendering/effect_position_scale = 0.0`, and tune `rendering/effect_opacity_scale`.
+- Sphere opacity-only dissolve or fade: enable `SphereEffector3D.affect_opacity`, set `SphereEffector3D.target_opacity` below `1.0`, set `rendering/effect_position_scale = 0.0`, and tune `rendering/effect_opacity_scale`.
 - Combined wind + sphere + dissolve: enable per-node wind override and keep both effect scales above zero.
 
 Current bounds:
@@ -368,6 +392,7 @@ Current bounds:
 - `SphereEffector3D` defaults to subtree scoping. Put the effector under the same gameplay parent as the splat nodes you want to affect, or use its explicit root/layer controls for broader setups.
 - ProjectSettings under `rendering/gaussian_splatting/effects/*` still act as a compatibility fallback when no scene-authored sphere effectors are active.
 - Invalid node-authored runtime inputs are sanitized where supported: opacity clamps to `0.0..1.0`, effect scales clamp to `>= 0.0`, and non-finite opacity or effect scale inputs fall back to stable defaults.
+- A matched opacity effector with `target_opacity = 1.0` is intentionally neutral. The node can still report a non-zero matched-effector count while `is_scene_effector_opacity_active()` remains `false`.
 
 Example scenes:
 
@@ -386,6 +411,21 @@ See also: `docs/api/sphere_effector_workflow.md`.
     </tr>
   </thead>
   <tbody>
+    <tr>
+      <td><code>get_last_matched_scene_effector_count()</code></td>
+      <td>Returns the current number of scene effectors that match this node after scope and layer-mask filtering.</td>
+      <td><code>modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp:1133</code></td>
+    </tr>
+    <tr>
+      <td><code>is_scene_effector_position_active()</code></td>
+      <td>Returns whether any currently matched scene effector can contribute position deformation after node-local scale checks.</td>
+      <td><code>modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp:1148</code></td>
+    </tr>
+    <tr>
+      <td><code>is_scene_effector_opacity_active()</code></td>
+      <td>Returns whether any currently matched scene effector can contribute opacity modulation after node-local opacity and scale checks.</td>
+      <td><code>modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp:1163</code></td>
+    </tr>
     <tr>
       <td><code>reload_asset()</code></td>
       <td>Triggers the same load path as setting a new file path.</td>

--- a/docs/api/gaussian_splat_node3d.md
+++ b/docs/api/gaussian_splat_node3d.md
@@ -375,7 +375,7 @@ The current branch exposes a scene-driven-plus-per-node workflow for gameplay ef
 - `rendering/scene_effectors_enabled`, `rendering/scene_effector_layer_mask`, and `rendering/scene_effector_scope_root` control whether this node participates in scene effectors and which ones may match.
 - `rendering/scene_effector_scope_root` is a node-side narrowing filter, not an opt-in to arbitrary world effectors. It must resolve to this node or one of its ancestors, and only effectors with the same resolved scope root will match.
 - `rendering/opacity` remains the direct per-node gameplay fade, while scene-effector opacity modulation multiplies on top for dissolve or degeneration effects.
-- `get_last_matched_scene_effector_count()`, `get_scene_effector_debug_state()`, `is_scene_effector_position_active()`, and `is_scene_effector_opacity_active()` expose the current runtime match state for gameplay and debugging.
+- `get_last_matched_scene_effector_count()`, `get_scene_effector_debug_state()`, `is_scene_effector_position_active()`, and `is_scene_effector_opacity_active()` expose the current runtime match state for gameplay and debugging. `matched_count` is the full logical match set, while `bound_count` is the subset that actually fit into the renderer budget.
 - `get_statistics()` mirrors those diagnostics under `matched_scene_effectors`, `bound_scene_effectors`, `scene_effector_truncated`, `scene_effector_position_active`, and `scene_effector_opacity_active`.
 - `get_configuration_warnings()` warns about inert scene-effector setups such as both response scales at `0.0`, scene-effector layer mask `0`, opacity modulation with base opacity `0.0`, or an invalid scope root path.
 
@@ -388,9 +388,9 @@ Practical recipes:
 
 Current bounds:
 
-- Scene effectors are bounded to `4` active bindings per renderer pass. If more are present, the highest-priority deterministic four are used.
+- Scene-authored effectors are bounded to `4` active bindings per renderer pass. If more match this node, the highest-priority deterministic four are bound and the rest remain logical matches only.
 - `SphereEffector3D` defaults to subtree scoping. Put the effector under the same gameplay parent as the splat nodes you want to affect, or use its explicit root/layer controls for broader setups.
-- ProjectSettings under `rendering/gaussian_splatting/effects/*` still act as a compatibility fallback when no scene-authored sphere effectors are active.
+- ProjectSettings under `rendering/gaussian_splatting/effects/*` still act as a compatibility fallback when no scene-authored sphere effectors are active. That fallback remains single-global and still honors `rendering/gaussian_splatting/effects/max_effectors` clamped to `0..1`.
 - Invalid node-authored runtime inputs are sanitized where supported: opacity clamps to `0.0..1.0`, effect scales clamp to `>= 0.0`, and non-finite opacity or effect scale inputs fall back to stable defaults.
 - A matched opacity effector with `target_opacity = 1.0` is intentionally neutral. The node can still report a non-zero matched-effector count while `is_scene_effector_opacity_active()` remains `false`.
 
@@ -418,7 +418,7 @@ See also: `docs/api/sphere_effector_workflow.md`.
     </tr>
     <tr>
       <td><code>get_scene_effector_debug_state()</code></td>
-      <td>Returns a Dictionary describing both logical matches and the subset that was actually bound to the renderer, including truncation and selected effector names.</td>
+      <td>Returns a Dictionary describing both logical matches and the subset that was actually bound to the renderer, including <code>matched_count</code>, <code>bound_count</code>, <code>truncated</code>, and selected effector ids and names.</td>
       <td><code>modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp:1165</code></td>
     </tr>
     <tr>

--- a/docs/api/gaussian_splat_node3d.md
+++ b/docs/api/gaussian_splat_node3d.md
@@ -375,8 +375,8 @@ The current branch exposes a scene-driven-plus-per-node workflow for gameplay ef
 - `rendering/scene_effectors_enabled`, `rendering/scene_effector_layer_mask`, and `rendering/scene_effector_scope_root` control whether this node participates in scene effectors and which ones may match.
 - `rendering/scene_effector_scope_root` is a node-side narrowing filter, not an opt-in to arbitrary world effectors. It must resolve to this node or one of its ancestors, and only effectors with the same resolved scope root will match.
 - `rendering/opacity` remains the direct per-node gameplay fade, while scene-effector opacity modulation multiplies on top for dissolve or degeneration effects.
-- `get_last_matched_scene_effector_count()`, `is_scene_effector_position_active()`, and `is_scene_effector_opacity_active()` expose the current runtime match state for gameplay and debugging.
-- `get_statistics()` mirrors those diagnostics under `matched_scene_effectors`, `scene_effector_position_active`, and `scene_effector_opacity_active`.
+- `get_last_matched_scene_effector_count()`, `get_scene_effector_debug_state()`, `is_scene_effector_position_active()`, and `is_scene_effector_opacity_active()` expose the current runtime match state for gameplay and debugging.
+- `get_statistics()` mirrors those diagnostics under `matched_scene_effectors`, `bound_scene_effectors`, `scene_effector_truncated`, `scene_effector_position_active`, and `scene_effector_opacity_active`.
 - `get_configuration_warnings()` warns about inert scene-effector setups such as both response scales at `0.0`, scene-effector layer mask `0`, opacity modulation with base opacity `0.0`, or an invalid scope root path.
 
 Practical recipes:
@@ -415,6 +415,11 @@ See also: `docs/api/sphere_effector_workflow.md`.
       <td><code>get_last_matched_scene_effector_count()</code></td>
       <td>Returns the current number of scene effectors that match this node after scope and layer-mask filtering.</td>
       <td><code>modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp:1133</code></td>
+    </tr>
+    <tr>
+      <td><code>get_scene_effector_debug_state()</code></td>
+      <td>Returns a Dictionary describing both logical matches and the subset that was actually bound to the renderer, including truncation and selected effector names.</td>
+      <td><code>modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp:1165</code></td>
     </tr>
     <tr>
       <td><code>is_scene_effector_position_active()</code></td>

--- a/docs/api/gaussian_splat_node3d.md
+++ b/docs/api/gaussian_splat_node3d.md
@@ -353,12 +353,13 @@ The current branch exposes a scene-driven-plus-per-node workflow for gameplay ef
 - `rendering/effect_position_scale` and `rendering/effect_opacity_scale` let each `GaussianSplatNode3D` partially follow, fully follow, or effectively ignore matched scene effectors.
 - `rendering/scene_effectors_enabled`, `rendering/scene_effector_layer_mask`, and `rendering/scene_effector_scope_root` control whether this node participates in scene effectors and which ones may match.
 - `rendering/opacity` remains the direct per-node gameplay fade, while scene-effector opacity modulation multiplies on top for dissolve or degeneration effects.
+- `get_last_matched_scene_effector_count()`, `is_scene_effector_position_active()`, and `is_scene_effector_opacity_active()` expose the current runtime match state for gameplay and debugging.
 
 Practical recipes:
 
 - Wind-only: disable `rendering/scene_effectors_enabled` or set both per-node effect scales to `0.0`.
 - Sphere position-only: enable a `SphereEffector3D`, keep `rendering/effect_position_scale > 0.0`, and set `rendering/effect_opacity_scale = 0.0`.
-- Sphere opacity-only dissolve: enable `SphereEffector3D.affect_opacity`, set `rendering/effect_position_scale = 0.0`, and tune `rendering/effect_opacity_scale`.
+- Sphere opacity-only dissolve or fade: enable `SphereEffector3D.affect_opacity`, set `SphereEffector3D.target_opacity`, set `rendering/effect_position_scale = 0.0`, and tune `rendering/effect_opacity_scale`.
 - Combined wind + sphere + dissolve: enable per-node wind override and keep both effect scales above zero.
 
 Current bounds:

--- a/docs/api/shader_reference.md
+++ b/docs/api/shader_reference.md
@@ -904,7 +904,7 @@ RenderParams (params)
     <tr>
       <td><pre><code>effector_sphere</code></pre></td>
       <td><pre><code>vec4</code></pre></td>
-      <td>Single global sphere effector (foundation for capped multi-effector support): effector_sphere: xyz = center (world), w = radius effector_config: x = enabled (0/1), y = displacement strength (meters), z = falloff exponent, w = reserved</td>
+      <td>Legacy ProjectSettings fallback sphere effector uniform: <code>effector_sphere</code> packs center xyz in world space and radius in w. This documents the single-global fallback path only; scene-authored <code>SphereEffector3D</code> bindings use a separate capped binding path with per-instance selection and truncation.</td>
     </tr>
   </tbody>
 </table>

--- a/docs/api/sphere_effector_workflow.md
+++ b/docs/api/sphere_effector_workflow.md
@@ -5,7 +5,7 @@
 This branch supports scene-authored sphere effectors for Gaussian splats through `SphereEffector3D`.
 
 - Author `SphereEffector3D` nodes directly in the scene.
-- Match splat nodes with subtree scope, explicit scope roots, and layer masks.
+- Match splat nodes with subtree scope, explicit scope roots, world scope, and layer masks.
 - Blend each splat node's response with:
   - `rendering/effect_position_scale`
   - `rendering/effect_opacity_scale`
@@ -35,6 +35,26 @@ ProjectSettings under `rendering/gaussian_splatting/effects/*` remain available 
 - If more than `4` candidate scene effectors are present, the highest-priority deterministic four are used.
 - Deterministic ordering uses priority first, then scope specificity, then scene path, then object id.
 - `get_primary_sphere_effector_for_instance()` is now a compatibility query only. It still returns one match even though the renderer can bind multiple.
+- `target_opacity = 1.0` is a neutral target. Matching nodes still count as matched, but no visible opacity change is produced and opacity diagnostics stay inactive.
+
+## Runtime Diagnostics
+
+- `GaussianSplatNode3D.get_last_matched_scene_effector_count()` reports logical matches after scope and layer-mask filtering. This count can stay non-zero even when both active-channel flags are `false`.
+- `GaussianSplatNode3D.is_scene_effector_position_active()` only returns `true` when a matched effector can actually contribute position deformation. Zero node position scale or zero effector strength keeps it `false`.
+- `GaussianSplatNode3D.is_scene_effector_opacity_active()` only returns `true` when a matched effector can actually contribute opacity modulation. It stays `false` when node opacity is `0.0`, node opacity scale is `0.0`, effector `opacity_strength` is `0.0`, or effector `target_opacity` is `1.0`.
+- `GaussianSplatNode3D.get_statistics()` mirrors these runtime values under `matched_scene_effectors`, `scene_effector_position_active`, and `scene_effector_opacity_active`.
+- `GaussianSplatNode3D.get_configuration_warnings()` surfaces common inert setups:
+  - both effect response scales at `0.0`
+  - `rendering/scene_effector_layer_mask = 0`
+  - opacity modulation enabled while `rendering/opacity = 0.0`
+  - invalid `rendering/scene_effector_scope_root`
+- `SphereEffector3D.get_configuration_warnings()` surfaces inert or invalid effector authoring:
+  - enabled with neither position nor opacity enabled
+  - `opacity_strength = 0.0`
+  - `target_opacity = 1.0`
+  - `layer_mask = 0`
+  - `Parent Subtree` scope without a parent
+  - `Explicit Root` scope without `scope_root`
 
 ## Authoring Recipes
 
@@ -57,8 +77,8 @@ ProjectSettings under `rendering/gaussian_splatting/effects/*` remain available 
 2. Set `affect_opacity = true`.
 3. Tune `opacity_strength`.
 4. Set `target_opacity`:
-   - `0.0` for a dissolve
-   - `0.35` or similar for partial degeneration
+  - `0.0` for a dissolve
+  - any value below `1.0`, such as `0.35`, for partial degeneration
 5. Set the node's `rendering/effect_position_scale = 0.0`.
 6. Set `rendering/effect_opacity_scale` above `0.0`.
 
@@ -70,11 +90,13 @@ ProjectSettings under `rendering/gaussian_splatting/effects/*` remain available 
 
 ## Artist Notes
 
-- Put a `SphereEffector3D` under the same gameplay parent as the splat nodes you want to affect. The default `Parent Subtree` scope is the safest workflow.
+- Put a `SphereEffector3D` under the same gameplay parent as the splat nodes you want to affect. The default `Parent Subtree` scope uses the effector's parent as the scope root.
+- Switch to `World` scope only when you intentionally want to reach matching splat nodes outside that subtree.
+- Use `Explicit Root` together with node `rendering/scene_effector_scope_root` when you need a narrower branch than the effector's default subtree.
 - Use effector `layer_mask` and node `rendering/scene_effector_layer_mask` when multiple effect systems share a world.
 - Use `priority` when multiple effectors overlap and you need deterministic truncation into the renderer's four-slot budget.
 - Keep `rendering/effect_opacity_scale` at `0.0` on nodes that should not dissolve even if they still follow position deformation.
-- Use `GaussianSplatNode3D.get_last_matched_scene_effector_count()`, `is_scene_effector_position_active()`, and `is_scene_effector_opacity_active()` from gameplay scripts when you need runtime diagnostics.
+- Use `GaussianSplatNode3D.get_last_matched_scene_effector_count()`, `is_scene_effector_position_active()`, `is_scene_effector_opacity_active()`, and `get_statistics()` from gameplay scripts when you need runtime diagnostics.
 
 ## Stability And Sanitization
 

--- a/docs/api/sphere_effector_workflow.md
+++ b/docs/api/sphere_effector_workflow.md
@@ -18,7 +18,7 @@ This branch supports scene-authored sphere effectors for Gaussian splats through
   - `rendering/wind_direction`
   - `rendering/wind_frequency`
 
-ProjectSettings under `rendering/gaussian_splatting/effects/*` remain available as a backward-compatible fallback when a scene does not author any active `SphereEffector3D` nodes.
+ProjectSettings under `rendering/gaussian_splatting/effects/*` remain available as a backward-compatible fallback when a scene does not author any active `SphereEffector3D` nodes. That fallback stays on the legacy single-global-effector path, so `rendering/gaussian_splatting/effects/max_effectors` is still clamped to `0..1` there even though scene-authored bindings can fill a larger renderer budget.
 
 ## What Works In Game
 
@@ -31,16 +31,17 @@ ProjectSettings under `rendering/gaussian_splatting/effects/*` remain available 
 
 ## Hard Bounds
 
-- The renderer binds at most `4` scene effectors per pass.
-- If more than `4` candidate scene effectors are present, the highest-priority deterministic four are used.
+- The renderer binds at most `4` scene-authored effectors per pass.
+- If more than `4` scene-authored effectors match one node, the highest-priority deterministic four are bound and the rest stay logical matches only.
 - Deterministic ordering uses priority first, then scope specificity, then registration order, then object id.
 - `get_primary_sphere_effector_for_instance()` is now a compatibility query only. It still returns one match even though the renderer can bind multiple.
+- ProjectSettings fallback effectors remain single-global and are still governed by `rendering/gaussian_splatting/effects/max_effectors` clamped to `0..1`.
 - `target_opacity = 1.0` is a neutral target. Matching nodes still count as matched, but no visible opacity change is produced and opacity diagnostics stay inactive.
 
 ## Runtime Diagnostics
 
 - `GaussianSplatNode3D.get_last_matched_scene_effector_count()` reports logical matches after scope and layer-mask filtering. This count can stay non-zero even when both active-channel flags are `false`.
-- `GaussianSplatNode3D.get_scene_effector_debug_state()` reports both logical and renderer-bound state, including `matched_count`, `bound_count`, `truncated`, `selected_effector_ids`, and `selected_effector_names`.
+- `GaussianSplatNode3D.get_scene_effector_debug_state()` reports both logical and renderer-bound state. `matched_count` is the full logical match set after scope and layer filtering, `bound_count` is the subset that actually fit into the renderer budget, and `truncated` tells you when `matched_count > bound_count`.
 - `GaussianSplatNode3D.is_scene_effector_position_active()` only returns `true` when a matched effector can actually contribute position deformation. Zero node position scale or zero effector strength keeps it `false`.
 - `GaussianSplatNode3D.is_scene_effector_opacity_active()` only returns `true` when a matched effector can actually contribute opacity modulation. It stays `false` when node opacity is `0.0`, node opacity scale is `0.0`, effector `opacity_strength` is `0.0`, or effector `target_opacity` is `1.0`.
 - `GaussianSplatNode3D.get_statistics()` mirrors these runtime values under `matched_scene_effectors`, `bound_scene_effectors`, `scene_effector_truncated`, `scene_effector_position_active`, and `scene_effector_opacity_active`.
@@ -95,9 +96,9 @@ ProjectSettings under `rendering/gaussian_splatting/effects/*` remain available 
 - Switch to `World` scope only when you intentionally want to reach matching splat nodes outside that subtree.
 - Use `Explicit Root` together with node `rendering/scene_effector_scope_root` when you need a narrower branch than the effector's default subtree.
 - Use effector `layer_mask` and node `rendering/scene_effector_layer_mask` when multiple effect systems share a world.
-- Use `priority` when multiple effectors overlap and you need deterministic truncation into the renderer's four-slot budget.
+- Use `priority` when multiple effectors overlap and you need deterministic truncation into the renderer's four-slot scene budget.
 - Keep `rendering/effect_opacity_scale` at `0.0` on nodes that should not dissolve even if they still follow position deformation.
-- Use `GaussianSplatNode3D.get_scene_effector_debug_state()` or `get_statistics()` from gameplay scripts when you need to understand why an effector matched but did not become active on the renderer.
+- Use `GaussianSplatNode3D.get_scene_effector_debug_state()` or `get_statistics()` from gameplay scripts when you need to understand why an effector matched but did not become renderer-bound, or why a matched effector stayed logically present but inactive.
 
 ## Stability And Sanitization
 

--- a/docs/api/sphere_effector_workflow.md
+++ b/docs/api/sphere_effector_workflow.md
@@ -10,6 +10,7 @@ This branch supports scene-authored sphere effectors for Gaussian splats through
   - `rendering/effect_position_scale`
   - `rendering/effect_opacity_scale`
   - `rendering/opacity`
+- Drive opacity toward `SphereEffector3D.target_opacity` instead of only dissolving to zero.
 - Override wind per node with:
   - `rendering/wind_override_enabled`
   - `rendering/wind_enabled`
@@ -50,15 +51,16 @@ ProjectSettings under `rendering/gaussian_splatting/effects/*` remain available 
 3. Set the node's `rendering/effect_position_scale` above `0.0`.
 4. Set `rendering/effect_opacity_scale = 0.0`.
 
-### Sphere Opacity-only Dissolve
+### Sphere Opacity-only Fade / Dissolve
 
 1. Add a `SphereEffector3D`.
 2. Set `affect_opacity = true`.
 3. Tune `opacity_strength`.
-4. Set the node's `rendering/effect_position_scale = 0.0`.
-5. Set `rendering/effect_opacity_scale` above `0.0`.
-
-Scene-driven opacity currently dissolves toward transparent. Use the ProjectSettings fallback path if you need a non-zero target opacity until the node API grows a dedicated target control.
+4. Set `target_opacity`:
+   - `0.0` for a dissolve
+   - `0.35` or similar for partial degeneration
+5. Set the node's `rendering/effect_position_scale = 0.0`.
+6. Set `rendering/effect_opacity_scale` above `0.0`.
 
 ### Combined Wind + Sphere + Opacity
 
@@ -72,6 +74,7 @@ Scene-driven opacity currently dissolves toward transparent. Use the ProjectSett
 - Use effector `layer_mask` and node `rendering/scene_effector_layer_mask` when multiple effect systems share a world.
 - Use `priority` when multiple effectors overlap and you need deterministic truncation into the renderer's four-slot budget.
 - Keep `rendering/effect_opacity_scale` at `0.0` on nodes that should not dissolve even if they still follow position deformation.
+- Use `GaussianSplatNode3D.get_last_matched_scene_effector_count()`, `is_scene_effector_position_active()`, and `is_scene_effector_opacity_active()` from gameplay scripts when you need runtime diagnostics.
 
 ## Stability And Sanitization
 
@@ -81,6 +84,7 @@ Scene-driven opacity currently dissolves toward transparent. Use the ProjectSett
 - `SphereEffector3D.falloff` clamps to `>= 0.001`.
 - `SphereEffector3D.frequency` clamps to `>= 0.1`.
 - `SphereEffector3D.opacity_strength` clamps to `0.0..1.0`.
+- `SphereEffector3D.target_opacity` clamps to `0.0..1.0`.
 - Non-finite node or effector values fall back to stable defaults instead of propagating NaNs into rendering.
 
 ## Example Scenes

--- a/docs/api/sphere_effector_workflow.md
+++ b/docs/api/sphere_effector_workflow.md
@@ -33,16 +33,17 @@ ProjectSettings under `rendering/gaussian_splatting/effects/*` remain available 
 
 - The renderer binds at most `4` scene effectors per pass.
 - If more than `4` candidate scene effectors are present, the highest-priority deterministic four are used.
-- Deterministic ordering uses priority first, then scope specificity, then scene path, then object id.
+- Deterministic ordering uses priority first, then scope specificity, then registration order, then object id.
 - `get_primary_sphere_effector_for_instance()` is now a compatibility query only. It still returns one match even though the renderer can bind multiple.
 - `target_opacity = 1.0` is a neutral target. Matching nodes still count as matched, but no visible opacity change is produced and opacity diagnostics stay inactive.
 
 ## Runtime Diagnostics
 
 - `GaussianSplatNode3D.get_last_matched_scene_effector_count()` reports logical matches after scope and layer-mask filtering. This count can stay non-zero even when both active-channel flags are `false`.
+- `GaussianSplatNode3D.get_scene_effector_debug_state()` reports both logical and renderer-bound state, including `matched_count`, `bound_count`, `truncated`, `selected_effector_ids`, and `selected_effector_names`.
 - `GaussianSplatNode3D.is_scene_effector_position_active()` only returns `true` when a matched effector can actually contribute position deformation. Zero node position scale or zero effector strength keeps it `false`.
 - `GaussianSplatNode3D.is_scene_effector_opacity_active()` only returns `true` when a matched effector can actually contribute opacity modulation. It stays `false` when node opacity is `0.0`, node opacity scale is `0.0`, effector `opacity_strength` is `0.0`, or effector `target_opacity` is `1.0`.
-- `GaussianSplatNode3D.get_statistics()` mirrors these runtime values under `matched_scene_effectors`, `scene_effector_position_active`, and `scene_effector_opacity_active`.
+- `GaussianSplatNode3D.get_statistics()` mirrors these runtime values under `matched_scene_effectors`, `bound_scene_effectors`, `scene_effector_truncated`, `scene_effector_position_active`, and `scene_effector_opacity_active`.
 - `GaussianSplatNode3D.get_configuration_warnings()` surfaces common inert setups:
   - both effect response scales at `0.0`
   - `rendering/scene_effector_layer_mask = 0`
@@ -96,7 +97,7 @@ ProjectSettings under `rendering/gaussian_splatting/effects/*` remain available 
 - Use effector `layer_mask` and node `rendering/scene_effector_layer_mask` when multiple effect systems share a world.
 - Use `priority` when multiple effectors overlap and you need deterministic truncation into the renderer's four-slot budget.
 - Keep `rendering/effect_opacity_scale` at `0.0` on nodes that should not dissolve even if they still follow position deformation.
-- Use `GaussianSplatNode3D.get_last_matched_scene_effector_count()`, `is_scene_effector_position_active()`, `is_scene_effector_opacity_active()`, and `get_statistics()` from gameplay scripts when you need runtime diagnostics.
+- Use `GaussianSplatNode3D.get_scene_effector_debug_state()` or `get_statistics()` from gameplay scripts when you need to understand why an effector matched but did not become active on the renderer.
 
 ## Stability And Sanitization
 

--- a/docs/reference/project-settings.md
+++ b/docs/reference/project-settings.md
@@ -757,6 +757,8 @@ These settings are registered with `GLOBAL_DEF(...)` and grouped by key prefix.
   </tbody>
 </table>
 
+For the `rendering/gaussian_splatting/effects/*` keys above, the current branch uses these settings as a compatibility fallback when no active `SphereEffector3D` nodes are present in the scene. That fallback still follows the legacy single-global-effector contract, so `rendering/gaussian_splatting/effects/max_effectors` is clamped to `0..1` even though scene-authored effectors can bind up to four entries per renderer pass.
+
 ### Runtime-only keys
 These keys are used by module code but are not registered with `GLOBAL_DEF(...)`.
 

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -2400,87 +2400,21 @@ bool GaussianSplatSceneDirector::get_primary_sphere_effector_for_instance(Object
 
 bool GaussianSplatSceneDirector::get_scene_effector_match_summary_for_instance(ObjectID p_node_id,
 		uint32_t *r_match_count, bool *r_position_active, bool *r_opacity_active) const {
-	if (r_match_count) {
-		*r_match_count = 0u;
-	}
-	if (r_position_active) {
-		*r_position_active = false;
-	}
-	if (r_opacity_active) {
-		*r_opacity_active = false;
-	}
-
-	MutexLock lock(world_mutex);
-	// Locate the world using the cached instance record — the render thread
-	// keeps this fresh via update_instance_scene_effector_filter(), so no
-	// scene-tree walk is needed here. Main-thread callers from node property
-	// queries are the only consumers.
-	const SharedWorld *world = nullptr;
-	for (const KeyValue<RID, SharedWorld> &E : worlds) {
-		if (E.value.instance_lookup.has(p_node_id)) {
-			world = &E.value;
-			break;
-		}
-	}
-	if (!world || world->sphere_effectors.is_empty()) {
-		return false;
-	}
-
-	const uint32_t *index_ptr = world->instance_lookup.getptr(p_node_id);
-	if (!index_ptr || *index_ptr >= world->instances.size()) {
-		return false;
-	}
-	const InstanceRecord &record = world->instances[*index_ptr];
-	if (!record.scene_effectors_enabled || record.scene_effector_layer_mask == 0u ||
-			(record.scene_effector_scope_filter_present && !record.scene_effector_scope_filter_valid)) {
-		return false;
-	}
-
-	uint32_t matched_count = 0u;
-	bool any_position = false;
-	bool any_opacity = false;
-	for (const SphereEffectorRecord &effector : world->sphere_effectors) {
-		if (!effector.enabled || (!effector.affect_position && !effector.affect_opacity)) {
-			continue;
-		}
-		if ((effector.layer_mask & record.scene_effector_layer_mask) == 0u) {
-			continue;
-		}
-		if (record.scene_effector_scope_filter_present) {
-			if (effector.scope_root_id == ObjectID() || effector.scope_root_id != record.scene_effector_scope_root_id) {
-				continue;
-			}
-		} else if (effector.scope_mode != SPHERE_EFFECTOR_SCOPE_WORLD) {
-			// Implicit subtree containment requires a tree walk — skipped here
-			// to keep this method safe to call under the director mutex.
-			continue;
-		}
-
-		matched_count++;
-		// An effector that reports a channel is "active" only when it can
-		// actually contribute a deformation. Codex called out the inert cases:
-		// strength == 0 (no position amplitude), opacity_strength == 0 (no
-		// opacity weight), or target_opacity == 1.0 (pushing fully opaque —
-		// the neutral target for already-opaque splats). Filter those out so
-		// the node's `is_scene_effector_*_active()` diagnostics match the
-		// API contract of "currently contributes".
-		if (effector.affect_position && !Math::is_zero_approx(effector.strength)) {
-			any_position = true;
-		}
-		if (effector.affect_opacity && !Math::is_zero_approx(effector.opacity_strength) &&
-				!Math::is_equal_approx(effector.target_opacity, 1.0f)) {
-			any_opacity = true;
-		}
-	}
-
+	// Delegate to the richer debug-state accessor so the summary and the
+	// Dictionary readout can't drift in their scope/subtree handling.
+	// Specifically, the subtree-without-explicit-node-scope case is resolved
+	// via the InstanceRecord's cached ancestor chain — matching the actual
+	// render-path behavior instead of dropping every non-WORLD effector.
+	const Dictionary state = get_scene_effector_debug_state_for_instance(p_node_id);
+	const uint32_t matched_count = uint32_t(int64_t(state.get(StringName("matched_count"), 0)));
 	if (r_match_count) {
 		*r_match_count = matched_count;
 	}
 	if (r_position_active) {
-		*r_position_active = any_position;
+		*r_position_active = bool(state.get(StringName("matched_position_active"), false));
 	}
 	if (r_opacity_active) {
-		*r_opacity_active = any_opacity;
+		*r_opacity_active = bool(state.get(StringName("matched_opacity_active"), false));
 	}
 	return matched_count > 0u;
 }

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -560,7 +560,13 @@ void GaussianSplatSceneDirector::_build_sorted_sphere_effector_payload(const Sha
 			continue;
 		}
 		const bool position_can_contribute = record.affect_position && !Math::is_zero_approx(record.strength);
-		const bool opacity_can_contribute = record.affect_opacity && !Math::is_zero_approx(record.opacity_strength);
+		// target_opacity==1.0 is the neutral "fully opaque" target; combined
+		// with non-zero opacity_strength it still produces no visible change
+		// for already-opaque splats, so treat it as inert here. Matches the
+		// diagnostic gate in `get_scene_effector_debug_state_for_instance`.
+		const bool opacity_can_contribute = record.affect_opacity &&
+				!Math::is_zero_approx(record.opacity_strength) &&
+				!Math::is_equal_approx(record.target_opacity, 1.0f);
 		if (!position_can_contribute && !opacity_can_contribute) {
 			continue;
 		}

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -602,6 +602,7 @@ void GaussianSplatSceneDirector::_build_sorted_sphere_effector_payload(const Sha
 		candidate.selection.falloff = record.falloff;
 		candidate.selection.frequency = record.frequency;
 		candidate.selection.opacity_strength = record.opacity_strength;
+		candidate.selection.target_opacity = record.target_opacity;
 		candidate.selection.layer_mask = record.layer_mask;
 		candidate.selection.scope_mode = record.scope_mode;
 		candidate.selection.scope_root_id = record.scope_root_id;
@@ -2010,17 +2011,17 @@ uint32_t GaussianSplatSceneDirector::get_instance_count_for_renderer(const Gauss
 
 void GaussianSplatSceneDirector::register_sphere_effector(ObjectID p_effector_id, const Transform3D &p_transform,
 		float p_radius, float p_strength, float p_falloff, float p_frequency, bool p_enabled,
-		bool p_affect_position, bool p_affect_opacity, float p_opacity_strength, uint32_t p_layer_mask,
-		uint32_t p_scope_mode, ObjectID p_scope_root_id, int32_t p_priority) {
+		bool p_affect_position, bool p_affect_opacity, float p_opacity_strength, float p_target_opacity,
+		uint32_t p_layer_mask, uint32_t p_scope_mode, ObjectID p_scope_root_id, int32_t p_priority) {
 	update_sphere_effector(p_effector_id, p_transform, p_radius, p_strength, p_falloff, p_frequency,
-			p_enabled, p_affect_position, p_affect_opacity, p_opacity_strength, p_layer_mask,
-			p_scope_mode, p_scope_root_id, p_priority);
+			p_enabled, p_affect_position, p_affect_opacity, p_opacity_strength, p_target_opacity,
+			p_layer_mask, p_scope_mode, p_scope_root_id, p_priority);
 }
 
 void GaussianSplatSceneDirector::update_sphere_effector(ObjectID p_effector_id, const Transform3D &p_transform,
 		float p_radius, float p_strength, float p_falloff, float p_frequency, bool p_enabled,
-		bool p_affect_position, bool p_affect_opacity, float p_opacity_strength, uint32_t p_layer_mask,
-		uint32_t p_scope_mode, ObjectID p_scope_root_id, int32_t p_priority) {
+		bool p_affect_position, bool p_affect_opacity, float p_opacity_strength, float p_target_opacity,
+		uint32_t p_layer_mask, uint32_t p_scope_mode, ObjectID p_scope_root_id, int32_t p_priority) {
 	if (p_effector_id == ObjectID()) {
 		return;
 	}
@@ -2070,6 +2071,12 @@ void GaussianSplatSceneDirector::update_sphere_effector(ObjectID p_effector_id, 
 	if (!Math::is_equal_approx(opacity_strength, p_opacity_strength) && Math::is_finite(p_opacity_strength)) {
 		WARN_PRINT(vformat("[GaussianSplatSceneDirector] opacity_strength for %s was clamped to [0, 1].", effector_context));
 	}
+	const float target_opacity = CLAMP(
+			_sanitize_finite_float(p_target_opacity, 0.0f, effector_context, "target_opacity"),
+			0.0f, 1.0f);
+	if (!Math::is_equal_approx(target_opacity, p_target_opacity) && Math::is_finite(p_target_opacity)) {
+		WARN_PRINT(vformat("[GaussianSplatSceneDirector] target_opacity for %s was clamped to [0, 1].", effector_context));
+	}
 	uint32_t scope_mode = p_scope_mode;
 	if (scope_mode > SPHERE_EFFECTOR_SCOPE_EXPLICIT_ROOT) {
 		WARN_PRINT(vformat("[GaussianSplatSceneDirector] Invalid scope_mode %u for %s; falling back to SUBTREE.",
@@ -2107,6 +2114,10 @@ void GaussianSplatSceneDirector::update_sphere_effector(ObjectID p_effector_id, 
 		}
 		if (!Math::is_equal_approx(record.opacity_strength, opacity_strength)) {
 			record.opacity_strength = opacity_strength;
+			dirty = true;
+		}
+		if (!Math::is_equal_approx(record.target_opacity, target_opacity)) {
+			record.target_opacity = target_opacity;
 			dirty = true;
 		}
 		if (record.enabled != p_enabled) {
@@ -2151,6 +2162,7 @@ void GaussianSplatSceneDirector::update_sphere_effector(ObjectID p_effector_id, 
 	record.falloff = falloff;
 	record.frequency = frequency;
 	record.opacity_strength = opacity_strength;
+	record.target_opacity = target_opacity;
 	record.layer_mask = p_layer_mask;
 	record.scope_mode = scope_mode;
 	record.scope_root_id = p_scope_root_id;
@@ -2348,6 +2360,7 @@ bool GaussianSplatSceneDirector::get_primary_sphere_effector_for_instance(Object
 		candidate.selection.falloff = record.falloff;
 		candidate.selection.frequency = record.frequency;
 		candidate.selection.opacity_strength = record.opacity_strength;
+		candidate.selection.target_opacity = record.target_opacity;
 		candidate.selection.layer_mask = record.layer_mask;
 		candidate.selection.scope_mode = record.scope_mode;
 		candidate.selection.scope_root_id = effective_scope_root_id;
@@ -2383,6 +2396,93 @@ bool GaussianSplatSceneDirector::get_primary_sphere_effector_for_instance(Object
 		scene_effector_multi_match_warned_nodes.erase(p_node_id);
 	}
 	return true;
+}
+
+bool GaussianSplatSceneDirector::get_scene_effector_match_summary_for_instance(ObjectID p_node_id,
+		uint32_t *r_match_count, bool *r_position_active, bool *r_opacity_active) const {
+	if (r_match_count) {
+		*r_match_count = 0u;
+	}
+	if (r_position_active) {
+		*r_position_active = false;
+	}
+	if (r_opacity_active) {
+		*r_opacity_active = false;
+	}
+
+	MutexLock lock(world_mutex);
+	// Locate the world using the cached instance record — the render thread
+	// keeps this fresh via update_instance_scene_effector_filter(), so no
+	// scene-tree walk is needed here. Main-thread callers from node property
+	// queries are the only consumers.
+	const SharedWorld *world = nullptr;
+	for (const KeyValue<RID, SharedWorld> &E : worlds) {
+		if (E.value.instance_lookup.has(p_node_id)) {
+			world = &E.value;
+			break;
+		}
+	}
+	if (!world || world->sphere_effectors.is_empty()) {
+		return false;
+	}
+
+	const uint32_t *index_ptr = world->instance_lookup.getptr(p_node_id);
+	if (!index_ptr || *index_ptr >= world->instances.size()) {
+		return false;
+	}
+	const InstanceRecord &record = world->instances[*index_ptr];
+	if (!record.scene_effectors_enabled || record.scene_effector_layer_mask == 0u ||
+			(record.scene_effector_scope_filter_present && !record.scene_effector_scope_filter_valid)) {
+		return false;
+	}
+
+	uint32_t matched_count = 0u;
+	bool any_position = false;
+	bool any_opacity = false;
+	for (const SphereEffectorRecord &effector : world->sphere_effectors) {
+		if (!effector.enabled || (!effector.affect_position && !effector.affect_opacity)) {
+			continue;
+		}
+		if ((effector.layer_mask & record.scene_effector_layer_mask) == 0u) {
+			continue;
+		}
+		if (record.scene_effector_scope_filter_present) {
+			if (effector.scope_root_id == ObjectID() || effector.scope_root_id != record.scene_effector_scope_root_id) {
+				continue;
+			}
+		} else if (effector.scope_mode != SPHERE_EFFECTOR_SCOPE_WORLD) {
+			// Implicit subtree containment requires a tree walk — skipped here
+			// to keep this method safe to call under the director mutex.
+			continue;
+		}
+
+		matched_count++;
+		// An effector that reports a channel is "active" only when it can
+		// actually contribute a deformation. Codex called out the inert cases:
+		// strength == 0 (no position amplitude), opacity_strength == 0 (no
+		// opacity weight), or target_opacity == 1.0 (pushing fully opaque —
+		// the neutral target for already-opaque splats). Filter those out so
+		// the node's `is_scene_effector_*_active()` diagnostics match the
+		// API contract of "currently contributes".
+		if (effector.affect_position && !Math::is_zero_approx(effector.strength)) {
+			any_position = true;
+		}
+		if (effector.affect_opacity && !Math::is_zero_approx(effector.opacity_strength) &&
+				!Math::is_equal_approx(effector.target_opacity, 1.0f)) {
+			any_opacity = true;
+		}
+	}
+
+	if (r_match_count) {
+		*r_match_count = matched_count;
+	}
+	if (r_position_active) {
+		*r_position_active = any_position;
+	}
+	if (r_opacity_active) {
+		*r_opacity_active = any_opacity;
+	}
+	return matched_count > 0u;
 }
 
 uint32_t GaussianSplatSceneDirector::get_sphere_effector_count_for_renderer(const GaussianSplatRenderer *p_renderer) const {

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -2510,10 +2510,15 @@ Dictionary GaussianSplatSceneDirector::get_scene_effector_debug_state_for_instan
 		}
 
 		matched_count++;
-		if (effector.affect_position && record.effect_position_scale > 0.0f && !Math::is_zero_approx(effector.strength)) {
+		// Radius <= 0 is inert on the GPU (see gs_apply_sphere_effectors'
+		// `effector_sphere.w <= 1e-6` early-out). Exclude from active flags so
+		// the diagnostic matches the shader.
+		const bool effector_radius_nonzero = effector.radius > 1e-6f;
+		if (effector_radius_nonzero && effector.affect_position && record.effect_position_scale > 0.0f &&
+				!Math::is_zero_approx(effector.strength)) {
 			matched_position_active = true;
 		}
-		if (effector.affect_opacity && record.effect_opacity_scale > 0.0f && record.opacity > 0.0f &&
+		if (effector_radius_nonzero && effector.affect_opacity && record.effect_opacity_scale > 0.0f && record.opacity > 0.0f &&
 				!Math::is_zero_approx(effector.opacity_strength) &&
 				!Math::is_equal_approx(effector.target_opacity, 1.0f)) {
 			matched_opacity_active = true;
@@ -2547,10 +2552,17 @@ Dictionary GaussianSplatSceneDirector::get_scene_effector_debug_state_for_instan
 		}
 		selected_effector_names.push_back(effector_name);
 
-		if (payload[i].affect_position && record.effect_position_scale > 0.0f && !Math::is_zero_approx(payload[i].strength)) {
+		// Mirror the shader's early-out: `gs_apply_sphere_effectors` skips any
+		// slot with `effector_sphere.w <= 1e-6` (i.e. radius <= 0), so a
+		// matched/bound zero-radius effector contributes nothing. Treat it
+		// as inactive here so `is_scene_effector_*_active()` doesn't over-
+		// report "active" relative to what the GPU actually does.
+		const bool radius_nonzero = payload[i].radius > 1e-6f;
+		if (radius_nonzero && payload[i].affect_position && record.effect_position_scale > 0.0f &&
+				!Math::is_zero_approx(payload[i].strength)) {
 			bound_position_active = true;
 		}
-		if (payload[i].affect_opacity && record.effect_opacity_scale > 0.0f && record.opacity > 0.0f &&
+		if (radius_nonzero && payload[i].affect_opacity && record.effect_opacity_scale > 0.0f && record.opacity > 0.0f &&
 				!Math::is_zero_approx(payload[i].opacity_strength) &&
 				!Math::is_equal_approx(payload[i].target_opacity, 1.0f)) {
 			bound_opacity_active = true;

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -2310,9 +2310,13 @@ bool GaussianSplatSceneDirector::get_primary_sphere_effector_for_instance(Object
 		}
 		// Mirror the inert-channel gate from `_build_sorted_sphere_effector_payload()`
 		// so the compatibility API doesn't report a primary that the render path
-		// would filter out.
+		// would filter out. Includes the `target_opacity != 1.0` check: neutral
+		// target on an opacity-only effector contributes nothing to already-opaque
+		// splats, and the payload builder drops those entries.
 		const bool position_can_contribute = record.affect_position && !Math::is_zero_approx(record.strength);
-		const bool opacity_can_contribute = record.affect_opacity && !Math::is_zero_approx(record.opacity_strength);
+		const bool opacity_can_contribute = record.affect_opacity &&
+				!Math::is_zero_approx(record.opacity_strength) &&
+				!Math::is_equal_approx(record.target_opacity, 1.0f);
 		if (!position_can_contribute && !opacity_can_contribute) {
 			continue;
 		}

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -2485,6 +2485,156 @@ bool GaussianSplatSceneDirector::get_scene_effector_match_summary_for_instance(O
 	return matched_count > 0u;
 }
 
+Dictionary GaussianSplatSceneDirector::get_scene_effector_debug_state_for_instance(ObjectID p_node_id) const {
+	Dictionary state;
+	state["matched_count"] = 0;
+	state["bound_count"] = 0;
+	state["truncated"] = false;
+	state["position_active"] = false;
+	state["opacity_active"] = false;
+	state["selected_effector_ids"] = Array();
+	state["selected_effector_names"] = PackedStringArray();
+	state["effective_layer_mask"] = int64_t(0);
+	state["scope_filter_present"] = false;
+	state["scope_filter_valid"] = true;
+	state["effective_scope_root_id"] = int64_t(0);
+	state["matched_position_active"] = false;
+	state["matched_opacity_active"] = false;
+
+	MutexLock lock(world_mutex);
+	const SharedWorld *world = nullptr;
+	for (const KeyValue<RID, SharedWorld> &E : worlds) {
+		if (E.value.instance_lookup.has(p_node_id)) {
+			world = &E.value;
+			break;
+		}
+	}
+	if (!world) {
+		return state;
+	}
+
+	const uint32_t *index_ptr = world->instance_lookup.getptr(p_node_id);
+	if (!index_ptr || *index_ptr >= world->instances.size()) {
+		return state;
+	}
+	const InstanceRecord &record = world->instances[*index_ptr];
+	state["effective_layer_mask"] = int64_t(record.scene_effector_layer_mask);
+	state["scope_filter_present"] = record.scene_effector_scope_filter_present;
+	state["scope_filter_valid"] = record.scene_effector_scope_filter_valid;
+	state["effective_scope_root_id"] = int64_t((uint64_t)record.scene_effector_scope_root_id);
+
+	if (!record.scene_effectors_enabled || record.scene_effector_layer_mask == 0u ||
+			(record.scene_effector_scope_filter_present && !record.scene_effector_scope_filter_valid)) {
+		return state;
+	}
+
+	// Helper: effector's scope is currently valid iff its cached scope_root_id
+	// still resolves to a live Node. ObjectDB lookups are thread-safe and catch
+	// the case where a scope-root node was deleted after the effector synced.
+	auto effector_scope_alive = [](const SphereEffectorRecord &eff) -> bool {
+		if (eff.scope_mode == SPHERE_EFFECTOR_SCOPE_WORLD) {
+			return true;
+		}
+		if (eff.scope_root_id == ObjectID()) {
+			return false;
+		}
+		return Object::cast_to<Node>(ObjectDB::get_instance(eff.scope_root_id)) != nullptr;
+	};
+
+	uint32_t matched_count = 0u;
+	bool matched_position_active = false;
+	bool matched_opacity_active = false;
+	for (const SphereEffectorRecord &effector : world->sphere_effectors) {
+		if (!effector.enabled || (!effector.affect_position && !effector.affect_opacity)) {
+			continue;
+		}
+		if ((effector.layer_mask & record.scene_effector_layer_mask) == 0u) {
+			continue;
+		}
+		if (effector.scope_mode != SPHERE_EFFECTOR_SCOPE_WORLD && !effector_scope_alive(effector)) {
+			continue;
+		}
+		if (record.scene_effector_scope_filter_present) {
+			if (effector.scope_root_id == ObjectID() ||
+					effector.scope_root_id != record.scene_effector_scope_root_id) {
+				continue;
+			}
+		} else if (effector.scope_mode != SPHERE_EFFECTOR_SCOPE_WORLD) {
+			if (effector.scope_root_id == ObjectID()) {
+				continue;
+			}
+			bool in_scope = false;
+			for (const ObjectID &ancestor_id : record.scene_tree_ancestor_ids) {
+				if (ancestor_id == effector.scope_root_id) {
+					in_scope = true;
+					break;
+				}
+			}
+			if (!in_scope) {
+				continue;
+			}
+		}
+
+		matched_count++;
+		if (effector.affect_position && record.effect_position_scale > 0.0f && !Math::is_zero_approx(effector.strength)) {
+			matched_position_active = true;
+		}
+		if (effector.affect_opacity && record.effect_opacity_scale > 0.0f && record.opacity > 0.0f &&
+				!Math::is_zero_approx(effector.opacity_strength) &&
+				!Math::is_equal_approx(effector.target_opacity, 1.0f)) {
+			matched_opacity_active = true;
+		}
+	}
+
+	// Bind-side stats: how many matched effectors actually survived the
+	// renderer's payload build + mask packing (limited by GS_MAX_SPHERE_EFFECTORS,
+	// invalid scope roots, etc). `_build_sorted_sphere_effector_payload` does the
+	// same scope_root liveness check via ObjectDB so the counts stay consistent.
+	LocalVector<SphereEffectorSelection> payload;
+	_build_sorted_sphere_effector_payload(*world, payload);
+	const uint32_t mask = _build_scene_effector_mask_for_record(record, payload);
+	uint32_t bound_count = 0u;
+	Array selected_effector_ids;
+	PackedStringArray selected_effector_names;
+	bool bound_position_active = false;
+	bool bound_opacity_active = false;
+	for (uint32_t i = 0; i < payload.size(); i++) {
+		if ((mask & (1u << i)) == 0u) {
+			continue;
+		}
+		bound_count++;
+		selected_effector_ids.push_back(int64_t((uint64_t)payload[i].effector_id));
+
+		String effector_name = String::num_uint64((uint64_t)payload[i].effector_id);
+		if (Object *effector_object = ObjectDB::get_instance(payload[i].effector_id)) {
+			if (Node *effector_node = Object::cast_to<Node>(effector_object)) {
+				effector_name = String(effector_node->get_name());
+			}
+		}
+		selected_effector_names.push_back(effector_name);
+
+		if (payload[i].affect_position && record.effect_position_scale > 0.0f && !Math::is_zero_approx(payload[i].strength)) {
+			bound_position_active = true;
+		}
+		if (payload[i].affect_opacity && record.effect_opacity_scale > 0.0f && record.opacity > 0.0f &&
+				!Math::is_zero_approx(payload[i].opacity_strength) &&
+				!Math::is_equal_approx(payload[i].target_opacity, 1.0f)) {
+			bound_opacity_active = true;
+		}
+	}
+
+	state["matched_count"] = int64_t(matched_count);
+	state["bound_count"] = int64_t(bound_count);
+	state["truncated"] = matched_count > bound_count;
+	state["position_active"] = bound_position_active;
+	state["opacity_active"] = bound_opacity_active;
+	state["selected_effector_ids"] = selected_effector_ids;
+	state["selected_effector_names"] = selected_effector_names;
+	state["matched_position_active"] = matched_position_active;
+	state["matched_opacity_active"] = matched_opacity_active;
+	return state;
+}
+
 uint32_t GaussianSplatSceneDirector::get_sphere_effector_count_for_renderer(const GaussianSplatRenderer *p_renderer) const {
 	MutexLock lock(world_mutex);
 	const SharedWorld *world = _find_world_for_renderer(p_renderer);

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
@@ -206,6 +206,7 @@ public:
             LocalVector<SphereEffectorSelection> &out,
             uint32_t *r_total_scene_effectors = nullptr) const;
     bool get_primary_sphere_effector_for_instance(ObjectID p_node_id, SphereEffectorSelection *r_selection) const;
+    Dictionary get_scene_effector_debug_state_for_instance(ObjectID p_node_id) const;
     bool get_scene_effector_match_summary_for_instance(ObjectID p_node_id, uint32_t *r_match_count = nullptr,
             bool *r_position_active = nullptr, bool *r_opacity_active = nullptr) const;
     uint32_t get_sphere_effector_count_for_renderer(const GaussianSplatRenderer *p_renderer) const;
@@ -280,10 +281,6 @@ private:
         bool scene_effector_scope_filter_present = false;
         bool scene_effector_scope_filter_valid = true;
         ObjectID scene_effector_scope_root_id;
-        // Ancestor ObjectIDs (self + parents up to the scene root), cached at
-        // registration/parent-change on the main thread. The render thread
-        // reads this set to evaluate subtree containment for SCOPE_SUBTREE /
-        // SCOPE_EXPLICIT_ROOT effectors without ever touching the live tree.
         LocalVector<ObjectID> scene_tree_ancestor_ids;
 	};
 
@@ -301,6 +298,7 @@ private:
         ObjectID scope_root_id;
         int32_t priority = 0;
         uint64_t registration_serial = 0;
+        uint32_t scope_specificity = 0u;
         // Cached liveness of scope_root_id. Starts true on register, flipped
         // false (and triggers a generation bump) by the payload builder when
         // `ObjectDB::get_instance(scope_root_id)` no longer resolves.
@@ -364,12 +362,9 @@ private:
             LocalVector<SphereEffectorSelection> &r_out);
 
     // Render-thread-safe mask builder: consumes the scene-effector filter state
-    // cached on the InstanceRecord instead of reading it back from the live
-    // Node3D. The main-thread node path keeps the cache fresh via
-    // update_instance_scene_effector_filter(). This path skips the implicit-
-    // subtree ancestor check because `is_ancestor_of` is a scene-tree walk and
-    // is not safe to call from the render thread; use SCOPE_EXPLICIT_ROOT +
-    // `rendering/scene_effector_scope_root` on the node to opt into scoping.
+    // and cached ancestor chain stored on the InstanceRecord instead of reading
+    // anything back from the live Node3D. The main-thread node path keeps this
+    // cache fresh via update_instance_scene_effector_filter().
     static uint32_t _build_scene_effector_mask_for_record(const InstanceRecord &p_record,
             const LocalVector<SphereEffectorSelection> &p_payload);
 

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
@@ -95,6 +95,7 @@ public:
         float falloff = 2.0f;
         float frequency = 2.0f;
         float opacity_strength = 1.0f;
+        float target_opacity = 0.0f;
         uint32_t layer_mask = 1u;
         uint32_t scope_mode = SPHERE_EFFECTOR_SCOPE_SUBTREE;
         ObjectID scope_root_id;
@@ -186,13 +187,13 @@ public:
     void register_sphere_effector(ObjectID p_effector_id, const Transform3D &p_transform,
             float p_radius, float p_strength, float p_falloff, float p_frequency,
             bool p_enabled = true, bool p_affect_position = true, bool p_affect_opacity = false,
-            float p_opacity_strength = 1.0f, uint32_t p_layer_mask = 1u,
+            float p_opacity_strength = 1.0f, float p_target_opacity = 0.0f, uint32_t p_layer_mask = 1u,
             uint32_t p_scope_mode = SPHERE_EFFECTOR_SCOPE_SUBTREE,
             ObjectID p_scope_root_id = ObjectID(), int32_t p_priority = 0);
     void update_sphere_effector(ObjectID p_effector_id, const Transform3D &p_transform,
             float p_radius, float p_strength, float p_falloff, float p_frequency,
             bool p_enabled = true, bool p_affect_position = true, bool p_affect_opacity = false,
-            float p_opacity_strength = 1.0f, uint32_t p_layer_mask = 1u,
+            float p_opacity_strength = 1.0f, float p_target_opacity = 0.0f, uint32_t p_layer_mask = 1u,
             uint32_t p_scope_mode = SPHERE_EFFECTOR_SCOPE_SUBTREE,
             ObjectID p_scope_root_id = ObjectID(), int32_t p_priority = 0);
     void unregister_sphere_effector(ObjectID p_effector_id);
@@ -205,6 +206,8 @@ public:
             LocalVector<SphereEffectorSelection> &out,
             uint32_t *r_total_scene_effectors = nullptr) const;
     bool get_primary_sphere_effector_for_instance(ObjectID p_node_id, SphereEffectorSelection *r_selection) const;
+    bool get_scene_effector_match_summary_for_instance(ObjectID p_node_id, uint32_t *r_match_count = nullptr,
+            bool *r_position_active = nullptr, bool *r_opacity_active = nullptr) const;
     uint32_t get_sphere_effector_count_for_renderer(const GaussianSplatRenderer *p_renderer) const;
     uint64_t get_sphere_effector_generation_for_renderer(const GaussianSplatRenderer *p_renderer) const;
     void register_instance_submission(ObjectID p_node_id, const Ref<GaussianSplatAsset> &p_asset,
@@ -292,6 +295,7 @@ private:
         float falloff = 2.0f;
         float frequency = 2.0f;
         float opacity_strength = 1.0f;
+        float target_opacity = 0.0f;
         uint32_t layer_mask = 1u;
         uint32_t scope_mode = SPHERE_EFFECTOR_SCOPE_SUBTREE;
         ObjectID scope_root_id;

--- a/modules/gaussian_splatting/interfaces/gpu_sorting_pipeline.cpp
+++ b/modules/gaussian_splatting/interfaces/gpu_sorting_pipeline.cpp
@@ -214,7 +214,7 @@ static bool _build_effector_payload_from_scene_bindings(const GaussianSplatRende
         r_opacity_configs[i][0] = selection.affect_position ? 1.0f : 0.0f;
         r_opacity_configs[i][1] = selection.affect_opacity ? 1.0f : 0.0f;
         r_opacity_configs[i][2] = CLAMP(selection.opacity_strength, 0.0f, 1.0f);
-        r_opacity_configs[i][3] = 0.0f;
+        r_opacity_configs[i][3] = CLAMP(selection.target_opacity, 0.0f, 1.0f);
     }
 
     r_meta[0] = float(payload.size());

--- a/modules/gaussian_splatting/nodes/README.md
+++ b/modules/gaussian_splatting/nodes/README.md
@@ -159,13 +159,14 @@ Notes:
 - `SphereEffector3D` is the scene-authored workflow for localized deformation and dissolve effects.
 - `SphereEffector3D` defaults to `Parent Subtree` scope, so an effector affects sibling/descendant splat nodes under the same parent without touching unrelated parts of the world.
 - `rendering/scene_effectors_enabled`, `rendering/scene_effector_layer_mask`, and `rendering/scene_effector_scope_root` let each `GaussianSplatNode3D` opt out, filter, or narrow which scene effectors it follows.
-- Runtime support is bounded to `4` scene effectors per renderer pass. If more effectors match, the renderer binds the highest-priority deterministic four.
-- ProjectSettings remain as a backward-compatible fallback when no scene-authored sphere effectors are active.
+- Runtime support is bounded to `4` scene-authored effectors per renderer pass. If more effectors match one node, the renderer binds the highest-priority deterministic four and the rest remain matched but unbound.
+- ProjectSettings remain as a backward-compatible fallback when no scene-authored sphere effectors are active. That fallback still uses the legacy single-global effector path, so `rendering/gaussian_splatting/effects/max_effectors` is clamped to `0..1`.
 - The practical runtime control surface is:
   - use `SphereEffector3D` to author center, radius, strength, falloff, frequency, scope, and opacity modulation in the scene
   - use `rendering/effect_position_scale` and `rendering/effect_opacity_scale` per node to blend each node's response
   - use `rendering/wind_override_enabled` plus the wind properties for node-local wind-only or mixed wind-plus-sphere setups
 - For dissolve-style effects, enable `SphereEffector3D.affect_opacity`, keep `rendering/effect_position_scale = 0.0`, and tune each node with `rendering/effect_opacity_scale`.
+- `get_scene_effector_debug_state()` and `get_statistics()` expose both logical matches and renderer-bound matches, including truncation and the selected effector names.
 - The example scenes `tests/examples/godot/test_project/scenes/wind_test.tscn` and `tests/examples/godot/test_project/scenes/sphere_effector_test.tscn` demonstrate the supported gameplay modes.
 
 See also: `docs/api/sphere_effector_workflow.md`.

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -199,6 +199,9 @@ void GaussianSplatNode3D::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_scene_effector_scope_root"), &GaussianSplatNode3D::get_scene_effector_scope_root);
     ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "rendering/scene_effector_scope_root", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Node"),
             "set_scene_effector_scope_root", "get_scene_effector_scope_root");
+    ClassDB::bind_method(D_METHOD("get_last_matched_scene_effector_count"), &GaussianSplatNode3D::get_last_matched_scene_effector_count);
+    ClassDB::bind_method(D_METHOD("is_scene_effector_position_active"), &GaussianSplatNode3D::is_scene_effector_position_active);
+    ClassDB::bind_method(D_METHOD("is_scene_effector_opacity_active"), &GaussianSplatNode3D::is_scene_effector_opacity_active);
 
     ClassDB::bind_method(D_METHOD("set_wind_override_enabled", "enabled"), &GaussianSplatNode3D::set_wind_override_enabled);
     ClassDB::bind_method(D_METHOD("is_wind_override_enabled"), &GaussianSplatNode3D::is_wind_override_enabled);
@@ -1142,6 +1145,51 @@ void GaussianSplatNode3D::set_scene_effector_scope_root(const NodePath &p_scope_
     _update_instance_params_in_director();
 }
 
+uint32_t GaussianSplatNode3D::get_last_matched_scene_effector_count() const {
+    if (!scene_effectors_enabled || !is_inside_tree() || !is_inside_world()) {
+        return 0u;
+    }
+
+    const GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
+    if (!director) {
+        return 0u;
+    }
+
+    uint32_t matched_count = 0u;
+    director->get_scene_effector_match_summary_for_instance(get_instance_id(), &matched_count, nullptr, nullptr);
+    return matched_count;
+}
+
+bool GaussianSplatNode3D::is_scene_effector_position_active() const {
+    if (!scene_effectors_enabled || effect_position_scale <= 0.0f || !is_inside_tree() || !is_inside_world()) {
+        return false;
+    }
+
+    const GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
+    if (!director) {
+        return false;
+    }
+
+    bool position_active = false;
+    director->get_scene_effector_match_summary_for_instance(get_instance_id(), nullptr, &position_active, nullptr);
+    return position_active;
+}
+
+bool GaussianSplatNode3D::is_scene_effector_opacity_active() const {
+    if (!scene_effectors_enabled || effect_opacity_scale <= 0.0f || opacity <= 0.0f || !is_inside_tree() || !is_inside_world()) {
+        return false;
+    }
+
+    const GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
+    if (!director) {
+        return false;
+    }
+
+    bool opacity_active = false;
+    director->get_scene_effector_match_summary_for_instance(get_instance_id(), nullptr, nullptr, &opacity_active);
+    return opacity_active;
+}
+
 void GaussianSplatNode3D::set_wind_override_enabled(bool p_enabled) {
     if (wind_override_enabled == p_enabled) {
         return;
@@ -1284,6 +1332,9 @@ Dictionary GaussianSplatNode3D::get_statistics() const {
     // reports aggregate world metrics.
     stats["visible_splats"] = visible_splat_count;
     stats["total_splats"] = total_splat_count;
+    stats["matched_scene_effectors"] = get_last_matched_scene_effector_count();
+    stats["scene_effector_position_active"] = is_scene_effector_position_active();
+    stats["scene_effector_opacity_active"] = is_scene_effector_opacity_active();
     stats["effective_config_snapshot"] = composed_effective_config;
 
     return stats;
@@ -1595,8 +1646,14 @@ PackedStringArray GaussianSplatNode3D::get_configuration_warnings() const {
     }
 
     if (scene_effectors_enabled) {
+        if (effect_position_scale <= 0.0f && effect_opacity_scale <= 0.0f) {
+            warnings.push_back("Scene effectors are enabled, but both effect response scales are 0. This node will ignore all scene-driven sphere effectors.");
+        }
         if (scene_effector_layer_mask == 0u) {
             warnings.push_back("Scene effectors are enabled, but scene_effector_layer_mask is 0. No scene-driven sphere effectors will match this node.");
+        }
+        if (effect_opacity_scale > 0.0f && opacity <= 0.0f) {
+            warnings.push_back("Opacity modulation is enabled, but rendering/opacity is 0. Scene-driven opacity effects will remain fully invisible.");
         }
         if (!scene_effector_scope_root.is_empty()) {
             if (!is_inside_tree()) {

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -56,10 +56,6 @@ static bool _is_renderer_shared_with_other_content(const Ref<GaussianSplatRender
     return false;
 }
 
-// Collect the instance node's ancestor ObjectID chain (self + every parent up
-// to the scene root). Cached on InstanceRecord so the render-thread mask
-// builder can evaluate subtree containment without a live `is_ancestor_of`
-// walk.
 static void _collect_scene_tree_ancestor_ids(const Node *p_node, LocalVector<ObjectID> &r_ids) {
     r_ids.clear();
     const Node *cursor = p_node;
@@ -200,6 +196,7 @@ void GaussianSplatNode3D::_bind_methods() {
     ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "rendering/scene_effector_scope_root", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Node"),
             "set_scene_effector_scope_root", "get_scene_effector_scope_root");
     ClassDB::bind_method(D_METHOD("get_last_matched_scene_effector_count"), &GaussianSplatNode3D::get_last_matched_scene_effector_count);
+    ClassDB::bind_method(D_METHOD("get_scene_effector_debug_state"), &GaussianSplatNode3D::get_scene_effector_debug_state);
     ClassDB::bind_method(D_METHOD("is_scene_effector_position_active"), &GaussianSplatNode3D::is_scene_effector_position_active);
     ClassDB::bind_method(D_METHOD("is_scene_effector_opacity_active"), &GaussianSplatNode3D::is_scene_effector_opacity_active);
 
@@ -598,16 +595,42 @@ bool GaussianSplatNode3D::_get(const StringName &p_name, Variant &r_ret) const {
         r_ret = gpu_memory_mb;
         return true;
     }
+    const Dictionary scene_effector_debug_state = get_scene_effector_debug_state();
+    if (p_name == StringName("stats/matched_scene_effectors")) {
+        r_ret = int64_t(scene_effector_debug_state.get(StringName("matched_count"), 0));
+        return true;
+    }
+    if (p_name == StringName("stats/bound_scene_effectors")) {
+        r_ret = int64_t(scene_effector_debug_state.get(StringName("bound_count"), 0));
+        return true;
+    }
+    if (p_name == StringName("stats/scene_effector_truncated")) {
+        r_ret = bool(scene_effector_debug_state.get(StringName("truncated"), false));
+        return true;
+    }
+    if (p_name == StringName("stats/scene_effector_position_active")) {
+        r_ret = bool(scene_effector_debug_state.get(StringName("position_active"), false));
+        return true;
+    }
+    if (p_name == StringName("stats/scene_effector_opacity_active")) {
+        r_ret = bool(scene_effector_debug_state.get(StringName("opacity_active"), false));
+        return true;
+    }
     return false;
 }
 
 void GaussianSplatNode3D::_get_property_list(List<PropertyInfo> *p_list) const {
     // Add performance statistics as read-only properties
-    if (show_statistics && splat_asset.is_valid()) {
+    if (show_statistics) {
         p_list->push_back(PropertyInfo(Variant::INT, "stats/visible_splats", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY));
         p_list->push_back(PropertyInfo(Variant::INT, "stats/total_splats", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY));
         p_list->push_back(PropertyInfo(Variant::FLOAT, "stats/update_time_ms", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY));
         p_list->push_back(PropertyInfo(Variant::FLOAT, "stats/gpu_memory_mb", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY));
+        p_list->push_back(PropertyInfo(Variant::INT, "stats/matched_scene_effectors", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY));
+        p_list->push_back(PropertyInfo(Variant::INT, "stats/bound_scene_effectors", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY));
+        p_list->push_back(PropertyInfo(Variant::BOOL, "stats/scene_effector_truncated", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY));
+        p_list->push_back(PropertyInfo(Variant::BOOL, "stats/scene_effector_position_active", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY));
+        p_list->push_back(PropertyInfo(Variant::BOOL, "stats/scene_effector_opacity_active", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY));
     }
 }
 
@@ -1146,48 +1169,44 @@ void GaussianSplatNode3D::set_scene_effector_scope_root(const NodePath &p_scope_
 }
 
 uint32_t GaussianSplatNode3D::get_last_matched_scene_effector_count() const {
+    const Dictionary debug_state = get_scene_effector_debug_state();
+    return uint32_t(int64_t(debug_state.get(StringName("matched_count"), 0)));
+}
+
+Dictionary GaussianSplatNode3D::get_scene_effector_debug_state() const {
+    Dictionary state;
+    state["matched_count"] = 0;
+    state["bound_count"] = 0;
+    state["truncated"] = false;
+    state["position_active"] = false;
+    state["opacity_active"] = false;
+    state["selected_effector_ids"] = Array();
+    state["selected_effector_names"] = PackedStringArray();
+    state["effective_layer_mask"] = int64_t(scene_effector_layer_mask);
+    state["scope_filter_present"] = !scene_effector_scope_root.is_empty();
+    state["scope_filter_valid"] = true;
+    state["effective_scope_root_id"] = int64_t(0);
+
     if (!scene_effectors_enabled || !is_inside_tree() || !is_inside_world()) {
-        return 0u;
+        return state;
     }
 
     const GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
     if (!director) {
-        return 0u;
+        return state;
     }
 
-    uint32_t matched_count = 0u;
-    director->get_scene_effector_match_summary_for_instance(get_instance_id(), &matched_count, nullptr, nullptr);
-    return matched_count;
+    return director->get_scene_effector_debug_state_for_instance(get_instance_id());
 }
 
 bool GaussianSplatNode3D::is_scene_effector_position_active() const {
-    if (!scene_effectors_enabled || effect_position_scale <= 0.0f || !is_inside_tree() || !is_inside_world()) {
-        return false;
-    }
-
-    const GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
-    if (!director) {
-        return false;
-    }
-
-    bool position_active = false;
-    director->get_scene_effector_match_summary_for_instance(get_instance_id(), nullptr, &position_active, nullptr);
-    return position_active;
+    const Dictionary debug_state = get_scene_effector_debug_state();
+    return bool(debug_state.get(StringName("position_active"), false));
 }
 
 bool GaussianSplatNode3D::is_scene_effector_opacity_active() const {
-    if (!scene_effectors_enabled || effect_opacity_scale <= 0.0f || opacity <= 0.0f || !is_inside_tree() || !is_inside_world()) {
-        return false;
-    }
-
-    const GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
-    if (!director) {
-        return false;
-    }
-
-    bool opacity_active = false;
-    director->get_scene_effector_match_summary_for_instance(get_instance_id(), nullptr, nullptr, &opacity_active);
-    return opacity_active;
+    const Dictionary debug_state = get_scene_effector_debug_state();
+    return bool(debug_state.get(StringName("opacity_active"), false));
 }
 
 void GaussianSplatNode3D::set_wind_override_enabled(bool p_enabled) {
@@ -1332,9 +1351,14 @@ Dictionary GaussianSplatNode3D::get_statistics() const {
     // reports aggregate world metrics.
     stats["visible_splats"] = visible_splat_count;
     stats["total_splats"] = total_splat_count;
-    stats["matched_scene_effectors"] = get_last_matched_scene_effector_count();
-    stats["scene_effector_position_active"] = is_scene_effector_position_active();
-    stats["scene_effector_opacity_active"] = is_scene_effector_opacity_active();
+    const Dictionary scene_effector_debug_state = get_scene_effector_debug_state();
+    stats["matched_scene_effectors"] = scene_effector_debug_state.get(StringName("matched_count"), 0);
+    stats["bound_scene_effectors"] = scene_effector_debug_state.get(StringName("bound_count"), 0);
+    stats["scene_effector_truncated"] = scene_effector_debug_state.get(StringName("truncated"), false);
+    stats["scene_effector_position_active"] = scene_effector_debug_state.get(StringName("position_active"), false);
+    stats["scene_effector_opacity_active"] = scene_effector_debug_state.get(StringName("opacity_active"), false);
+    stats["scene_effector_selected_ids"] = scene_effector_debug_state.get(StringName("selected_effector_ids"), Array());
+    stats["scene_effector_selected_names"] = scene_effector_debug_state.get(StringName("selected_effector_names"), PackedStringArray());
     stats["effective_config_snapshot"] = composed_effective_config;
 
     return stats;

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
@@ -633,6 +633,9 @@ public:
     /** @brief Returns the number of currently matched scene effectors for this node. */
     uint32_t get_last_matched_scene_effector_count() const;
 
+    /** @brief Returns detailed runtime scene-effector matching/debug state for this node. */
+    Dictionary get_scene_effector_debug_state() const;
+
     /** @brief Returns true when at least one matched scene effector currently contributes position deformation. */
     bool is_scene_effector_position_active() const;
 

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
@@ -630,6 +630,15 @@ public:
     void set_scene_effector_scope_root(const NodePath &p_scope_root);
     NodePath get_scene_effector_scope_root() const { return scene_effector_scope_root; }
 
+    /** @brief Returns the number of currently matched scene effectors for this node. */
+    uint32_t get_last_matched_scene_effector_count() const;
+
+    /** @brief Returns true when at least one matched scene effector currently contributes position deformation. */
+    bool is_scene_effector_position_active() const;
+
+    /** @brief Returns true when at least one matched scene effector currently contributes opacity modulation. */
+    bool is_scene_effector_opacity_active() const;
+
     /** @brief Enables per-instance wind overrides for this node. */
     void set_wind_override_enabled(bool p_enabled);
     bool is_wind_override_enabled() const { return wind_override_enabled; }

--- a/modules/gaussian_splatting/nodes/sphere_effector_3d.cpp
+++ b/modules/gaussian_splatting/nodes/sphere_effector_3d.cpp
@@ -52,6 +52,10 @@ void SphereEffector3D::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_opacity_strength"), &SphereEffector3D::get_opacity_strength);
     ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "opacity_strength", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_opacity_strength", "get_opacity_strength");
 
+    ClassDB::bind_method(D_METHOD("set_target_opacity", "target_opacity"), &SphereEffector3D::set_target_opacity);
+    ClassDB::bind_method(D_METHOD("get_target_opacity"), &SphereEffector3D::get_target_opacity);
+    ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "target_opacity", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_target_opacity", "get_target_opacity");
+
     ClassDB::bind_method(D_METHOD("set_layer_mask", "layer_mask"), &SphereEffector3D::set_layer_mask);
     ClassDB::bind_method(D_METHOD("get_layer_mask"), &SphereEffector3D::get_layer_mask);
     ADD_PROPERTY(PropertyInfo(Variant::INT, "layer_mask", PROPERTY_HINT_FLAGS,
@@ -82,7 +86,7 @@ void SphereEffector3D::_bind_methods() {
 }
 
 void SphereEffector3D::_validate_property(PropertyInfo &p_property) const {
-    if (!affect_opacity && p_property.name == "opacity_strength") {
+    if (!affect_opacity && (p_property.name == "opacity_strength" || p_property.name == "target_opacity")) {
         p_property.usage = PROPERTY_USAGE_NO_EDITOR;
     }
     if (scope_mode != SCOPE_EXPLICIT_ROOT && p_property.name == "scope_root") {
@@ -165,6 +169,7 @@ void SphereEffector3D::_sync_with_director() {
             affect_position,
             affect_opacity,
             opacity_strength,
+            target_opacity,
             layer_mask,
             uint32_t(scope_mode),
             scope_root_id,
@@ -265,6 +270,17 @@ void SphereEffector3D::set_opacity_strength(float p_opacity_strength) {
     _sync_with_director();
 }
 
+void SphereEffector3D::set_target_opacity(float p_target_opacity) {
+    const float sanitized = CLAMP(_sanitize_finite_or_default(p_target_opacity, 0.0f, "target_opacity"), 0.0f, 1.0f);
+    if (Math::is_equal_approx(target_opacity, sanitized)) {
+        return;
+    }
+
+    target_opacity = sanitized;
+    update_configuration_warnings();
+    _sync_with_director();
+}
+
 void SphereEffector3D::set_layer_mask(uint32_t p_layer_mask) {
     if (layer_mask == p_layer_mask) {
         return;
@@ -323,6 +339,10 @@ PackedStringArray SphereEffector3D::get_configuration_warnings() const {
 
     if (affect_opacity && opacity_strength <= 0.0f) {
         warnings.push_back("Opacity modulation is enabled but opacity_strength is 0.");
+    }
+
+    if (affect_opacity && Math::is_equal_approx(target_opacity, 1.0f)) {
+        warnings.push_back("Opacity modulation is enabled but target_opacity is 1.0. This effector will not visibly change opacity.");
     }
 
     if (layer_mask == 0u) {

--- a/modules/gaussian_splatting/nodes/sphere_effector_3d.cpp
+++ b/modules/gaussian_splatting/nodes/sphere_effector_3d.cpp
@@ -144,9 +144,6 @@ void SphereEffector3D::_sync_with_director() {
 
     ObjectID scope_root_id;
     if (scope_mode == SCOPE_SUBTREE) {
-        // Implicit subtree scope: the effector affects nodes under its own parent.
-        // Cache the parent's ObjectID so the director's ancestor-based matching
-        // can resolve containment without walking the tree on the render path.
         Node *parent = get_parent();
         if (parent) {
             scope_root_id = parent->get_instance_id();

--- a/modules/gaussian_splatting/nodes/sphere_effector_3d.h
+++ b/modules/gaussian_splatting/nodes/sphere_effector_3d.h
@@ -35,6 +35,7 @@ private:
     bool affect_position = true;
     bool affect_opacity = false;
     float opacity_strength = 1.0f;
+    float target_opacity = 0.0f;
     uint32_t layer_mask = 1u;
     int scope_mode = SCOPE_SUBTREE;
     NodePath scope_root;
@@ -80,6 +81,9 @@ public:
 
     void set_opacity_strength(float p_opacity_strength);
     float get_opacity_strength() const { return opacity_strength; }
+
+    void set_target_opacity(float p_target_opacity);
+    float get_target_opacity() const { return target_opacity; }
 
     void set_layer_mask(uint32_t p_layer_mask);
     uint32_t get_layer_mask() const { return layer_mask; }

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -146,6 +146,12 @@ static uint64_t _hash_scene_effector_selection(const GaussianSplatSceneDirector:
 	p_seed = _hash_float_bits(p_selection.falloff, p_seed);
 	p_seed = _hash_float_bits(p_selection.frequency, p_seed);
 	p_seed = _hash_float_bits(p_selection.opacity_strength, p_seed);
+	// target_opacity must participate in the signature — it's propagated into
+	// renderer params and drives the shader's opacity deformation. Without
+	// this, a target_opacity-only change would keep the cache signature
+	// stable and `OutputCompositor::can_reuse_cached_render()` would serve
+	// a stale raster instead of re-rendering with the new opacity behavior.
+	p_seed = _hash_float_bits(p_selection.target_opacity, p_seed);
 	p_seed = _hash_u64(static_cast<uint64_t>(p_selection.layer_mask), p_seed);
 	p_seed = _hash_u64(static_cast<uint64_t>(p_selection.scope_mode), p_seed);
 	p_seed = _hash_u64(static_cast<uint64_t>(p_selection.scope_root_id), p_seed);

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -223,7 +223,7 @@ static uint32_t _populate_scene_effector_payload_for_renderer(const GaussianSpla
 		entry.affect_position = payload[i].affect_position;
 		entry.affect_opacity = payload[i].affect_opacity;
 		entry.opacity_strength = payload[i].opacity_strength;
-		entry.target_opacity = 0.0f;
+		entry.target_opacity = payload[i].target_opacity;
 	}
 	return total_scene_effectors;
 }

--- a/modules/gaussian_splatting/shaders/includes/gs_deformation.glsl
+++ b/modules/gaussian_splatting/shaders/includes/gs_deformation.glsl
@@ -107,9 +107,7 @@ GSDeformationResult gs_apply_sphere_effectors(vec3 world_position,
     float opacity_scale = max(instance_effect_config.y, 0.0);
     uint instance_effector_mask = gs_decode_instance_scene_effector_mask(instance_effect_config, effector_meta);
     vec3 total_position_delta = vec3(0.0);
-    float opacity_weighted_target_sum = 0.0;
-    float opacity_weight_sum = 0.0;
-    float opacity_keep_product = 1.0;
+    float opacity_modifier_product = 1.0;
 
     for (uint i = 0u; i < effector_count; i++) {
         vec4 effector_sphere = effector_spheres[i];
@@ -135,23 +133,19 @@ GSDeformationResult gs_apply_sphere_effectors(vec3 world_position,
         }
 
         if (effector_opacity_config.y > 0.5 && opacity_scale > 0.0) {
-            float opacity_strength = clamp(effector_opacity_config.z, 0.0, 1.0) * opacity_scale;
-            float opacity_weight = clamp(weight * opacity_strength, 0.0, 1.0);
-            if (opacity_weight > 0.0) {
+            float opacity_strength = clamp(effector_opacity_config.z, 0.0, 1.0);
+            float response_weight = clamp(opacity_strength * opacity_scale, 0.0, 1.0);
+            if (response_weight > 0.0) {
                 float target_opacity = clamp(effector_opacity_config.w, 0.0, 1.0);
-                opacity_weighted_target_sum += target_opacity * opacity_weight;
-                opacity_weight_sum += opacity_weight;
-                opacity_keep_product *= (1.0 - opacity_weight);
+                float desired = mix(1.0, target_opacity, clamp(weight, 0.0, 1.0));
+                float modifier = mix(1.0, desired, response_weight);
+                opacity_modifier_product *= clamp(modifier, 0.0, 1.0);
             }
         }
     }
 
     result.position += total_position_delta;
-    if (opacity_weight_sum > 0.0) {
-        float blended_target = opacity_weighted_target_sum / opacity_weight_sum;
-        float combined_weight = clamp(1.0 - opacity_keep_product, 0.0, 1.0);
-        result.opacity = clamp(mix(result.opacity, blended_target, combined_weight), 0.0, 1.0);
-    }
+    result.opacity = clamp(result.opacity * opacity_modifier_product, 0.0, 1.0);
 
     return result;
 }

--- a/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
@@ -1285,6 +1285,17 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Scene sphere effect
         CHECK(bool(debug_state_a.get(StringName("truncated"), true)) == false);
         CHECK(bool(debug_state_a.get(StringName("position_active"), false)));
         CHECK(bool(debug_state_a.get(StringName("opacity_active"), false)));
+        const PackedStringArray selected_names = debug_state_a.get(StringName("selected_effector_names"), PackedStringArray());
+        CHECK(selected_names.size() == 1);
+        CHECK(selected_names[0] == String("EffectorA"));
+    }
+    {
+        const Dictionary stats_a = node_a->get_statistics();
+        CHECK(int64_t(stats_a.get(StringName("matched_scene_effectors"), -1)) == 1);
+        CHECK(int64_t(stats_a.get(StringName("bound_scene_effectors"), -1)) == 1);
+        CHECK(bool(stats_a.get(StringName("scene_effector_truncated"), true)) == false);
+        CHECK(bool(stats_a.get(StringName("scene_effector_position_active"), false)));
+        CHECK(bool(stats_a.get(StringName("scene_effector_opacity_active"), false)));
     }
 
     node_b->set_scene_effectors_enabled(false);
@@ -1366,6 +1377,18 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Scene sphere effect
         CHECK(int64_t(debug_state.get(StringName("matched_count"), -1)) == 5);
         CHECK(int64_t(debug_state.get(StringName("bound_count"), -1)) == 4);
         CHECK(bool(debug_state.get(StringName("truncated"), false)));
+        const PackedStringArray selected_names = debug_state.get(StringName("selected_effector_names"), PackedStringArray());
+        REQUIRE(selected_names.size() == 4);
+        CHECK(selected_names[0] == String("EffectorB"));
+        CHECK(selected_names[1] == String("EffectorC"));
+        CHECK(selected_names[2] == String("EffectorE"));
+        CHECK(selected_names[3] == String("EffectorA"));
+    }
+    {
+        const Dictionary stats = node->get_statistics();
+        CHECK(int64_t(stats.get(StringName("matched_scene_effectors"), -1)) == 5);
+        CHECK(int64_t(stats.get(StringName("bound_scene_effectors"), -1)) == 4);
+        CHECK(bool(stats.get(StringName("scene_effector_truncated"), false)));
     }
     CHECK(payload[0].priority == 7);
     CHECK(payload[1].priority == 5);

--- a/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
@@ -1278,6 +1278,14 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Scene sphere effect
     CHECK(node_a->is_scene_effector_opacity_active());
     CHECK(node_b->is_scene_effector_position_active());
     CHECK_FALSE(node_b->is_scene_effector_opacity_active());
+    {
+        const Dictionary debug_state_a = node_a->get_scene_effector_debug_state();
+        CHECK(int64_t(debug_state_a.get(StringName("matched_count"), -1)) == 1);
+        CHECK(int64_t(debug_state_a.get(StringName("bound_count"), -1)) == 1);
+        CHECK(bool(debug_state_a.get(StringName("truncated"), true)) == false);
+        CHECK(bool(debug_state_a.get(StringName("position_active"), false)));
+        CHECK(bool(debug_state_a.get(StringName("opacity_active"), false)));
+    }
 
     node_b->set_scene_effectors_enabled(false);
     tree->process(0.0);
@@ -1353,6 +1361,12 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Scene sphere effect
     REQUIRE(payload.size() == 4);
     CHECK(director->get_sphere_effector_count_for_renderer(renderer.ptr()) == 5u);
     CHECK(node->get_last_matched_scene_effector_count() == 5u);
+    {
+        const Dictionary debug_state = node->get_scene_effector_debug_state();
+        CHECK(int64_t(debug_state.get(StringName("matched_count"), -1)) == 5);
+        CHECK(int64_t(debug_state.get(StringName("bound_count"), -1)) == 4);
+        CHECK(bool(debug_state.get(StringName("truncated"), false)));
+    }
     CHECK(payload[0].priority == 7);
     CHECK(payload[1].priority == 5);
     CHECK(payload[2].priority == 3);

--- a/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splat_node.h
@@ -1229,6 +1229,9 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Scene sphere effect
     effector_a->set_radius(8.0f);
     effector_a->set_strength(1.0f);
     effector_a->set_affect_position(true);
+    effector_a->set_affect_opacity(true);
+    effector_a->set_opacity_strength(0.75f);
+    effector_a->set_target_opacity(0.35f);
 
     effector_b->set_enabled(true);
     effector_b->set_radius(8.0f);
@@ -1257,6 +1260,7 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Scene sphere effect
     LocalVector<GaussianSplatSceneDirector::SphereEffectorSelection> payload;
     director->build_sphere_effector_payload_for_renderer(renderer.ptr(), payload);
     REQUIRE(payload.size() == 2);
+    CHECK(payload[0].target_opacity == doctest::Approx(0.35f));
 
     LocalVector<InstanceDataGPU> instance_buffer;
     director->build_instance_buffer_for_renderer(renderer.ptr(), instance_buffer);
@@ -1268,6 +1272,12 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Scene sphere effect
     CHECK(decode_scene_effector_mask(instance_buffer[node_b_index]) == 0x2u);
     CHECK(instance_buffer[node_a_index].effect_params[3] == doctest::Approx(2.0f));
     CHECK(instance_buffer[node_b_index].effect_params[3] == doctest::Approx(2.0f));
+    CHECK(node_a->get_last_matched_scene_effector_count() == 1u);
+    CHECK(node_b->get_last_matched_scene_effector_count() == 1u);
+    CHECK(node_a->is_scene_effector_position_active());
+    CHECK(node_a->is_scene_effector_opacity_active());
+    CHECK(node_b->is_scene_effector_position_active());
+    CHECK_FALSE(node_b->is_scene_effector_opacity_active());
 
     node_b->set_scene_effectors_enabled(false);
     tree->process(0.0);
@@ -1275,11 +1285,81 @@ TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Scene sphere effect
     const int node_b_disabled_index = find_instance_index_by_translation_x(instance_buffer, node_b_x);
     REQUIRE(node_b_disabled_index >= 0);
     CHECK(decode_scene_effector_mask(instance_buffer[node_b_disabled_index]) == 0u);
+    CHECK(node_b->get_last_matched_scene_effector_count() == 0u);
+    CHECK_FALSE(node_b->is_scene_effector_position_active());
+    CHECK_FALSE(node_b->is_scene_effector_opacity_active());
 
     root->remove_child(group_b);
     root->remove_child(group_a);
     memdelete(group_b);
     memdelete(group_a);
+}
+
+TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Scene sphere effectors deterministically truncate to the renderer budget") {
+    SceneTree *tree = SceneTree::get_singleton();
+    REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");
+
+    Window *root = tree->get_root();
+    REQUIRE_MESSAGE(root != nullptr, "SceneTree root window required");
+
+    Node3D *group = memnew(Node3D);
+    GaussianSplatNode3D *node = memnew(GaussianSplatNode3D);
+    REQUIRE(group != nullptr);
+    REQUIRE(node != nullptr);
+
+    group->set_name("EffectGroup");
+    node->set_name("TargetNode");
+    node->set_splat_asset(make_single_splat_asset(3336.0f));
+
+    struct EffectorSpec {
+        const char *name;
+        int priority;
+    };
+    const EffectorSpec effector_specs[] = {
+        { "EffectorA", 2 },
+        { "EffectorB", 7 },
+        { "EffectorC", 5 },
+        { "EffectorD", -1 },
+        { "EffectorE", 3 },
+    };
+
+    root->add_child(group);
+    group->add_child(node);
+
+    LocalVector<SphereEffector3D *> effectors;
+    for (const EffectorSpec &spec : effector_specs) {
+        SphereEffector3D *effector = memnew(SphereEffector3D);
+        effector->set_name(spec.name);
+        effector->set_enabled(true);
+        effector->set_radius(10.0f);
+        effector->set_strength(float(spec.priority));
+        effector->set_priority(spec.priority);
+        effector->set_affect_position(true);
+        group->add_child(effector);
+        effectors.push_back(effector);
+    }
+    tree->process(0.0);
+
+    Ref<GaussianSplatRenderer> renderer = node->get_renderer();
+    GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
+    if (!renderer.is_valid() || !director) {
+        root->remove_child(group);
+        memdelete(group);
+        return;
+    }
+
+    LocalVector<GaussianSplatSceneDirector::SphereEffectorSelection> payload;
+    director->build_sphere_effector_payload_for_renderer(renderer.ptr(), payload);
+    REQUIRE(payload.size() == 4);
+    CHECK(director->get_sphere_effector_count_for_renderer(renderer.ptr()) == 5u);
+    CHECK(node->get_last_matched_scene_effector_count() == 5u);
+    CHECK(payload[0].priority == 7);
+    CHECK(payload[1].priority == 5);
+    CHECK(payload[2].priority == 3);
+    CHECK(payload[3].priority == 2);
+
+    root->remove_child(group);
+    memdelete(group);
 }
 
 TEST_CASE("[GaussianSplatting][Node] Runtime effect controls sanitize invalid gameplay values") {
@@ -1317,6 +1397,52 @@ TEST_CASE("[GaussianSplatting][Node] Runtime effect controls sanitize invalid ga
     CHECK(node->get_wind_frequency() == doctest::Approx(0.0f));
 
     memdelete(node);
+}
+
+TEST_CASE("[GaussianSplatting][SphereEffector] Runtime opacity controls sanitize and warn on inert configs") {
+    SphereEffector3D *effector = memnew(SphereEffector3D);
+    REQUIRE(effector != nullptr);
+
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+
+    CHECK(effector->get_target_opacity() == doctest::Approx(0.0f));
+    CHECK_FALSE(is_property_editor_exposed(effector, StringName("opacity_strength")));
+    CHECK_FALSE(is_property_editor_exposed(effector, StringName("target_opacity")));
+
+    effector->set_affect_opacity(true);
+    CHECK(is_property_editor_exposed(effector, StringName("opacity_strength")));
+    CHECK(is_property_editor_exposed(effector, StringName("target_opacity")));
+
+    effector->set_target_opacity(-0.5f);
+    CHECK(effector->get_target_opacity() == doctest::Approx(0.0f));
+    effector->set_target_opacity(1.5f);
+    CHECK(effector->get_target_opacity() == doctest::Approx(1.0f));
+    effector->set_target_opacity(nan);
+    CHECK(effector->get_target_opacity() == doctest::Approx(0.0f));
+
+    effector->set_enabled(true);
+    effector->set_radius(5.0f);
+    effector->set_affect_position(false);
+    effector->set_opacity_strength(0.0f);
+    effector->set_target_opacity(1.0f);
+
+    PackedStringArray warnings = effector->get_configuration_warnings();
+    bool has_opacity_strength_warning = false;
+    bool has_target_opacity_warning = false;
+    for (int i = 0; i < warnings.size(); i++) {
+        const String warning = warnings[i];
+        if (warning.contains("opacity_strength is 0")) {
+            has_opacity_strength_warning = true;
+        }
+        if (warning.contains("target_opacity is 1.0")) {
+            has_target_opacity_warning = true;
+        }
+    }
+
+    CHECK(has_opacity_strength_warning);
+    CHECK(has_target_opacity_warning);
+
+    memdelete(effector);
 }
 
 TEST_CASE("[GaussianSplatting][Node][SceneTree][RequiresGPU] Shared renderer instance buffer drops hidden nodes") {

--- a/tests/runtime/run_runtime_validation.py
+++ b/tests/runtime/run_runtime_validation.py
@@ -81,6 +81,7 @@ GDS_TESTS: Dict[str, Path] = {
     "Interactive State": RUNTIME_DIR / "test_interactive_state.gd",
     "GPU Streaming Stress": RUNTIME_DIR / "test_gpu_streaming_stress.gd",
     "Engine Capability Sanity": RUNTIME_DIR / "test_engine_capabilities.gd",
+    "Scene Effector Runtime Controls": RUNTIME_DIR / "test_scene_effector_runtime_controls.gd",
     "World Streaming Gate": RUNTIME_DIR / "test_world_streaming_gate.gd",
     "Streaming Residency API": RUNTIME_DIR / "test_streaming_residency_api.gd",
     "Data Flow Recent Window": RUNTIME_DIR / "test_data_flow_recent_window.gd",

--- a/tests/runtime/run_runtime_validation.py
+++ b/tests/runtime/run_runtime_validation.py
@@ -559,7 +559,15 @@ def _build_godot_command(config: GodotRunConfig, script: Path) -> List[str]:
     if config.project_path is not None:
         command.extend(["--path", str(config.project_path)])
     command.extend(config.extra_args)
-    command.extend(["--verbose", "--script", str(script.relative_to(ROOT))])
+    script_arg: Path
+    if config.project_path is None:
+        script_arg = script.relative_to(ROOT)
+    else:
+        try:
+            script_arg = script.relative_to(config.project_path)
+        except ValueError:
+            script_arg = script
+    command.extend(["--verbose", "--script", str(script_arg)])
     return command
 
 

--- a/tests/runtime/runtime_scenarios.json
+++ b/tests/runtime/runtime_scenarios.json
@@ -27,6 +27,7 @@
         "Interactive State",
         "GPU Streaming Stress",
         "Engine Capability Sanity",
+        "Scene Effector Runtime Controls",
         "World Streaming Gate",
         "Streaming Residency API",
         "Data Flow Recent Window",

--- a/tests/runtime/test_scene_effector_runtime_controls.gd
+++ b/tests/runtime/test_scene_effector_runtime_controls.gd
@@ -1,0 +1,182 @@
+extends SceneTree
+
+const ASSET_PATH := "res://tests/fixtures/test_splats.ply"
+const SKIP_MARKER := "[RUNTIME_SKIP]"
+const FAIL_MARKER := "[RUNTIME_FAIL]"
+const METRICS_MARKER := "[RUNTIME_METRICS]"
+const MAX_RENDERER_WAIT_FRAMES := 120
+
+var failures: Array[String] = []
+var metrics := {
+	"frames": 0,
+	"matched_count": 0,
+	"position_active": false,
+	"opacity_active": false,
+}
+
+var scene_root: Node3D
+var runtime_camera: Camera3D
+var effect_group: Node3D
+var effector: SphereEffector3D
+var node_a: GaussianSplatNode3D
+var node_b: GaussianSplatNode3D
+
+func _init() -> void:
+	call_deferred("_run")
+
+func _is_headless_runtime() -> bool:
+	return OS.has_feature("headless") or DisplayServer.get_name() == "headless"
+
+func _record_check(condition: bool, label: String, context: Dictionary = {}) -> void:
+	if condition:
+		print("PASS ", label)
+		return
+	_record_failure(label, context)
+
+func _record_failure(label: String, context: Dictionary = {}) -> void:
+	var reason := label
+	if not context.is_empty():
+		reason = "%s | context=%s" % [label, str(context)]
+	failures.append(reason)
+	push_error("%s %s" % [FAIL_MARKER, reason])
+
+func _emit_metrics(status: String, reason: String = "") -> void:
+	var payload := metrics.duplicate(true)
+	payload["status"] = status
+	if reason != "":
+		payload["reason"] = reason
+	print("%s %s" % [METRICS_MARKER, JSON.stringify(payload)])
+
+func _cleanup() -> void:
+	if scene_root != null:
+		scene_root.queue_free()
+	scene_root = null
+	runtime_camera = null
+	effect_group = null
+	effector = null
+	node_a = null
+	node_b = null
+
+func _setup_scene() -> bool:
+	scene_root = Node3D.new()
+	scene_root.name = "SceneEffectorRuntimeControls"
+	root.add_child(scene_root)
+
+	runtime_camera = Camera3D.new()
+	runtime_camera.name = "RuntimeCamera"
+	runtime_camera.position = Vector3(0.0, 2.0, 8.0)
+	runtime_camera.look_at(Vector3.ZERO, Vector3.UP)
+	runtime_camera.make_current()
+	scene_root.add_child(runtime_camera)
+
+	effect_group = Node3D.new()
+	effect_group.name = "EffectGroup"
+	scene_root.add_child(effect_group)
+
+	var asset := GaussianSplatAsset.new()
+	var load_err := asset.load_from_file(ASSET_PATH)
+	if load_err != OK:
+		_record_failure("Failed to load fixture asset", {"path": ASSET_PATH, "err": load_err})
+		return false
+
+	effector = SphereEffector3D.new()
+	effector.name = "RuntimeEffector"
+	effector.enabled = true
+	effector.radius = 12.0
+	effector.strength = 1.0
+	effector.falloff = 2.0
+	effector.frequency = 2.0
+	effector.affect_position = true
+	effector.affect_opacity = true
+	effector.opacity_strength = 0.8
+	effector.target_opacity = 0.35
+	effect_group.add_child(effector)
+
+	node_a = GaussianSplatNode3D.new()
+	node_a.name = "NodeA"
+	node_a.splat_asset = asset
+	node_a.position = Vector3(-1.5, 0.0, 0.0)
+	node_a.set_effect_position_scale(1.0)
+	node_a.set_effect_opacity_scale(1.0)
+	effect_group.add_child(node_a)
+
+	node_b = GaussianSplatNode3D.new()
+	node_b.name = "NodeB"
+	node_b.splat_asset = asset
+	node_b.position = Vector3(1.5, 0.0, 0.0)
+	node_b.set_scene_effector_layer_mask(2)
+	effect_group.add_child(node_b)
+
+	return true
+
+func _wait_for_renderer() -> GaussianSplatRenderer:
+	for i in range(MAX_RENDERER_WAIT_FRAMES):
+		await process_frame
+		metrics["frames"] = i + 1
+		if node_a != null:
+			var renderer: GaussianSplatRenderer = node_a.get_renderer()
+			if renderer != null:
+				return renderer
+	return null
+
+func _run() -> void:
+	if _is_headless_runtime():
+		var skip_reason := "Scene effector runtime controls require non-headless execution."
+		_emit_metrics("skipped", skip_reason)
+		print("%s %s" % [SKIP_MARKER, skip_reason])
+		quit(0)
+		return
+
+	if not _setup_scene():
+		_emit_metrics("failed", "scene_setup_failed")
+		_cleanup()
+		quit(1)
+		return
+
+	var renderer := await _wait_for_renderer()
+	if renderer == null:
+		var skip_reason := "Renderer unavailable (local RenderingDevice required)."
+		_emit_metrics("skipped", skip_reason)
+		print("%s %s" % [SKIP_MARKER, skip_reason])
+		_cleanup()
+		quit(0)
+		return
+
+	await process_frame
+	metrics["matched_count"] = node_a.get_last_matched_scene_effector_count()
+	metrics["position_active"] = node_a.is_scene_effector_position_active()
+	metrics["opacity_active"] = node_a.is_scene_effector_opacity_active()
+
+	_record_check(node_a.get_last_matched_scene_effector_count() == 1, "Node A matches one scene effector")
+	_record_check(node_a.is_scene_effector_position_active(), "Node A reports active position deformation")
+	_record_check(node_a.is_scene_effector_opacity_active(), "Node A reports active opacity modulation")
+	_record_check(node_b.get_last_matched_scene_effector_count() == 0, "Node B is excluded by layer mask")
+	_record_check(not node_b.is_scene_effector_position_active(), "Node B position effect stays inactive")
+	_record_check(not node_b.is_scene_effector_opacity_active(), "Node B opacity effect stays inactive")
+
+	effector.enabled = false
+	await process_frame
+	_record_check(node_a.get_last_matched_scene_effector_count() == 0, "Disabling effector clears runtime matches")
+	_record_check(not node_a.is_scene_effector_position_active(), "Disabled effector clears position activity")
+	_record_check(not node_a.is_scene_effector_opacity_active(), "Disabled effector clears opacity activity")
+
+	effector.enabled = true
+	effector.target_opacity = 0.6
+	await process_frame
+	_record_check(node_a.get_last_matched_scene_effector_count() == 1, "Re-enabling effector restores runtime matches")
+
+	node_a.set_effect_position_scale(0.0)
+	node_a.set_effect_opacity_scale(0.0)
+	await process_frame
+	_record_check(node_a.get_last_matched_scene_effector_count() == 1, "Match count remains visible when response scales are zeroed")
+	_record_check(not node_a.is_scene_effector_position_active(), "Zero position scale disables active position contribution")
+	_record_check(not node_a.is_scene_effector_opacity_active(), "Zero opacity scale disables active opacity contribution")
+
+	node_a.set_effect_opacity_scale(1.0)
+	node_a.set_opacity(0.0)
+	await process_frame
+	_record_check(not node_a.is_scene_effector_opacity_active(), "Base opacity 0 keeps opacity contribution inactive")
+
+	_emit_metrics("passed" if failures.is_empty() else "failed")
+	_cleanup()
+	quit(0 if failures.is_empty() else 1)

--- a/tests/runtime/test_scene_effector_runtime_controls.gd
+++ b/tests/runtime/test_scene_effector_runtime_controls.gd
@@ -9,17 +9,27 @@ const MAX_RENDERER_WAIT_FRAMES := 120
 var failures: Array[String] = []
 var metrics := {
 	"frames": 0,
-	"matched_count": 0,
-	"position_active": false,
-	"opacity_active": false,
+	"baseline_matched_count": 0,
+	"baseline_position_active": false,
+	"baseline_opacity_active": false,
+	"outside_subtree_matched_count": 0,
+	"world_scope_outside_matched_count": 0,
+	"explicit_scope_matched_count": 0,
+	"target_opacity_partial_active": false,
+	"target_opacity_neutral_active": false,
 }
 
 var scene_root: Node3D
 var runtime_camera: Camera3D
 var effect_group: Node3D
+var default_branch: Node3D
+var scoped_branch: Node3D
+var outside_group: Node3D
 var effector: SphereEffector3D
 var node_a: GaussianSplatNode3D
 var node_b: GaussianSplatNode3D
+var node_c: GaussianSplatNode3D
+var node_d: GaussianSplatNode3D
 
 func _init() -> void:
 	call_deferred("_run")
@@ -53,9 +63,64 @@ func _cleanup() -> void:
 	scene_root = null
 	runtime_camera = null
 	effect_group = null
+	default_branch = null
+	scoped_branch = null
+	outside_group = null
 	effector = null
 	node_a = null
 	node_b = null
+	node_c = null
+	node_d = null
+
+func _create_splat_node(asset: GaussianSplatAsset, node_name: String, node_position: Vector3) -> GaussianSplatNode3D:
+	var node := GaussianSplatNode3D.new()
+	node.name = node_name
+	node.splat_asset = asset
+	node.position = node_position
+	node.set_effect_position_scale(1.0)
+	node.set_effect_opacity_scale(1.0)
+	return node
+
+func _await_runtime_sync(frame_count: int = 2) -> void:
+	for i in range(frame_count):
+		await process_frame
+
+func _record_node_state(node: GaussianSplatNode3D, label: String, expected_count: int, expect_position_active: bool, expect_opacity_active: bool) -> void:
+	var matched_count := int(node.get_last_matched_scene_effector_count())
+	var position_active := bool(node.is_scene_effector_position_active())
+	var opacity_active := bool(node.is_scene_effector_opacity_active())
+	var context := {
+		"matched_count": matched_count,
+		"position_active": position_active,
+		"opacity_active": opacity_active,
+	}
+	_record_check(matched_count == expected_count, "%s matched count" % label, context)
+	_record_check(position_active == expect_position_active, "%s position activity" % label, context)
+	_record_check(opacity_active == expect_opacity_active, "%s opacity activity" % label, context)
+
+func _record_statistics_surface(node: GaussianSplatNode3D, label: String) -> void:
+	var stats := node.get_statistics()
+	_record_check(stats.has("matched_scene_effectors"), "%s statistics include matched_scene_effectors" % label, {"stats": stats})
+	_record_check(stats.has("scene_effector_position_active"), "%s statistics include scene_effector_position_active" % label, {"stats": stats})
+	_record_check(stats.has("scene_effector_opacity_active"), "%s statistics include scene_effector_opacity_active" % label, {"stats": stats})
+	if stats.has("matched_scene_effectors"):
+		_record_check(
+			int(stats["matched_scene_effectors"]) == int(node.get_last_matched_scene_effector_count()),
+			"%s statistics matched_scene_effectors mirrors runtime query" % label,
+			{"stats": stats}
+		)
+	if stats.has("scene_effector_position_active"):
+		_record_check(
+			bool(stats["scene_effector_position_active"]) == bool(node.is_scene_effector_position_active()),
+			"%s statistics position flag mirrors runtime query" % label,
+			{"stats": stats}
+		)
+	if stats.has("scene_effector_opacity_active"):
+		_record_check(
+			bool(stats["scene_effector_opacity_active"]) == bool(node.is_scene_effector_opacity_active()),
+			"%s statistics opacity flag mirrors runtime query" % label,
+			{"stats": stats}
+		)
 
 func _setup_scene() -> bool:
 	scene_root = Node3D.new()
@@ -72,6 +137,18 @@ func _setup_scene() -> bool:
 	effect_group = Node3D.new()
 	effect_group.name = "EffectGroup"
 	scene_root.add_child(effect_group)
+
+	default_branch = Node3D.new()
+	default_branch.name = "DefaultBranch"
+	effect_group.add_child(default_branch)
+
+	scoped_branch = Node3D.new()
+	scoped_branch.name = "ScopedBranch"
+	effect_group.add_child(scoped_branch)
+
+	outside_group = Node3D.new()
+	outside_group.name = "OutsideGroup"
+	scene_root.add_child(outside_group)
 
 	var asset := GaussianSplatAsset.new()
 	var load_err := asset.load_from_file(ASSET_PATH)
@@ -92,20 +169,19 @@ func _setup_scene() -> bool:
 	effector.target_opacity = 0.35
 	effect_group.add_child(effector)
 
-	node_a = GaussianSplatNode3D.new()
-	node_a.name = "NodeA"
-	node_a.splat_asset = asset
-	node_a.position = Vector3(-1.5, 0.0, 0.0)
-	node_a.set_effect_position_scale(1.0)
-	node_a.set_effect_opacity_scale(1.0)
-	effect_group.add_child(node_a)
+	node_a = _create_splat_node(asset, "NodeA", Vector3(-1.5, 0.0, 0.0))
+	default_branch.add_child(node_a)
 
-	node_b = GaussianSplatNode3D.new()
-	node_b.name = "NodeB"
-	node_b.splat_asset = asset
-	node_b.position = Vector3(1.5, 0.0, 0.0)
+	node_b = _create_splat_node(asset, "NodeB", Vector3(1.5, 0.0, 0.0))
 	node_b.set_scene_effector_layer_mask(2)
-	effect_group.add_child(node_b)
+	default_branch.add_child(node_b)
+
+	node_c = _create_splat_node(asset, "NodeC", Vector3(0.0, 0.0, 0.0))
+	outside_group.add_child(node_c)
+
+	node_d = _create_splat_node(asset, "NodeD", Vector3(0.0, 0.0, -2.0))
+	node_d.set_scene_effector_scope_root(NodePath(".."))
+	scoped_branch.add_child(node_d)
 
 	return true
 
@@ -142,40 +218,93 @@ func _run() -> void:
 		quit(0)
 		return
 
-	await process_frame
-	metrics["matched_count"] = node_a.get_last_matched_scene_effector_count()
-	metrics["position_active"] = node_a.is_scene_effector_position_active()
-	metrics["opacity_active"] = node_a.is_scene_effector_opacity_active()
+	await _await_runtime_sync()
+	metrics["baseline_matched_count"] = node_a.get_last_matched_scene_effector_count()
+	metrics["baseline_position_active"] = node_a.is_scene_effector_position_active()
+	metrics["baseline_opacity_active"] = node_a.is_scene_effector_opacity_active()
+	metrics["outside_subtree_matched_count"] = node_c.get_last_matched_scene_effector_count()
 
-	_record_check(node_a.get_last_matched_scene_effector_count() == 1, "Node A matches one scene effector")
-	_record_check(node_a.is_scene_effector_position_active(), "Node A reports active position deformation")
-	_record_check(node_a.is_scene_effector_opacity_active(), "Node A reports active opacity modulation")
-	_record_check(node_b.get_last_matched_scene_effector_count() == 0, "Node B is excluded by layer mask")
-	_record_check(not node_b.is_scene_effector_position_active(), "Node B position effect stays inactive")
-	_record_check(not node_b.is_scene_effector_opacity_active(), "Node B opacity effect stays inactive")
+	_record_node_state(node_a, "Node A baseline subtree match", 1, true, true)
+	_record_node_state(node_b, "Node B layer-mask exclusion", 0, false, false)
+	_record_node_state(node_c, "Node C default subtree exclusion", 0, false, false)
+	_record_node_state(node_d, "Node D node-side scope narrowing", 0, false, false)
+	_record_statistics_surface(node_a, "Node A")
+
+	node_b.set_scene_effector_layer_mask(1)
+	await _await_runtime_sync()
+	_record_node_state(node_b, "Node B layer-mask opt-in", 1, true, true)
+
+	node_b.set_scene_effector_layer_mask(2)
+	await _await_runtime_sync()
+	_record_node_state(node_b, "Node B layer-mask opt-out", 0, false, false)
+
+	effector.scope_mode = SphereEffector3D.SCOPE_WORLD
+	await _await_runtime_sync()
+	metrics["world_scope_outside_matched_count"] = node_c.get_last_matched_scene_effector_count()
+	_record_node_state(node_a, "Node A world scope", 1, true, true)
+	_record_node_state(node_c, "Node C world scope inclusion", 1, true, true)
+	_record_node_state(node_d, "Node D world scope still filtered by node scope", 0, false, false)
+
+	effector.scope_mode = SphereEffector3D.SCOPE_EXPLICIT_ROOT
+	effector.scope_root = NodePath("../ScopedBranch")
+	await _await_runtime_sync()
+	metrics["explicit_scope_matched_count"] = node_d.get_last_matched_scene_effector_count()
+	_record_node_state(node_a, "Node A explicit-root exclusion", 0, false, false)
+	_record_node_state(node_c, "Node C explicit-root exclusion", 0, false, false)
+	_record_node_state(node_d, "Node D explicit-root inclusion", 1, true, true)
+	_record_statistics_surface(node_d, "Node D")
+
+	effector.scope_mode = SphereEffector3D.SCOPE_SUBTREE
+	effector.scope_root = NodePath("")
+	await _await_runtime_sync()
+	_record_node_state(node_a, "Node A subtree scope restored", 1, true, true)
+	_record_node_state(node_c, "Node C subtree scope restored", 0, false, false)
+	_record_node_state(node_d, "Node D subtree scope restored", 0, false, false)
 
 	effector.enabled = false
-	await process_frame
-	_record_check(node_a.get_last_matched_scene_effector_count() == 0, "Disabling effector clears runtime matches")
-	_record_check(not node_a.is_scene_effector_position_active(), "Disabled effector clears position activity")
-	_record_check(not node_a.is_scene_effector_opacity_active(), "Disabled effector clears opacity activity")
+	await _await_runtime_sync()
+	_record_node_state(node_a, "Disabled effector", 0, false, false)
+	_record_node_state(node_c, "Disabled effector outside subtree", 0, false, false)
 
 	effector.enabled = true
 	effector.target_opacity = 0.6
-	await process_frame
-	_record_check(node_a.get_last_matched_scene_effector_count() == 1, "Re-enabling effector restores runtime matches")
+	await _await_runtime_sync()
+	metrics["target_opacity_partial_active"] = node_a.is_scene_effector_opacity_active()
+	_record_node_state(node_a, "Re-enabled effector with partial target opacity", 1, true, true)
+
+	effector.affect_opacity = false
+	await _await_runtime_sync()
+	_record_node_state(node_a, "Opacity channel disabled at runtime", 1, true, false)
+
+	effector.affect_opacity = true
+	effector.target_opacity = 1.0
+	await _await_runtime_sync()
+	metrics["target_opacity_neutral_active"] = node_a.is_scene_effector_opacity_active()
+	_record_node_state(node_a, "Neutral target opacity remains matched but inert", 1, true, false)
+
+	effector.target_opacity = 0.6
+	await _await_runtime_sync()
+	_record_node_state(node_a, "Partial target opacity restores active opacity channel", 1, true, true)
+
+	node_a.set_scene_effectors_enabled(false)
+	await _await_runtime_sync()
+	_record_node_state(node_a, "Node A scene-effector toggle off", 0, false, false)
+
+	node_a.set_scene_effectors_enabled(true)
+	await _await_runtime_sync()
+	_record_node_state(node_a, "Node A scene-effector toggle on", 1, true, true)
 
 	node_a.set_effect_position_scale(0.0)
 	node_a.set_effect_opacity_scale(0.0)
-	await process_frame
-	_record_check(node_a.get_last_matched_scene_effector_count() == 1, "Match count remains visible when response scales are zeroed")
-	_record_check(not node_a.is_scene_effector_position_active(), "Zero position scale disables active position contribution")
-	_record_check(not node_a.is_scene_effector_opacity_active(), "Zero opacity scale disables active opacity contribution")
+	await _await_runtime_sync()
+	_record_node_state(node_a, "Node A zero response scales", 1, false, false)
 
+	node_a.set_effect_position_scale(1.0)
 	node_a.set_effect_opacity_scale(1.0)
 	node_a.set_opacity(0.0)
-	await process_frame
-	_record_check(not node_a.is_scene_effector_opacity_active(), "Base opacity 0 keeps opacity contribution inactive")
+	await _await_runtime_sync()
+	_record_node_state(node_a, "Node A base opacity zero", 1, true, false)
+	_record_statistics_surface(node_a, "Node A after base opacity zero")
 
 	_emit_metrics("passed" if failures.is_empty() else "failed")
 	_cleanup()

--- a/tests/runtime/test_scene_effector_runtime_controls.gd
+++ b/tests/runtime/test_scene_effector_runtime_controls.gd
@@ -12,9 +12,16 @@ var metrics := {
 	"baseline_matched_count": 0,
 	"baseline_position_active": false,
 	"baseline_opacity_active": false,
+	"baseline_bound_count": 0,
+	"baseline_selected_name": "",
+	"baseline_truncated": false,
+	"combined_wind_sphere_active": false,
 	"outside_subtree_matched_count": 0,
 	"world_scope_outside_matched_count": 0,
 	"explicit_scope_matched_count": 0,
+	"reparent_into_subtree_matched_count": 0,
+	"reparent_outside_subtree_matched_count": 0,
+	"reparent_effector_widened_matched_count": 0,
 	"target_opacity_partial_active": false,
 	"target_opacity_neutral_active": false,
 }
@@ -30,6 +37,7 @@ var node_a: GaussianSplatNode3D
 var node_b: GaussianSplatNode3D
 var node_c: GaussianSplatNode3D
 var node_d: GaussianSplatNode3D
+var node_e: GaussianSplatNode3D
 
 func _init() -> void:
 	call_deferred("_run")
@@ -71,6 +79,7 @@ func _cleanup() -> void:
 	node_b = null
 	node_c = null
 	node_d = null
+	node_e = null
 
 func _create_splat_node(asset: GaussianSplatAsset, node_name: String, node_position: Vector3) -> GaussianSplatNode3D:
 	var node := GaussianSplatNode3D.new()
@@ -101,6 +110,8 @@ func _record_node_state(node: GaussianSplatNode3D, label: String, expected_count
 func _record_statistics_surface(node: GaussianSplatNode3D, label: String) -> void:
 	var stats := node.get_statistics()
 	_record_check(stats.has("matched_scene_effectors"), "%s statistics include matched_scene_effectors" % label, {"stats": stats})
+	_record_check(stats.has("bound_scene_effectors"), "%s statistics include bound_scene_effectors" % label, {"stats": stats})
+	_record_check(stats.has("scene_effector_truncated"), "%s statistics include scene_effector_truncated" % label, {"stats": stats})
 	_record_check(stats.has("scene_effector_position_active"), "%s statistics include scene_effector_position_active" % label, {"stats": stats})
 	_record_check(stats.has("scene_effector_opacity_active"), "%s statistics include scene_effector_opacity_active" % label, {"stats": stats})
 	if stats.has("matched_scene_effectors"):
@@ -121,6 +132,59 @@ func _record_statistics_surface(node: GaussianSplatNode3D, label: String) -> voi
 			"%s statistics opacity flag mirrors runtime query" % label,
 			{"stats": stats}
 		)
+
+func _record_debug_state_surface(
+	node: GaussianSplatNode3D,
+	label: String,
+	expected_matched_count: int,
+	expected_bound_count: int,
+	expect_position_active: bool,
+	expect_opacity_active: bool,
+	expected_selected_names: Array = [],
+	expected_truncated: bool = false,
+	extra_expectations: Dictionary = {}
+) -> void:
+	var state := node.get_scene_effector_debug_state()
+	var required_keys := [
+		"matched_count",
+		"bound_count",
+		"truncated",
+		"position_active",
+		"opacity_active",
+		"selected_effector_ids",
+		"selected_effector_names",
+	]
+	for key in required_keys:
+		_record_check(state.has(key), "%s debug state includes %s" % [label, key], {"state": state})
+
+	var selected_names: Array = state.get("selected_effector_names", [])
+	var context := {
+		"state": state,
+		"selected_names": selected_names,
+	}
+	_record_check(int(state.get("matched_count", -1)) == expected_matched_count, "%s debug matched_count" % label, context)
+	_record_check(int(state.get("bound_count", -1)) == expected_bound_count, "%s debug bound_count" % label, context)
+	_record_check(bool(state.get("truncated", true)) == expected_truncated, "%s debug truncated flag" % label, context)
+	_record_check(bool(state.get("position_active", false)) == expect_position_active, "%s debug position flag" % label, context)
+	_record_check(bool(state.get("opacity_active", false)) == expect_opacity_active, "%s debug opacity flag" % label, context)
+	_record_check(selected_names == expected_selected_names, "%s debug selected names" % label, context)
+
+	for key in extra_expectations.keys():
+		_record_check(
+			state.get(key) == extra_expectations[key],
+			"%s debug %s expectation" % [label, key],
+			{"state": state, "expected": extra_expectations}
+		)
+
+func _reparent_preserve_global(node: Node3D, new_parent: Node3D) -> void:
+	if node == null or new_parent == null:
+		return
+	var previous_transform := node.global_transform
+	var current_parent := node.get_parent()
+	if current_parent != null:
+		current_parent.remove_child(node)
+	new_parent.add_child(node)
+	node.global_transform = previous_transform
 
 func _setup_scene() -> bool:
 	scene_root = Node3D.new()
@@ -183,6 +247,14 @@ func _setup_scene() -> bool:
 	node_d.set_scene_effector_scope_root(NodePath(".."))
 	scoped_branch.add_child(node_d)
 
+	node_e = _create_splat_node(asset, "NodeE", Vector3(0.0, 0.0, 2.0))
+	node_e.set_wind_override_enabled(true)
+	node_e.set_wind_enabled(true)
+	node_e.set_wind_strength(0.85)
+	node_e.set_wind_direction(Vector3(0.0, 0.0, 1.0))
+	node_e.set_wind_frequency(1.5)
+	default_branch.add_child(node_e)
+
 	return true
 
 func _wait_for_renderer() -> GaussianSplatRenderer:
@@ -223,12 +295,49 @@ func _run() -> void:
 	metrics["baseline_position_active"] = node_a.is_scene_effector_position_active()
 	metrics["baseline_opacity_active"] = node_a.is_scene_effector_opacity_active()
 	metrics["outside_subtree_matched_count"] = node_c.get_last_matched_scene_effector_count()
+	var baseline_debug_state := node_a.get_scene_effector_debug_state()
+	metrics["baseline_bound_count"] = int(baseline_debug_state.get("bound_count", 0))
+	metrics["baseline_truncated"] = bool(baseline_debug_state.get("truncated", false))
+	var baseline_names: Array = baseline_debug_state.get("selected_effector_names", [])
+	if not baseline_names.is_empty():
+		metrics["baseline_selected_name"] = str(baseline_names[0])
+	metrics["combined_wind_sphere_active"] = false
 
 	_record_node_state(node_a, "Node A baseline subtree match", 1, true, true)
+	_record_debug_state_surface(node_a, "Node A baseline subtree match", 1, 1, true, true, ["RuntimeEffector"], false)
 	_record_node_state(node_b, "Node B layer-mask exclusion", 0, false, false)
 	_record_node_state(node_c, "Node C default subtree exclusion", 0, false, false)
 	_record_node_state(node_d, "Node D node-side scope narrowing", 0, false, false)
+	_record_debug_state_surface(
+		node_d,
+		"Node D node-side scope narrowing",
+		0,
+		0,
+		false,
+		false,
+		[],
+		false,
+		{
+			"scope_filter_present": true,
+			"scope_filter_valid": true,
+		}
+	)
+	_record_node_state(node_e, "Node E combined wind + sphere baseline", 1, true, true)
+	_record_debug_state_surface(node_e, "Node E combined wind + sphere baseline", 1, 1, true, true, ["RuntimeEffector"], false)
 	_record_statistics_surface(node_a, "Node A")
+	_record_statistics_surface(node_e, "Node E")
+	metrics["combined_wind_sphere_active"] = node_e.is_scene_effector_position_active() and node_e.is_scene_effector_opacity_active()
+
+	node_e.set_wind_enabled(false)
+	await _await_runtime_sync()
+	_record_node_state(node_e, "Node E sphere path survives wind disable", 1, true, true)
+	_record_debug_state_surface(node_e, "Node E sphere path survives wind disable", 1, 1, true, true, ["RuntimeEffector"], false)
+
+	node_e.set_wind_enabled(true)
+	node_e.set_wind_frequency(2.25)
+	node_e.set_wind_direction(Vector3(1.0, 0.0, 0.25))
+	await _await_runtime_sync()
+	_record_node_state(node_e, "Node E combined wind + sphere after wind retune", 1, true, true)
 
 	node_b.set_scene_effector_layer_mask(1)
 	await _await_runtime_sync()
@@ -260,6 +369,28 @@ func _run() -> void:
 	_record_node_state(node_a, "Node A subtree scope restored", 1, true, true)
 	_record_node_state(node_c, "Node C subtree scope restored", 0, false, false)
 	_record_node_state(node_d, "Node D subtree scope restored", 0, false, false)
+
+	_reparent_preserve_global(node_c, default_branch)
+	await _await_runtime_sync()
+	metrics["reparent_into_subtree_matched_count"] = node_c.get_last_matched_scene_effector_count()
+	_record_node_state(node_c, "Node C reparented into subtree", 1, true, true)
+	_record_debug_state_surface(node_c, "Node C reparented into subtree", 1, 1, true, true, ["RuntimeEffector"], false)
+
+	_reparent_preserve_global(node_c, outside_group)
+	await _await_runtime_sync()
+	metrics["reparent_outside_subtree_matched_count"] = node_c.get_last_matched_scene_effector_count()
+	_record_node_state(node_c, "Node C reparented back outside subtree", 0, false, false)
+
+	_reparent_preserve_global(effector, scene_root)
+	await _await_runtime_sync()
+	metrics["reparent_effector_widened_matched_count"] = node_c.get_last_matched_scene_effector_count()
+	_record_node_state(node_a, "Node A matched after effector reparent", 1, true, true)
+	_record_node_state(node_c, "Node C matched after effector reparent to scene root", 1, true, true)
+	_record_node_state(node_d, "Node D remains narrowed after effector reparent", 0, false, false)
+
+	_reparent_preserve_global(effector, effect_group)
+	await _await_runtime_sync()
+	_record_node_state(node_c, "Node C excluded after effector reparent restore", 0, false, false)
 
 	effector.enabled = false
 	await _await_runtime_sync()


### PR DESCRIPTION
## Summary
- add SphereEffector3D target_opacity authoring and scene-director propagation
- switch scene effector opacity deformation to a stable multiplicative modifier path
- expose GaussianSplatNode3D runtime scene-effector diagnostics and add focused coverage/docs

## Validation
- scons platform=linuxbsd target=editor module_gaussian_splatting_enabled=yes -j2
- python3 -m py_compile tests/runtime/run_runtime_validation.py
- bin/godot.linuxbsd.editor.x86_64 --headless --import --path tests/examples/godot/test_project --quit

## Notes
- base branch is feat/per-instance-color-grading so this PR contains only the runtime opacity control slice
- direct headless script execution for the new runtime harness still crashes in the current environment before the test can complete