### PR TITLE
gaussian_splatting: land Wave 1 fallback cleanup

### DIFF
--- a/docs/api/gaussian_splat_container.md
+++ b/docs/api/gaussian_splat_container.md
@@ -117,11 +117,6 @@ This class does not define any enums.
       <td><code>modules/gaussian_splatting/nodes/gaussian_splat_container.cpp:159</code></td>
     </tr>
     <tr>
-      <td><code>apply_to_renderer(renderer)</code></td>
-      <td>Low-level compatibility helper that pushes merged <code>GaussianData</code> and static chunks to the given <code>GaussianSplatRenderer</code>. Prefer <code>apply_to_node()</code> or <code>export_world_resource()</code> for normal scene workflows. Returns <code>ERR_UNAVAILABLE</code> when no merged data exists.</td>
-      <td><code>modules/gaussian_splatting/nodes/gaussian_splat_container.cpp:86</code></td>
-    </tr>
-    <tr>
       <td><code>apply_to_node(node)</code></td>
       <td>Applies merged data to a <code>GaussianSplatWorld3D</code> (via <code>export_world_resource()</code>) or a <code>GaussianSplatNode3D</code> (via asset conversion). Returns <code>ERR_INVALID_PARAMETER</code> for unsupported node types.</td>
       <td><code>modules/gaussian_splatting/nodes/gaussian_splat_container.cpp:102</code></td>

--- a/docs/architecture/gaussian-pipeline-deprecation-deletion-plan.md
+++ b/docs/architecture/gaussian-pipeline-deprecation-deletion-plan.md
@@ -53,7 +53,7 @@ That means the remaining cleanup work is concentrated in compatibility seams, no
 | `GaussianSplatNode3D::ply_file_path` | Raw file load, auto-load, drag/drop, validation | Runtime and editor compatibility route | Demote from editor-primary path first; later decide whether runtime raw-load survives | Bucket C |
 | `GaussianSplatDynamicInstance3D::ply_file_path` | Raw file to `GaussianData` bypass | Runtime compatibility route | Deprecate earlier than normal node path; require `splat_asset` or explicit `GaussianData` later | Bucket B/C |
 | `GaussianSplatRenderer::set_gaussian_data()` | Low-level renderer/test/tool hook | Public low-level API | Keep for now, narrow usage contract, remove only after replacements exist | Bucket C |
-| `GaussianSplatContainer::apply_to_renderer()` | Container-level direct renderer bypass | Low-level convenience API | Demote in README/API docs now; keep only while the direct raw-data renderer route still exists | Bucket C |
+| `GaussianSplatContainer::apply_to_renderer()` | Container-level direct renderer bypass | Removed in Wave 1 cleanup | Delete outright; keep `apply_to_node()` / export workflows only | Complete |
 | Duplicated source-path resolution helpers | Same logic in node/editor code | Internal duplication | Consolidate into one shared helper | Bucket A |
 | Explicit-resident legacy resident fallback | Accepted runtime fallback when resident atlas publish is infeasible | Runtime compatibility behavior | Keep until resident atlas covers explicit-resident edge cases or the fallback is intentionally retired | Bucket C |
 
@@ -269,7 +269,7 @@ Verified blockers:
 Secondary callers that should not drive the keep/remove decision by themselves:
 
 - Editor preview direct upload in [gaussian_editor_plugin.cpp](../../modules/gaussian_splatting/editor/gaussian_editor_plugin.cpp)
-- [GaussianSplatContainer::apply_to_renderer()](../../modules/gaussian_splatting/nodes/gaussian_splat_container.cpp)
+- `GaussianSplatContainer::apply_to_renderer()` was removed in Wave 1 cleanup; container tooling now hands off through `apply_to_node()` or world export only.
 
 Why it still exists:
 
@@ -281,9 +281,7 @@ Recommended action:
 - Do not delete it yet.
 - Narrow its contract instead:
   - document `set_gaussian_data()` as a low-level/test/tool/editor-preview API, not the canonical high-level scene path
-  - demote `GaussianSplatContainer::apply_to_renderer()` in README/API docs to legacy low-level convenience usage
   - migrate or explicitly bless editor preview
-  - retire container-level convenience usage
   - keep high-level scene code off it
   - remove the underlying runtime route only after world submission realization, streaming bootstrap, and explicit-resident fallback no longer depend on primary `gaussian_data`
 

--- a/docs/features/streaming.md
+++ b/docs/features/streaming.md
@@ -13,6 +13,18 @@ Load and evict Gaussian splat chunks on demand so that datasets larger than avai
 | Camera moves continuously through a large environment | Enable predictive prefetch to preload chunks along the camera path. |
 | Multiple Gaussian assets share a single world | Use multi-asset registration so the atlas shares VRAM across assets. |
 
+## Source residency model
+
+Streaming behavior depends on the format of the source asset:
+
+| Source | Residency | Chunk payloads | Notes |
+| --- | --- | --- | --- |
+| Uncompressed `.gsplatworld` | Resident `GaussianData` plus file-backed `StagedFileChunkPayloadSource` | Loaded on demand from the source file | Only format that supports file-backed streaming reads. |
+| Compressed `.gsplatworld` | Resident only | None — full gaussian array is decoded into memory at load | Format is resident-only and has no "out-of-core" streaming path; the streaming system still manages visibility, LOD, and VRAM residency. |
+| `.ply` / `.spz` via `GaussianSplatNode3D` | Resident only | None | Direct instance nodes always publish a resident submission hint. |
+
+`GaussianStreamingSystem` runs in all three cases, but "streaming" here means GPU residency and LOD management, not out-of-core source loading, except for uncompressed `.gsplatworld`.
+
 ## Enabling streaming
 
 Streaming is enabled globally through a project setting and is active by default.

--- a/docs/reference/project-settings.md
+++ b/docs/reference/project-settings.md
@@ -153,11 +153,6 @@ These settings are registered with `GLOBAL_DEF(...)` and grouped by key prefix.
       <td><pre><code>modules/gaussian_splatting/core/gaussian_splat_manager.cpp:1111</code></pre></td>
     </tr>
     <tr>
-      <td><pre><code>rendering/gaussian_splatting/streaming/io_source_path</code></pre></td>
-      <td><pre><code>String()</code></pre></td>
-      <td><pre><code>modules/gaussian_splatting/core/gaussian_splat_manager.cpp:1116</code></pre></td>
-    </tr>
-    <tr>
       <td><pre><code>rendering/gaussian_splatting/streaming/max_chunk_loads_per_frame</code></pre></td>
       <td><pre><code>16</code></pre></td>
       <td><pre><code>modules/gaussian_splatting/core/gaussian_splat_manager.cpp:1092</code></pre></td>
@@ -775,7 +770,6 @@ These keys are used by module code but are not registered with `GLOBAL_DEF(...)`
 | `rendering/gaussian_splatting/debug/show_residency_hud` | `modules/gaussian_splatting/core/gaussian_splat_settings_manager.cpp:12` |
 | `rendering/gaussian_splatting/debug/show_tile_grid` | `modules/gaussian_splatting/core/gaussian_splat_settings_manager.cpp:9` |
 | `rendering/gaussian_splatting/debug/splat_audit_sample_count` | `modules/gaussian_splatting/renderer/render_debug_state_orchestrator.cpp:369` |
-| `rendering/gaussian_splatting/import/ply_ascii_strict_parse` | `modules/gaussian_splatting/io/ply_loader.cpp:58` |
 | `rendering/gaussian_splatting/lighting/dc_logit` | `modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp:119` |
 | `rendering/gaussian_splatting/lighting/direct_light_scale` | `modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp:116` |
 | `rendering/gaussian_splatting/lighting/indirect_sh_scale` | `modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp:117` |
@@ -814,7 +808,6 @@ These registered keys have no additional string-literal references beyond their 
 | `rendering/gaussian_splatting/debug/enable_mainloop_probes` | `modules/gaussian_splatting/core/gaussian_splat_manager.cpp:1039` |
 | `rendering/gaussian_splatting/max_gpu_buffer_count` | `modules/gaussian_splatting/core/gaussian_splat_manager.cpp:989` |
 | `rendering/gaussian_splatting/streaming/async_io_enabled` | `modules/gaussian_splatting/core/gaussian_splat_manager.cpp:1115` |
-| `rendering/gaussian_splatting/streaming/io_source_path` | `modules/gaussian_splatting/core/gaussian_splat_manager.cpp:1116` |
 
 ## Examples
 ```bash

--- a/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
@@ -963,9 +963,12 @@ Ref<Texture2D> GaussianSplatAsset::get_preview_texture() const {
         return Ref<Texture2D>();
     }
 
-    ERR_FAIL_COND_V_MSG(!Thread::is_main_thread(), Ref<Texture2D>(),
-            "GaussianSplatAsset preview textures must be created on the main thread.");
-
+    // Safe to call from `EditorResourcePreview`'s worker threads: the main
+    // thread services the RS command queue in editor mode, so the sync RS
+    // chain underneath `create_from_image` completes. The `--headless
+    // --import` deadlock motivating #251 is avoided because the import path
+    // stores `preview_image` directly via `set_preview_image()` and never
+    // invokes this lazy texture-creation accessor.
     preview_texture_cache = ImageTexture::create_from_image(preview_image);
     return preview_texture_cache;
 }

--- a/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
@@ -1,5 +1,4 @@
 #include "gaussian_splat_asset.h"
-#include "../io/gaussian_data_loader.h"
 #include "../io/ply_loader.h"
 #include "../io/spz_loader.h"
 #include "../core/gaussian_data.h"
@@ -1044,15 +1043,10 @@ Error GaussianSplatAsset::load_from_file(const String &p_path) {
 			source_stage = "raw";
 		}
 	} else {
-		GaussianDataLoadResult load_result;
-		err = load_gaussian_data_from_file(p_path, load_result);
-		if (err == OK) {
-			gaussian_data = load_result.data;
-			missing_required = load_result.missing_required;
-			missing_optional = load_result.missing_optional;
-			file_label = load_result.used_spz ? "SPZ" : "PLY";
-			source_stage = "raw";
-		}
+		GS_LOG_ERROR_DEFAULT(vformat(
+				"Unsupported Gaussian splat raw format '%s' for path: %s. Supported extensions: .ply, .spz.",
+				extension, p_path));
+		return ERR_FILE_UNRECOGNIZED;
 	}
 
 	if (err != OK) {

--- a/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
@@ -5,11 +5,14 @@
 #include "../core/gaussian_data.h"
 #include "core/error/error_macros.h"
 #include "core/io/file_access.h"
+#include "core/io/image.h"
 #include "core/math/basis.h"
 #include "core/math/math_funcs.h"
 #include "core/math/quaternion.h"
 #include "core/os/os.h"
+#include "core/os/thread.h"
 #include "../logger/gs_logger.h"
+#include "scene/resources/image_texture.h"
 
 namespace {
 
@@ -101,6 +104,9 @@ void GaussianSplatAsset::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_import_quality_preset"), &GaussianSplatAsset::get_import_quality_preset);
     ClassDB::bind_method(D_METHOD("set_compression_flags", "flags"), &GaussianSplatAsset::set_compression_flags);
     ClassDB::bind_method(D_METHOD("get_compression_flags"), &GaussianSplatAsset::get_compression_flags);
+    ClassDB::bind_method(D_METHOD("set_preview_image", "image"), &GaussianSplatAsset::set_preview_image);
+    ClassDB::bind_method(D_METHOD("get_preview_image"), &GaussianSplatAsset::get_preview_image);
+    ClassDB::bind_method(D_METHOD("get_preview_texture"), &GaussianSplatAsset::get_preview_texture);
     ClassDB::bind_method(D_METHOD("set_thumbnail", "texture"), &GaussianSplatAsset::set_thumbnail);
     ClassDB::bind_method(D_METHOD("get_thumbnail"), &GaussianSplatAsset::get_thumbnail);
     ClassDB::bind_method(D_METHOD("set_source_path", "path"), &GaussianSplatAsset::set_source_path);
@@ -117,8 +123,6 @@ void GaussianSplatAsset::_bind_methods() {
     ADD_PROPERTY(PropertyInfo(Variant::INT, "import/compression_flags", PROPERTY_HINT_FLAGS, "Positions,Colors,Scales,Rotations"),
             "set_compression_flags", "get_compression_flags");
     ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "import/metadata"), "set_import_metadata", "get_import_metadata");
-    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "import/thumbnail", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"),
-            "set_thumbnail", "get_thumbnail");
     ADD_PROPERTY(PropertyInfo(Variant::STRING, "import/source_path", PROPERTY_HINT_FILE, "*.ply,*.spz"),
             "set_source_path", "get_source_path");
     ADD_PROPERTY(PropertyInfo(Variant::PACKED_FLOAT32_ARRAY, "data/positions"), "set_positions", "get_positions");
@@ -142,6 +146,50 @@ void GaussianSplatAsset::_bind_methods() {
     BIND_ENUM_CONSTANT(COMPRESSION_COLORS);
     BIND_ENUM_CONSTANT(COMPRESSION_SCALES);
     BIND_ENUM_CONSTANT(COMPRESSION_ROTATIONS);
+}
+
+bool GaussianSplatAsset::_set(const StringName &p_name, const Variant &p_value) {
+    if (p_name == StringName("import/thumbnail")) {
+        if (p_value.get_type() == Variant::NIL) {
+            set_preview_image(Ref<Image>());
+            return true;
+        }
+
+        Ref<Image> image = p_value;
+        if (image.is_valid()) {
+            set_preview_image(image);
+            return true;
+        }
+
+        Ref<Texture2D> texture = p_value;
+        if (texture.is_valid()) {
+            ERR_FAIL_COND_V_MSG(!Thread::is_main_thread(), false,
+                    "Legacy GaussianSplatAsset thumbnails must be converted on the main thread.");
+            Ref<Image> texture_image = texture->get_image();
+            if (texture_image.is_null()) {
+                return true;
+            }
+            set_preview_image(texture_image);
+            return true;
+        }
+
+        return false;
+    }
+
+    return false;
+}
+
+bool GaussianSplatAsset::_get(const StringName &p_name, Variant &r_ret) const {
+    if (p_name == StringName("import/thumbnail")) {
+        r_ret = preview_image;
+        return true;
+    }
+
+    return false;
+}
+
+void GaussianSplatAsset::_get_property_list(List<PropertyInfo> *p_list) const {
+    p_list->push_back(PropertyInfo(Variant::OBJECT, "import/thumbnail", PROPERTY_HINT_RESOURCE_TYPE, "Image"));
 }
 
 GaussianSplatAsset::GaussianSplatAsset() {
@@ -895,13 +943,43 @@ void GaussianSplatAsset::set_compression_flags(uint32_t p_flags) {
     emit_changed();
 }
 
-void GaussianSplatAsset::set_thumbnail(const Ref<Texture2D> &p_thumbnail) {
-    if (thumbnail == p_thumbnail) {
+void GaussianSplatAsset::set_preview_image(const Ref<Image> &p_image) {
+    if (preview_image == p_image) {
         return;
     }
-    thumbnail = p_thumbnail;
-    import_metadata[StringName("has_thumbnail")] = thumbnail.is_valid();
+
+    preview_image = p_image;
+    preview_texture_cache.unref();
+    import_metadata[StringName("has_thumbnail")] = preview_image.is_valid() && !preview_image->is_empty();
     emit_changed();
+}
+
+Ref<Texture2D> GaussianSplatAsset::get_preview_texture() const {
+    if (preview_texture_cache.is_valid()) {
+        return preview_texture_cache;
+    }
+
+    if (preview_image.is_null() || preview_image->is_empty()) {
+        return Ref<Texture2D>();
+    }
+
+    ERR_FAIL_COND_V_MSG(!Thread::is_main_thread(), Ref<Texture2D>(),
+            "GaussianSplatAsset preview textures must be created on the main thread.");
+
+    preview_texture_cache = ImageTexture::create_from_image(preview_image);
+    return preview_texture_cache;
+}
+
+void GaussianSplatAsset::set_thumbnail(const Ref<Texture2D> &p_thumbnail) {
+    if (p_thumbnail.is_null()) {
+        set_preview_image(Ref<Image>());
+        return;
+    }
+
+    ERR_FAIL_COND_MSG(!Thread::is_main_thread(),
+            "GaussianSplatAsset::set_thumbnail() can only convert textures on the main thread. Use set_preview_image() during threaded import.");
+    Ref<Image> image = p_thumbnail->get_image();
+    set_preview_image(image);
 }
 
 void GaussianSplatAsset::set_source_path(const String &p_path) {

--- a/modules/gaussian_splatting/core/gaussian_splat_asset.h
+++ b/modules/gaussian_splatting/core/gaussian_splat_asset.h
@@ -2,6 +2,7 @@
 #define GAUSSIAN_SPLAT_ASSET_H
 
 #include "core/io/resource.h"
+#include "core/io/image.h"
 #include "scene/resources/texture.h"
 #include "core/io/resource_loader.h"
 #include "core/math/quaternion.h"
@@ -12,6 +13,7 @@
 #include <atomic>
 
 class GaussianData;
+class ImageTexture;
 
 class GaussianSplatAsset : public Resource {
     GDCLASS(GaussianSplatAsset, Resource);
@@ -53,7 +55,8 @@ private:
     uint32_t compression_flags = COMPRESSION_NONE;
     String import_quality_preset = "high";
     Dictionary import_metadata;
-    Ref<Texture2D> thumbnail;
+    Ref<Image> preview_image;
+    mutable Ref<ImageTexture> preview_texture_cache;
     bool has_sh_dc_coefficients = false;
     mutable Ref<::GaussianData> gaussian_data_cache;
 
@@ -66,6 +69,9 @@ private:
 
 protected:
     static void _bind_methods();
+    bool _set(const StringName &p_name, const Variant &p_value);
+    bool _get(const StringName &p_name, Variant &r_ret) const;
+    void _get_property_list(List<PropertyInfo> *p_list) const;
 
 public:
     GaussianSplatAsset();
@@ -137,8 +143,12 @@ public:
     void set_compression_flags(uint32_t p_flags);
     uint32_t get_compression_flags() const { return compression_flags; }
 
+    void set_preview_image(const Ref<Image> &p_image);
+    Ref<Image> get_preview_image() const { return preview_image; }
+    Ref<Texture2D> get_preview_texture() const;
+
     void set_thumbnail(const Ref<Texture2D> &p_thumbnail);
-    Ref<Texture2D> get_thumbnail() const { return thumbnail; }
+    Ref<Texture2D> get_thumbnail() const { return get_preview_texture(); }
 
     void set_source_path(const String &p_path);
     String get_source_path() const;

--- a/modules/gaussian_splatting/core/gaussian_splat_manager.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_manager.cpp
@@ -1120,7 +1120,6 @@ void GaussianSplatManager::initialize_module() {
 	GLOBAL_DEF("rendering/gaussian_splatting/streaming/max_evictions_per_frame", 4);
 	// Async IO for gsplatworld sources.
 	GLOBAL_DEF("rendering/gaussian_splatting/streaming/async_io_enabled", false);
-	GLOBAL_DEF("rendering/gaussian_splatting/streaming/io_source_path", String());
 
 	// VRAM budget auto-regulation settings for streaming system (H3DGS-style).
 	// Enables graceful degradation when approaching memory limits.

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -109,7 +109,6 @@ static const StringName &WORLD_STREAMING_VRAM_BUDGET_MB() { static const StringN
 static const StringName &WORLD_STREAMING_VRAM_MIN_CHUNKS() { static const StringName s("vram_min_chunks"); return s; }
 static const StringName &WORLD_STREAMING_VRAM_MAX_CHUNKS() { static const StringName s("vram_max_chunks"); return s; }
 static const StringName &WORLD_STREAMING_OVERRIDE_IO_SOURCE() { static const StringName s("override_io_source"); return s; }
-static const StringName &WORLD_STREAMING_IO_SOURCE_PATH() { static const StringName s("io_source_path"); return s; }
 static const StringName &NODE_SCENE_EFFECTORS_ENABLED_PROPERTY() { static const StringName s("rendering/scene_effectors_enabled"); return s; }
 static const StringName &NODE_SCENE_EFFECTOR_LAYER_MASK_PROPERTY() { static const StringName s("rendering/scene_effector_layer_mask"); return s; }
 static const StringName &NODE_SCENE_EFFECTOR_SCOPE_ROOT_PROPERTY() { static const StringName s("rendering/scene_effector_scope_root"); return s; }
@@ -313,9 +312,6 @@ GaussianSplatRenderer::WorldSubmissionContract GaussianSplatSceneDirector::_buil
 		contract.streaming_overrides.override_io_source =
 				_dict_get_bool(streaming_dict, WORLD_STREAMING_OVERRIDE_IO_SOURCE(),
 						contract.streaming_overrides.override_io_source);
-		contract.streaming_overrides.io_source_path =
-				_dict_get_string(streaming_dict, WORLD_STREAMING_IO_SOURCE_PATH(),
-						contract.streaming_overrides.io_source_path);
 		if (contract.streaming_overrides.override_vram_budget) {
 			contract.streaming_overrides.vram_budget_config.min_chunks =
 					MIN(contract.streaming_overrides.vram_budget_config.min_chunks,

--- a/modules/gaussian_splatting/core/gaussian_splat_world.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_world.cpp
@@ -113,6 +113,10 @@ Array GaussianSplatWorld::get_chunk_aabbs() const {
 
 void GaussianSplatWorld::clear() {
     gaussian_data.unref();
+    // Payload source lifetime is tied to world liveness; leaving it live
+    // across clear() would retain file handles / in-memory splat data after
+    // the world has been logically emptied.
+    chunk_payload_source.unref();
     static_chunks.clear();
     bounds = AABB();
     metadata.clear();

--- a/modules/gaussian_splatting/core/streaming_config_overrides.h
+++ b/modules/gaussian_splatting/core/streaming_config_overrides.h
@@ -1,7 +1,6 @@
 #ifndef STREAMING_CONFIG_OVERRIDES_H
 #define STREAMING_CONFIG_OVERRIDES_H
 
-#include "core/string/ustring.h"
 #include "streaming_vram_regulator.h"
 #include "../lod/lod_config.h"
 
@@ -29,7 +28,6 @@ struct ConfigOverrides {
     uint32_t max_chunk_loads_per_frame = 0;
 
     bool override_io_source = false;
-    String io_source_path;
 
     bool has_any_override() const {
         return override_chunk_culling || override_prefetch || override_vram_budget ||

--- a/modules/gaussian_splatting/doc_classes/GaussianSplatContainer.xml
+++ b/modules/gaussian_splatting/doc_classes/GaussianSplatContainer.xml
@@ -4,7 +4,7 @@
 		Container node that merges child splat nodes into a single optimized dataset.
 	</brief_description>
 	<description>
-		GaussianSplatContainer collects GaussianSplatNode3D and GaussianSplatWorld3D children, merges their splat data into a single GaussianData resource with spatial chunking, and can apply the result to a target renderer or node. This enables rendering multiple assets as one draw call for improved performance. The container supports automatic merging on ready, chunk-based spatial subdivision, and export to GaussianSplatWorld resources. Prefer [method apply_to_node] or [method export_world_resource] for scene workflows; [method apply_to_renderer] remains a low-level compatibility helper while the direct renderer raw-data route still exists.
+		GaussianSplatContainer is an offline/tooling node that collects GaussianSplatNode3D and GaussianSplatWorld3D children, merges their splat data into a single GaussianData resource with spatial chunking, and applies the result to a target scene node. The container supports automatic merging on ready, chunk-based spatial subdivision, and export to GaussianSplatWorld resources. Use [method apply_to_node] or [method export_world_resource]; container output always flows through the canonical node/world scene surfaces.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -84,13 +84,6 @@
 			<return type="void" />
 			<description>
 				Clears the merged data and chunk information, releasing the internal GaussianData resource.
-			</description>
-		</method>
-		<method name="apply_to_renderer">
-			<return type="int" enum="Error" />
-			<param index="0" name="renderer" type="GaussianSplatRenderer" />
-			<description>
-				Applies the merged data and chunk layout to the given [param renderer]. This is a low-level compatibility helper; prefer [method apply_to_node] or [method export_world_resource] for normal scene workflows. Returns [constant OK] on success, or [constant ERR_UNAVAILABLE] if no merged data exists.
 			</description>
 		</method>
 		<method name="apply_to_node">

--- a/modules/gaussian_splatting/docs/CORE_DECOMPOSITION_ANALYSIS.md
+++ b/modules/gaussian_splatting/docs/CORE_DECOMPOSITION_ANALYSIS.md
@@ -48,7 +48,7 @@ Top 3 recommendations:
 - **Long term**: Move global atlas + residency into a dedicated registry module. This is the largest seam and will reduce complexity in streaming's main update loop.
 
 #### Notes / Potential dead or incomplete areas
-- `ConfigOverrides.override_io_source` exists in the header and is set from `gaussian_splat_world_3d.cpp`, but there is no usage in `gaussian_streaming.cpp`. This looks like an unimplemented override path worth either wiring or removing in a future cleanup.
+- `ConfigOverrides.override_io_source` is set from `gaussian_splat_world_3d.cpp` and consumed in `gaussian_streaming.cpp` to gate IO chunk layout reuse. The companion `io_source_path` string field was removed (no runtime reader); the flag is the only honest remaining knob.
 
 ---
 
@@ -106,8 +106,7 @@ This shows **strong coupling between core/data and renderer/IO/animation**, whic
 3. **Animation adapter**: separate animation caching and sampling from data storage to reduce incidental coupling.
 
 ### Low Priority / Future
-1. **Config override cleanup**: either implement `override_io_source` in streaming or remove unused override fields.
-2. **Telemetry consolidation**: move analytics snapshot assembly into a small utility class.
+1. **Telemetry consolidation**: move analytics snapshot assembly into a small utility class.
 
 ## Risk Assessment
 - **Risks**: high coupling to renderer and threading (upload queue), potential performance regressions if boundaries introduce extra copies or synchronization, subtle changes in streaming timing.

--- a/modules/gaussian_splatting/editor/gaussian_asset_preview_control.cpp
+++ b/modules/gaussian_splatting/editor/gaussian_asset_preview_control.cpp
@@ -145,7 +145,7 @@ void GaussianAssetPreviewControl::_update_fallback_texture() {
 
 	Ref<Texture2D> texture;
 	if (asset.is_valid()) {
-		texture = asset->get_thumbnail();
+		texture = asset->get_preview_texture();
 	}
 
 	if (texture.is_null() && thumbnail_generator.is_valid() && asset.is_valid() && asset->get_splat_count() > 0) {

--- a/modules/gaussian_splatting/editor/gaussian_editor_plugin.cpp
+++ b/modules/gaussian_splatting/editor/gaussian_editor_plugin.cpp
@@ -537,7 +537,7 @@ Ref<Texture2D> GaussianEditorPlugin::_resolve_asset_thumbnail(const Ref<Gaussian
         return Ref<Texture2D>();
     }
 
-    Ref<Texture2D> existing = p_asset->get_thumbnail();
+    Ref<Texture2D> existing = p_asset->get_preview_texture();
     if (existing.is_valid()) {
         return existing;
     }

--- a/modules/gaussian_splatting/editor/gaussian_resource_preview_generator.cpp
+++ b/modules/gaussian_splatting/editor/gaussian_resource_preview_generator.cpp
@@ -22,7 +22,7 @@ Ref<Texture2D> GaussianSplatAssetPreviewGenerator::generate(const Ref<Resource> 
 		return Ref<Texture2D>();
 	}
 
-	Ref<Texture2D> existing_thumbnail = asset->get_thumbnail();
+	Ref<Texture2D> existing_thumbnail = asset->get_preview_texture();
 	if (existing_thumbnail.is_valid()) {
 		p_metadata[StringName("gaussian_preview_source")] = String("stored_thumbnail");
 		return existing_thumbnail;

--- a/modules/gaussian_splatting/editor/gaussian_thumbnail_generator.cpp
+++ b/modules/gaussian_splatting/editor/gaussian_thumbnail_generator.cpp
@@ -7,6 +7,7 @@
 #include "core/math/color.h"
 #include "core/math/math_funcs.h"
 #include "core/math/quaternion.h"
+#include "core/os/thread.h"
 #include "core/templates/local_vector.h"
 #include "core/variant/dictionary.h"
 #include "scene/resources/image_texture.h"
@@ -181,29 +182,24 @@ String GaussianThumbnailGenerator::_disk_cache_path_for_key(uint64_t p_fingerpri
     return String(DISK_CACHE_DIR) + "/" + String::num_uint64(p_fingerprint, 16) + "_" + itos(p_size) + "_" + itos(int(p_style)) + ".png";
 }
 
-Ref<Texture2D> GaussianThumbnailGenerator::_load_from_disk_cache(uint64_t p_fingerprint, int p_size, ThumbnailStyle p_style) const {
+Ref<Image> GaussianThumbnailGenerator::_load_from_disk_cache(uint64_t p_fingerprint, int p_size, ThumbnailStyle p_style) const {
     String path = _disk_cache_path_for_key(p_fingerprint, p_size, p_style);
     if (!FileAccess::exists(path)) {
-        return Ref<Texture2D>();
+        return Ref<Image>();
     }
 
     Ref<Image> image;
     image.instantiate();
     Error err = image->load(path);
     if (err != OK || image->is_empty()) {
-        return Ref<Texture2D>();
+        return Ref<Image>();
     }
 
-    return ImageTexture::create_from_image(image);
+    return image;
 }
 
-void GaussianThumbnailGenerator::_save_to_disk_cache(uint64_t p_fingerprint, int p_size, ThumbnailStyle p_style, const Ref<Texture2D> &p_texture) const {
-    if (p_texture.is_null()) {
-        return;
-    }
-
-    Ref<Image> image = p_texture->get_image();
-    if (image.is_null() || image->is_empty()) {
+void GaussianThumbnailGenerator::_save_to_disk_cache(uint64_t p_fingerprint, int p_size, ThumbnailStyle p_style, const Ref<Image> &p_image) const {
+    if (p_image.is_null() || p_image->is_empty()) {
         return;
     }
 
@@ -212,7 +208,7 @@ void GaussianThumbnailGenerator::_save_to_disk_cache(uint64_t p_fingerprint, int
     }
 
     String path = _disk_cache_path_for_key(p_fingerprint, p_size, p_style);
-    image->save_png(path);
+    p_image->save_png(path);
 }
 
 Dictionary GaussianThumbnailGenerator::_project_to_canvas(const Ref<GaussianSplatAsset> &p_asset, int p_size,
@@ -304,7 +300,7 @@ Dictionary GaussianThumbnailGenerator::_project_to_canvas(const Ref<GaussianSpla
     return result;
 }
 
-Ref<Texture2D> GaussianThumbnailGenerator::_generate_color_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const {
+Ref<Image> GaussianThumbnailGenerator::_generate_color_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const {
     Vector<int> hits;
     Vector<Color> accum;
     _project_to_canvas(p_asset, p_size, hits, accum);
@@ -324,10 +320,10 @@ Ref<Texture2D> GaussianThumbnailGenerator::_generate_color_thumbnail(const Ref<G
         image->set_pixel(i % p_size, i / p_size, c);
     }
 
-    return ImageTexture::create_from_image(image);
+    return image;
 }
 
-Ref<Texture2D> GaussianThumbnailGenerator::_generate_density_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const {
+Ref<Image> GaussianThumbnailGenerator::_generate_density_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const {
     Vector<int> hits;
     Vector<Color> accum;
     _project_to_canvas(p_asset, p_size, hits, accum);
@@ -350,10 +346,10 @@ Ref<Texture2D> GaussianThumbnailGenerator::_generate_density_thumbnail(const Ref
         image->set_pixel(i % p_size, i / p_size, c);
     }
 
-    return ImageTexture::create_from_image(image);
+    return image;
 }
 
-Ref<Texture2D> GaussianThumbnailGenerator::_generate_normals_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const {
+Ref<Image> GaussianThumbnailGenerator::_generate_normals_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const {
     Vector<int> hits;
     Vector<Color> accum;
     Dictionary projection = _project_to_canvas(p_asset, p_size, hits, accum);
@@ -429,10 +425,10 @@ Ref<Texture2D> GaussianThumbnailGenerator::_generate_normals_thumbnail(const Ref
         image->set_pixel(i % p_size, i / p_size, c);
     }
 
-    return ImageTexture::create_from_image(image);
+    return image;
 }
 
-Ref<Texture2D> GaussianThumbnailGenerator::_generate_heatmap_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const {
+Ref<Image> GaussianThumbnailGenerator::_generate_heatmap_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const {
     Vector<int> hits;
     Vector<Color> accum;
     _project_to_canvas(p_asset, p_size, hits, accum);
@@ -459,21 +455,21 @@ Ref<Texture2D> GaussianThumbnailGenerator::_generate_heatmap_thumbnail(const Ref
         image->set_pixel(i % p_size, i / p_size, c);
     }
 
-    return ImageTexture::create_from_image(image);
+    return image;
 }
 
-Ref<Texture2D> GaussianThumbnailGenerator::generate_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size,
+Ref<Image> GaussianThumbnailGenerator::generate_thumbnail_image(const Ref<GaussianSplatAsset> &p_asset, int p_size,
         ThumbnailStyle p_style) const {
-    ERR_FAIL_COND_V(p_size <= 0, Ref<Texture2D>());
-    ERR_FAIL_COND_V(p_asset.is_null(), Ref<Texture2D>());
-    ERR_FAIL_COND_V(p_asset->get_splat_count() == 0, Ref<Texture2D>());
+    ERR_FAIL_COND_V(p_size <= 0, Ref<Image>());
+    ERR_FAIL_COND_V(p_asset.is_null(), Ref<Image>());
+    ERR_FAIL_COND_V(p_asset->get_splat_count() == 0, Ref<Image>());
 
     const String cache_key = _build_cache_key(p_asset, p_size, p_style);
     const uint64_t fingerprint = _compute_asset_fingerprint(p_asset);
 
     // Check in-memory cache first.
     if (!cache_key.is_empty()) {
-        const Ref<Texture2D> *cached = thumbnail_cache.getptr(cache_key);
+        const Ref<Image> *cached = thumbnail_cache.getptr(cache_key);
         if (cached && cached->is_valid()) {
             cache_hit_count++;
             _touch_cache_key(cache_key);
@@ -483,7 +479,7 @@ Ref<Texture2D> GaussianThumbnailGenerator::generate_thumbnail(const Ref<Gaussian
 
     // Check disk cache before generating.
     if (fingerprint != 0) {
-        Ref<Texture2D> disk_cached = _load_from_disk_cache(fingerprint, p_size, p_style);
+        Ref<Image> disk_cached = _load_from_disk_cache(fingerprint, p_size, p_style);
         if (disk_cached.is_valid()) {
             disk_cache_hit_count++;
             if (!cache_key.is_empty()) {
@@ -497,7 +493,7 @@ Ref<Texture2D> GaussianThumbnailGenerator::generate_thumbnail(const Ref<Gaussian
     }
 
     cache_miss_count++;
-    Ref<Texture2D> generated;
+    Ref<Image> generated;
 
     switch (p_style) {
         case THUMBNAIL_STYLE_COLOR:
@@ -531,6 +527,18 @@ Ref<Texture2D> GaussianThumbnailGenerator::generate_thumbnail(const Ref<Gaussian
     }
 
     return generated;
+}
+
+Ref<Texture2D> GaussianThumbnailGenerator::generate_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size,
+        ThumbnailStyle p_style) const {
+    Ref<Image> image = generate_thumbnail_image(p_asset, p_size, p_style);
+    if (image.is_null() || image->is_empty()) {
+        return Ref<Texture2D>();
+    }
+
+    ERR_FAIL_COND_V_MSG(!Thread::is_main_thread(), Ref<Texture2D>(),
+            "GaussianThumbnailGenerator::generate_thumbnail() must only wrap textures on the main thread.");
+    return ImageTexture::create_from_image(image);
 }
 
 Dictionary GaussianThumbnailGenerator::compute_memory_statistics(uint32_t p_splat_count, uint32_t p_compression_flags,

--- a/modules/gaussian_splatting/editor/gaussian_thumbnail_generator.cpp
+++ b/modules/gaussian_splatting/editor/gaussian_thumbnail_generator.cpp
@@ -536,8 +536,11 @@ Ref<Texture2D> GaussianThumbnailGenerator::generate_thumbnail(const Ref<Gaussian
         return Ref<Texture2D>();
     }
 
-    ERR_FAIL_COND_V_MSG(!Thread::is_main_thread(), Ref<Texture2D>(),
-            "GaussianThumbnailGenerator::generate_thumbnail() must only wrap textures on the main thread.");
+    // Safe to call from `EditorResourcePreview`'s worker threads in editor
+    // mode: the main thread pumps the RS command queue so the sync RS call
+    // chain underneath `create_from_image` completes. The `--headless
+    // --import` deadlock case that motivated #251 is avoided by having the
+    // importer call `generate_thumbnail_image()` directly (no RS calls).
     return ImageTexture::create_from_image(image);
 }
 

--- a/modules/gaussian_splatting/editor/gaussian_thumbnail_generator.h
+++ b/modules/gaussian_splatting/editor/gaussian_thumbnail_generator.h
@@ -3,6 +3,7 @@
 
 #ifdef TOOLS_ENABLED
 
+#include "core/io/image.h"
 #include "core/math/color.h"
 #include "core/math/vector3.h"
 #include "core/object/ref_counted.h"
@@ -28,7 +29,7 @@ private:
     static constexpr int MAX_CACHE_ENTRIES = 64;
     static const char *DISK_CACHE_DIR;
 
-    mutable HashMap<String, Ref<Texture2D>> thumbnail_cache;
+    mutable HashMap<String, Ref<Image>> thumbnail_cache;
     mutable Vector<String> thumbnail_cache_order;
     mutable uint64_t cache_hit_count = 0;
     mutable uint64_t cache_miss_count = 0;
@@ -42,19 +43,20 @@ private:
 
     // Disk cache helpers.
     String _disk_cache_path_for_key(uint64_t p_fingerprint, int p_size, ThumbnailStyle p_style) const;
-    Ref<Texture2D> _load_from_disk_cache(uint64_t p_fingerprint, int p_size, ThumbnailStyle p_style) const;
-    void _save_to_disk_cache(uint64_t p_fingerprint, int p_size, ThumbnailStyle p_style, const Ref<Texture2D> &p_texture) const;
+    Ref<Image> _load_from_disk_cache(uint64_t p_fingerprint, int p_size, ThumbnailStyle p_style) const;
+    void _save_to_disk_cache(uint64_t p_fingerprint, int p_size, ThumbnailStyle p_style, const Ref<Image> &p_image) const;
     bool _ensure_disk_cache_dir() const;
 
-    Ref<Texture2D> _generate_color_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const;
-    Ref<Texture2D> _generate_density_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const;
-    Ref<Texture2D> _generate_normals_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const;
-    Ref<Texture2D> _generate_heatmap_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const;
+    Ref<Image> _generate_color_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const;
+    Ref<Image> _generate_density_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const;
+    Ref<Image> _generate_normals_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const;
+    Ref<Image> _generate_heatmap_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const;
 
     Dictionary _project_to_canvas(const Ref<GaussianSplatAsset> &p_asset, int p_size, Vector<int> &r_hits,
             Vector<Color> &r_accum) const;
 
 public:
+    Ref<Image> generate_thumbnail_image(const Ref<GaussianSplatAsset> &p_asset, int p_size, ThumbnailStyle p_style) const;
     Ref<Texture2D> generate_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size, ThumbnailStyle p_style) const;
     Dictionary compute_memory_statistics(uint32_t p_splat_count, uint32_t p_compression_flags, bool p_pack_opacity) const;
     int get_cache_entry_count() const;

--- a/modules/gaussian_splatting/io/gaussian_data_loader.cpp
+++ b/modules/gaussian_splatting/io/gaussian_data_loader.cpp
@@ -1,5 +1,6 @@
 #include "gaussian_data_loader.h"
 
+#include "../logger/gs_logger.h"
 #include "ply_loader.h"
 #include "spz_loader.h"
 
@@ -24,6 +25,13 @@ Error load_gaussian_data_from_file(const String &p_path, GaussianDataLoadResult 
         r_result.data = gaussian_data;
         r_result.used_spz = true;
         return OK;
+    }
+
+    if (extension != "ply") {
+        GS_LOG_ERROR_DEFAULT(vformat(
+                "Unsupported Gaussian splat raw format '%s' for path: %s. Supported extensions: .ply, .spz.",
+                extension, p_path));
+        return ERR_FILE_UNRECOGNIZED;
     }
 
     Ref<PLYLoader> ply_loader;

--- a/modules/gaussian_splatting/io/gaussian_splat_world_io.cpp
+++ b/modules/gaussian_splatting/io/gaussian_splat_world_io.cpp
@@ -418,9 +418,9 @@ Ref<Resource> ResourceFormatLoaderGaussianSplatWorld::load(const String &p_path,
 	world->set_metadata(file_metadata);
 	world->set_static_chunks(chunks);
 
-	// For uncompressed files, create a file-backed payload source so the streaming
-	// system can load chunk payloads on demand without retaining the full gaussian
-	// array in process memory.
+	// Only uncompressed files support file-backed chunk payload reads. Compressed
+	// .gsplatworld files are resident-only: the decoded payload lives in memory on
+	// the GaussianData above and no staged-file payload source is attached.
 	if (!gaussian_data_compressed) {
 		Ref<StagedFileChunkPayloadSource> file_source;
 		file_source.instantiate();

--- a/modules/gaussian_splatting/io/ply_loader.cpp
+++ b/modules/gaussian_splatting/io/ply_loader.cpp
@@ -53,13 +53,6 @@ static bool _is_ply_cache_enabled() {
     return true;
 }
 
-static bool _is_ascii_strict_parse_enabled() {
-    if (ProjectSettings *ps = ProjectSettings::get_singleton()) {
-        return GaussianSplattingIO::get_bool_setting(ps, "rendering/gaussian_splatting/import/ply_ascii_strict_parse", true);
-    }
-    return true;
-}
-
 } // namespace
 
 PLYLoader::PLYLoader() {
@@ -572,7 +565,6 @@ Error PLYLoader::parse_binary_data(Ref<FileAccess> file) {
 
 Error PLYLoader::parse_ascii_data(Ref<FileAccess> file) {
     gaussian_data->resize(header.vertex_count);
-    const bool strict_ascii_parse = _is_ascii_strict_parse_enabled();
 
     // Check if normal properties exist to determine 2D mode
     bool has_normals = (find_property_index("nx") >= 0 &&
@@ -615,14 +607,10 @@ Error PLYLoader::parse_ascii_data(Ref<FileAccess> file) {
         Vector<String> values = line.split_spaces();
 
         if (values.size() < header.properties.size()) {
-            String msg = vformat("[PLY ASCII] Malformed row at vertex index %d: expected at least %d fields, got %d.",
-                    i, header.properties.size(), values.size());
-            if (strict_ascii_parse) {
-                GS_LOG_ERROR_DEFAULT(msg + " Treating file as corrupt.");
-                return ERR_FILE_CORRUPT;
-            }
-            WARN_PRINT(msg + " Skipping row because strict parsing is disabled.");
-            continue;
+            GS_LOG_ERROR_DEFAULT(vformat(
+                    "[PLY ASCII] Malformed row at vertex index %d: expected at least %d fields, got %d. Treating file as corrupt.",
+                    i, header.properties.size(), values.size()));
+            return ERR_FILE_CORRUPT;
         }
 
         Gaussian g;
@@ -645,7 +633,7 @@ Error PLYLoader::parse_ascii_data(Ref<FileAccess> file) {
         for (int j = 0; j < header.properties.size(); j++) {
             const PLYProperty &prop = header.properties[j];
             const String &token = values[j];
-            if (strict_ascii_parse && !token.is_valid_float()) {
+            if (!token.is_valid_float()) {
                 GS_LOG_ERROR_DEFAULT(vformat("[PLY ASCII] Invalid numeric token at vertex index %d property '%s' (column %d): '%s'.",
                         i, prop.name, j, token));
                 return ERR_FILE_CORRUPT;

--- a/modules/gaussian_splatting/io/resource_importer_ply.cpp
+++ b/modules/gaussian_splatting/io/resource_importer_ply.cpp
@@ -13,8 +13,6 @@
 #include "core/string/print_string.h"
 #include "core/templates/vector.h"
 #include "core/variant/dictionary.h"
-#include "scene/resources/texture.h"
-
 #include "../core/gaussian_data.h"
 #include "../editor/gaussian_thumbnail_generator.h"
 #include "../logger/gs_logger.h"
@@ -303,7 +301,7 @@ Error ResourceImporterPLY::import(ResourceUID::ID p_source_id, const String &p_s
     int thumbnail_size = _get_int_option(p_options, OPTION_THUMBNAIL_SIZE, StringName(), preset.default_thumbnail_size);
     bool include_stats = _get_bool_option(p_options, OPTION_INCLUDE_STATS, StringName(), preset.include_statistics);
     bool include_memory = _get_bool_option(p_options, OPTION_INCLUDE_MEMORY, StringName(), preset.include_memory_estimate);
-    bool customized = _get_bool_option(p_options, OPTION_CUSTOMIZED, StringName(), false);
+    bool customized = _get_bool_option(p_options, OPTION_CUSTOMIZED, StringName(), false) || legacy_pack_opacity_requested;
 
     thumbnail_style = CLAMP(thumbnail_style, 0, 3);
     thumbnail_size = CLAMP(thumbnail_size, 32, 512);
@@ -379,17 +377,15 @@ Error ResourceImporterPLY::import(ResourceUID::ID p_source_id, const String &p_s
 
     uint32_t compression_flags = _build_compression_flags(quantize_positions, quantize_colors, quantize_scales, quantize_rotations);
     asset->set_compression_flags(compression_flags);
-    asset->set_source_path(p_source_file);
-
-    Ref<Texture2D> thumbnail;
+    Ref<Image> thumbnail;
     if (generate_thumbnail) {
         Ref<GaussianThumbnailGenerator> generator;
         generator.instantiate();
-        thumbnail = generator->generate_thumbnail(asset, thumbnail_size,
+        thumbnail = generator->generate_thumbnail_image(asset, thumbnail_size,
                 GaussianThumbnailGenerator::style_from_int(thumbnail_style));
-        asset->set_thumbnail(thumbnail);
+        asset->set_preview_image(thumbnail);
     } else {
-        asset->set_thumbnail(Ref<Texture2D>());
+        asset->set_preview_image(Ref<Image>());
     }
 
     Dictionary option_dict;
@@ -407,6 +403,7 @@ Error ResourceImporterPLY::import(ResourceUID::ID p_source_id, const String &p_s
     option_dict[OPTION_QUANTIZE_COLORS] = quantize_colors;
     option_dict[OPTION_QUANTIZE_SCALES] = quantize_scales;
     option_dict[OPTION_QUANTIZE_ROTATIONS] = quantize_rotations;
+    option_dict[OPTION_PACK_OPACITY] = legacy_pack_opacity_requested;
     option_dict[OPTION_GENERATE_THUMBNAIL] = generate_thumbnail;
     option_dict[OPTION_THUMBNAIL_STYLE] = thumbnail_style;
     option_dict[OPTION_THUMBNAIL_SIZE] = thumbnail_size;
@@ -455,6 +452,7 @@ Error ResourceImporterPLY::import(ResourceUID::ID p_source_id, const String &p_s
     import_metadata[StringName("bounds")] = bounds;
 
     asset->set_import_metadata(import_metadata);
+    asset->set_source_path(p_source_file);
 
     String save_path = p_save_path + "." + get_save_extension();
     err = ResourceSaver::save(asset, save_path);

--- a/modules/gaussian_splatting/io/resource_importer_ply.h
+++ b/modules/gaussian_splatting/io/resource_importer_ply.h
@@ -23,14 +23,7 @@ public:
 
     virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
-    // Import runs on a WorkerThreadPool thread when this returns true, but our
-    // thumbnail path (ResourceSaver::save -> ImageTexture::_get("image") ->
-    // RenderingServer::texture_2d_get) is FUNC1RC = synchronous push_and_ret to
-    // the render thread. In `--headless --import` the main thread sits in
-    // EditorFileSystem's ep->step busy-loop and never pumps the RS command
-    // queue, so every worker deadlocks. Force serial import until the
-    // thumbnail pipeline no longer takes a sync RS round-trip.
-    virtual bool can_import_threaded() const override { return false; }
+    virtual bool can_import_threaded() const override { return true; }
     virtual bool has_advanced_options() const override;
     virtual void show_advanced_options(const String &p_path) override;
 
@@ -46,7 +39,10 @@ public:
     //       resize_initialized() instead of resize() for POD vectors).
     //       Caches written by v0/v1 may contain 0xC0C0C0C0 poison and must
     //       be re-imported.
-    virtual int get_format_version() const override { return 2; }
+    //   v3: preview thumbnails now serialize as Image resources instead of
+    //       ImageTexture to avoid threaded importer deadlocks under
+    //       `--headless --import`.
+    virtual int get_format_version() const override { return 3; }
 
     // Validation helpers
     Error validate_ply_properties(const Ref<class PLYLoader> &p_loader) const;

--- a/modules/gaussian_splatting/io/resource_importer_spz.cpp
+++ b/modules/gaussian_splatting/io/resource_importer_spz.cpp
@@ -13,8 +13,6 @@
 #include "core/string/print_string.h"
 #include "core/templates/vector.h"
 #include "core/variant/dictionary.h"
-#include "scene/resources/texture.h"
-
 #include "../core/gaussian_data.h"
 #include "../editor/gaussian_thumbnail_generator.h"
 #include "../logger/gs_logger.h"
@@ -346,19 +344,37 @@ Error ResourceImporterSPZ::import(ResourceUID::ID p_source_id, const String &p_s
 
     uint32_t compression_flags = _build_compression_flags(quantize_positions, quantize_colors, quantize_scales, quantize_rotations);
     asset->set_compression_flags(compression_flags);
-    asset->set_source_path(p_source_file);
-
     // Generate thumbnail
-    Ref<Texture2D> thumbnail;
+    Ref<Image> thumbnail;
     if (generate_thumbnail) {
         Ref<GaussianThumbnailGenerator> generator;
         generator.instantiate();
-        thumbnail = generator->generate_thumbnail(asset, thumbnail_size,
+        thumbnail = generator->generate_thumbnail_image(asset, thumbnail_size,
                 GaussianThumbnailGenerator::style_from_int(thumbnail_style));
-        asset->set_thumbnail(thumbnail);
+        asset->set_preview_image(thumbnail);
     } else {
-        asset->set_thumbnail(Ref<Texture2D>());
+        asset->set_preview_image(Ref<Image>());
     }
+
+    Dictionary option_dict;
+    option_dict[OPTION_PRESET] = preset_name;
+    option_dict[OPTION_ASSET_TYPE] = asset_type_value;
+    option_dict[OPTION_MAX_SPLATS] = max_splats;
+    option_dict[OPTION_DENSITY] = density_multiplier;
+    option_dict[OPTION_ENABLE_LOD] = enable_lod;
+    option_dict[OPTION_OPTIMIZE_GPU] = optimize_for_gpu;
+    option_dict[OPTION_NORMALIZE_OPACITY] = normalize_opacity;
+    option_dict[OPTION_SORT_OPACITY] = sort_by_opacity;
+    option_dict[OPTION_QUANTIZE_POSITIONS] = quantize_positions;
+    option_dict[OPTION_QUANTIZE_COLORS] = quantize_colors;
+    option_dict[OPTION_QUANTIZE_SCALES] = quantize_scales;
+    option_dict[OPTION_QUANTIZE_ROTATIONS] = quantize_rotations;
+    option_dict[OPTION_PACK_OPACITY] = legacy_pack_opacity_requested;
+    option_dict[OPTION_GENERATE_THUMBNAIL] = generate_thumbnail;
+    option_dict[OPTION_THUMBNAIL_STYLE] = thumbnail_style;
+    option_dict[OPTION_THUMBNAIL_SIZE] = thumbnail_size;
+    option_dict[OPTION_INCLUDE_STATS] = include_stats;
+    option_dict[OPTION_INCLUDE_MEMORY] = include_memory;
 
     // Build metadata
     Dictionary import_metadata;
@@ -378,6 +394,7 @@ Error ResourceImporterSPZ::import(ResourceUID::ID p_source_id, const String &p_s
     import_metadata[StringName("normalize_opacity")] = normalize_opacity;
     import_metadata[StringName("sort_by_opacity")] = sort_by_opacity;
     import_metadata[StringName("compression_flags")] = int(compression_flags);
+    import_metadata[StringName("options")] = option_dict;
     import_metadata[StringName("thumbnail_generated")] = generate_thumbnail;
     import_metadata[StringName("thumbnail_style")] = thumbnail_style;
     import_metadata[StringName("thumbnail_size")] = thumbnail_size;
@@ -406,6 +423,7 @@ Error ResourceImporterSPZ::import(ResourceUID::ID p_source_id, const String &p_s
     import_metadata[StringName("bounds")] = bounds;
 
     asset->set_import_metadata(import_metadata);
+    asset->set_source_path(p_source_file);
 
     // Save asset
     String save_path = p_save_path + "." + get_save_extension();

--- a/modules/gaussian_splatting/io/resource_importer_spz.h
+++ b/modules/gaussian_splatting/io/resource_importer_spz.h
@@ -32,17 +32,13 @@ public:
             const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants,
             List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
-    // Same deadlock as ResourceImporterPLY — thumbnail generation does a
-    // synchronous RenderingServer::texture_2d_get round-trip, which hangs on
-    // worker threads under `--headless --import`.
-    virtual bool can_import_threaded() const override { return false; }
+    virtual bool can_import_threaded() const override { return true; }
     virtual bool has_advanced_options() const override;
     virtual void show_advanced_options(const String &p_path) override;
 
     // See ResourceImporterPLY::get_format_version() for the bump rationale.
-    // SPZ assets share the GaussianSplatAsset deserialization path, so the
-    // same _ensure_buffer_sizes() zero-init fix applies.
-    virtual int get_format_version() const override { return 2; }
+    // SPZ assets share the GaussianSplatAsset deserialization path.
+    virtual int get_format_version() const override { return 3; }
 
     ResourceImporterSPZ();
 };

--- a/modules/gaussian_splatting/nodes/README.md
+++ b/modules/gaussian_splatting/nodes/README.md
@@ -17,14 +17,13 @@ container.apply_to_node($MergedWorldRenderer)  # GaussianSplatNode3D
 
 Methods:
 - `merge_children()` – build merged data + chunk cache.
-- `apply_to_renderer(renderer)` – legacy low-level convenience helper that pushes merged data + static chunks into a renderer. Prefer `apply_to_node(node)` or `export_world_resource()` for normal scene workflows.
 - `apply_to_node(node)` – convenience wrapper for GaussianSplatNode3D and GaussianSplatWorld3D targets.
 - `merge_children_to_node(node)` – merge + apply in one step.
 - `export_world_resource()` – build a GaussianSplatWorld resource from merged data.
 
-Note: `apply_to_renderer()` bypasses the canonical node/world submission flow and
-is kept only as a low-level convenience while direct raw-data renderer binding
-still exists.
+`GaussianSplatContainer` is an offline/tooling node: its output always flows
+through `GaussianSplatNode3D` or `GaussianSplatWorld3D`. Direct renderer binding
+has been removed.
 
 Optional properties:
 - `apply_to_target_on_merge`: auto-apply after merge.

--- a/modules/gaussian_splatting/nodes/gaussian_splat_container.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_container.cpp
@@ -22,7 +22,6 @@ void GaussianSplatContainer::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_target_node_path"), &GaussianSplatContainer::get_target_node_path);
     ClassDB::bind_method(D_METHOD("merge_children"), &GaussianSplatContainer::merge_children);
     ClassDB::bind_method(D_METHOD("clear_merged_data"), &GaussianSplatContainer::clear_merged_data);
-    ClassDB::bind_method(D_METHOD("apply_to_renderer", "renderer"), &GaussianSplatContainer::apply_to_renderer);
     ClassDB::bind_method(D_METHOD("apply_to_node", "node"), &GaussianSplatContainer::apply_to_node);
     ClassDB::bind_method(D_METHOD("merge_children_to_node", "node"), &GaussianSplatContainer::merge_children_to_node);
     ClassDB::bind_method(D_METHOD("export_world_resource"), &GaussianSplatContainer::export_world_resource);
@@ -81,23 +80,6 @@ void GaussianSplatContainer::merge_children() {
             apply_to_node(target);
         }
     }
-}
-
-Error GaussianSplatContainer::apply_to_renderer(const Ref<GaussianSplatRenderer> &p_renderer) {
-    ERR_FAIL_COND_V(p_renderer.is_null(), ERR_INVALID_PARAMETER);
-    WARN_PRINT_ONCE("GaussianSplatContainer::apply_to_renderer() is a low-level compatibility helper. Prefer apply_to_node() or export_world_resource() for scene workflows.");
-    if (merged_data.is_null() || merged_data->get_count() == 0) {
-        GS_LOG_WARN_DEFAULT("GaussianSplatContainer: no merged data available to apply.");
-        return ERR_UNAVAILABLE;
-    }
-
-    Error err = p_renderer->set_gaussian_data(merged_data);
-    if (err != OK) {
-        GS_LOG_WARN_DEFAULT(vformat("GaussianSplatContainer: failed to apply merged data (err=%d).", err));
-        return err;
-    }
-    p_renderer->set_static_chunks(merged_chunks);
-    return OK;
 }
 
 Error GaussianSplatContainer::apply_to_node(Node *p_node) {

--- a/modules/gaussian_splatting/nodes/gaussian_splat_container.h
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_container.h
@@ -51,16 +51,6 @@ public:
 
     void merge_children();
     void clear_merged_data();
-    /**
-     * @brief Legacy low-level convenience helper that pushes merged data
-     * directly into a renderer.
-     *
-     * Prefer apply_to_node() or export_world_resource() for normal scene
-     * workflows so data flows through the canonical node/world submission path.
-     * Kept for low-level tooling while the direct raw-data renderer route still
-     * exists.
-     */
-    Error apply_to_renderer(const Ref<GaussianSplatRenderer> &p_renderer);
     Error apply_to_node(Node *p_node);
     Error merge_children_to_node(Node *p_node);
     Ref<GaussianSplatWorld> export_world_resource() const;

--- a/modules/gaussian_splatting/nodes/gaussian_splat_world_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_world_3d.cpp
@@ -294,7 +294,6 @@ Dictionary GaussianSplatWorld3D::_build_desired_renderer_overrides() const {
     const String world_path = world.is_valid() ? world->get_path() : String();
     if (!world_path.is_empty() && world_path.get_extension().to_lower() == "gsplatworld") {
         streaming_overrides[StringName("override_io_source")] = true;
-        streaming_overrides[StringName("io_source_path")] = world_path;
     }
 
     overrides[StringName("streaming")] = streaming_overrides;

--- a/modules/gaussian_splatting/persistence/gaussian_scene_serializer.cpp
+++ b/modules/gaussian_splatting/persistence/gaussian_scene_serializer.cpp
@@ -436,13 +436,24 @@ Error GaussianSceneSerializer::_read_gaussian_data_chunk(Ref<FileAccess> file, c
     const uint64_t expected_payload_size = sizeof(uint32_t) + uint64_t(count) * sizeof(Gaussian);
     ERR_FAIL_COND_V(expected_payload_size > uint64_t(payload.size()), ERR_FILE_CORRUPT);
 
-    gaussian_data->resize(count);
+    // Reconstruct through the canonical bulk setter so octree, overlays,
+    // animation caches, SH first-order count, and content revision are all
+    // invalidated/recomputed in one place. The previous resize()+set_gaussian()
+    // loop left sh_first_order_count at 0 because set_gaussian does not scan
+    // sh_1[] to rederive SH metadata.
+    //
+    // Format limitation: the GAUSSIAN_DATA chunk carries only the per-splat
+    // `Gaussian` struct bytes (which embed the first-order SH triplet `sh_1[3]`).
+    // The high-order SH sidecar (`sh_high_order_coefficients`) is NOT persisted
+    // by this format, and the 2D-mode flag is not persisted either. After load
+    // both reset to defaults (sh_high_order_count == 0, is_2d_mode == false).
+    // Callers that need high-order SH must persist it outside this serializer.
+    LocalVector<Gaussian> loaded_gaussians;
     if (count > 0) {
-        const Gaussian *gaussians = reinterpret_cast<const Gaussian *>(r + sizeof(uint32_t));
-        for (uint32_t i = 0; i < count; i++) {
-            gaussian_data->set_gaussian(i, gaussians[i]);
-        }
+        loaded_gaussians.resize(count);
+        memcpy(loaded_gaussians.ptr(), r + sizeof(uint32_t), uint64_t(count) * sizeof(Gaussian));
     }
+    gaussian_data->set_gaussians(loaded_gaussians);
 
     return OK;
 }

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
@@ -1391,7 +1391,6 @@ GaussianSplatRenderer::FrameBackendPlan GaussianSplatRenderer::build_frame_backe
     plan.streaming_ready = p_streaming_ready;
     plan.should_attempt_streaming_bootstrap =
             plan.streaming_requested && !plan.prefer_resident_backend && !plan.streaming_ready;
-    plan.allow_legacy_resident_fallback = !plan.streaming_requested;
     // Allow the streaming path to inject a synthetic identity instance when
     // the SceneDirector has no instances and no world submission is active.
     // World submissions (gsplatworld) own the streaming cull/sort/raster
@@ -1983,8 +1982,7 @@ void GaussianSplatRenderer::_reset_legacy_streaming_data_path_state() {
 bool GaussianSplatRenderer::_try_render_resident_frame(RenderDataRD *p_render_data,
         const Transform3D &p_world_to_camera_transform, const Projection &p_projection,
         const Projection &p_render_projection, RenderSceneBuffersRD *p_render_buffers,
-        bool p_allow_legacy_resident_fallback, String *r_reason) {
-    // Fallback to test data if streaming is not active.
+        String *r_reason) {
     _reset_legacy_streaming_data_path_state();
 
     if (r_reason) {
@@ -1997,9 +1995,6 @@ bool GaussianSplatRenderer::_try_render_resident_frame(RenderDataRD *p_render_da
     if (has_buffer_manager_data) {
         has_buffer_manager_data = get_resource_state().buffer_manager->get_gaussian_count() > 0;
     }
-
-    // Legacy instance transforms removed; use the view transform directly.
-    Transform3D effective_view_transform = p_world_to_camera_transform;
 
 #if defined(DEBUG_ENABLED) || kLogFrameDebug
     // DEBUG: Log instance transform in resident path
@@ -2017,17 +2012,7 @@ bool GaussianSplatRenderer::_try_render_resident_frame(RenderDataRD *p_render_da
         if (r_reason) {
             *r_reason = "no_render_data";
         }
-        if (!p_allow_legacy_resident_fallback) {
-            return false;
-        }
-        _run_cull_sort_pipeline_frame(p_render_data, effective_view_transform, p_projection, p_render_projection,
-                p_render_buffers, false,
-                "Cull skipped: no render data",
-                "Sort skipped: no render data",
-                RenderFallbackReason::DATA_UNAVAILABLE,
-                RenderFallbackReason::DATA_UNAVAILABLE,
-                true, true);
-        return true;
+        return false;
     }
 
     String resident_contract_reason = "resident_contract_published";
@@ -2055,26 +2040,13 @@ bool GaussianSplatRenderer::_try_render_resident_frame(RenderDataRD *p_render_da
     if (r_reason) {
         *r_reason = resident_contract_reason;
     }
-    if (!p_allow_legacy_resident_fallback) {
-        return false;
-    }
-    WARN_PRINT_ONCE(vformat("[GaussianSplatRenderer] Resident instance contract not ready; falling back to legacy resident path (%s).",
-            resident_contract_reason));
-    _run_cull_sort_pipeline_frame(p_render_data, effective_view_transform, p_projection, p_render_projection,
-            p_render_buffers, true,
-            String(),
-            String(),
-            RenderFallbackReason::NONE,
-            RenderFallbackReason::NONE,
-            false, false);
-    return true;
+    return false;
 }
 
 void GaussianSplatRenderer::_render_resident_frame(RenderDataRD *p_render_data, const Transform3D &p_world_to_camera_transform,
-        const Projection &p_projection, const Projection &p_render_projection, RenderSceneBuffersRD *p_render_buffers,
-        bool p_allow_legacy_resident_fallback) {
+        const Projection &p_projection, const Projection &p_render_projection, RenderSceneBuffersRD *p_render_buffers) {
     _try_render_resident_frame(p_render_data, p_world_to_camera_transform, p_projection,
-            p_render_projection, p_render_buffers, p_allow_legacy_resident_fallback, nullptr);
+            p_render_projection, p_render_buffers, nullptr);
 }
 
 void GaussianSplatRenderer::render_scene_instance(RenderDataRD *p_render_data) {
@@ -2245,7 +2217,7 @@ void GaussianSplatRenderer::render_scene_instance(RenderDataRD *p_render_data) {
     if (backend_plan.prefer_resident_backend) {
         String resident_attempt_reason;
         if (_try_render_resident_frame(p_render_data, view_transform, cam_projection, render_projection,
-                    render_buffers_rd, backend_plan.allow_legacy_resident_fallback, &resident_attempt_reason)) {
+                    render_buffers_rd, &resident_attempt_reason)) {
             _set_instance_backend_diagnostics(InstanceBackendPolicy::RESIDENT,
                     backend_plan.resident_backend_reason,
                     is_instance_contract_ready(),
@@ -2283,44 +2255,36 @@ void GaussianSplatRenderer::render_scene_instance(RenderDataRD *p_render_data) {
                     get_instance_contract_shape());
             return;
         }
+    }
+    // Streaming was requested. Either bootstrap failed, ready state was false, or
+    // render_streaming_frame() rejected the frame. Hard-fail with the typed skip
+    // route rather than silently falling through to the resident render path —
+    // that bounce is exactly the fallback-for-fallback sprawl we are retiring.
+    if (backend_plan.streaming_requested) {
         String fallback_route_uid;
         if (debug_state_orchestrator) {
             DebugState &debug_state = get_debug_state();
-            if (debug_state.route_uid.is_empty() ||
-                    debug_state.route_uid == RenderRouteUID::INSTANCE_STREAMING ||
-                    debug_state.route_uid == RenderRouteUID::COMMON_SKIP_STREAMING_NOT_READY) {
-                debug_state.route_uid = _streaming_not_ready_route_uid("UNKNOWN");
+            const bool prior_is_typed = !debug_state.route_uid.is_empty() &&
+                    _is_typed_streaming_not_ready_route(debug_state.route_uid) &&
+                    debug_state.route_uid != RenderRouteUID::COMMON_SKIP_STREAMING_NOT_READY;
+            if (!prior_is_typed) {
+                const char *state_token = backend_plan.streaming_ready ? "UNKNOWN" : "MISSING_STREAMING_SYSTEM";
+                debug_state.route_uid = _streaming_not_ready_route_uid(state_token);
             }
             fallback_route_uid = debug_state.route_uid;
         }
-        if (fallback_route_uid.is_empty()) {
-            WARN_PRINT_ONCE("[GaussianSplatRenderer] Streaming resources not ready; falling back to resident render path.");
-        } else {
-            WARN_PRINT_ONCE(vformat("[GaussianSplatRenderer] Streaming resources not ready (route=%s); falling back to resident render path.",
-                    fallback_route_uid));
-        }
-        _set_instance_backend_diagnostics(InstanceBackendPolicy::RESIDENT,
-                backend_plan.streaming_not_ready_fallback_reason, has_instance_pipeline_buffers(), "atlas_emulation");
-    } else {
-        // Streaming was requested but the system failed to initialize.
-        _set_instance_backend_diagnostics(InstanceBackendPolicy::RESIDENT,
-                backend_plan.streaming_unavailable_fallback_reason, has_instance_pipeline_buffers(), "atlas_emulation");
-        String fallback_route_uid = _streaming_not_ready_route_uid("MISSING_STREAMING_SYSTEM");
-        if (debug_state_orchestrator) {
-            DebugState &debug_state = get_debug_state();
-            if (debug_state.route_uid.is_empty() ||
-                    debug_state.route_uid == RenderRouteUID::COMMON_SKIP_STREAMING_NOT_READY ||
-                    !_is_typed_streaming_not_ready_route(debug_state.route_uid)) {
-                debug_state.route_uid = fallback_route_uid;
-            } else {
-                fallback_route_uid = debug_state.route_uid;
-            }
-        }
-        WARN_PRINT_ONCE(vformat("[GaussianSplatRenderer] Streaming unavailable (route=%s); falling back to resident render path.",
+        const String &reason = backend_plan.streaming_ready
+                ? backend_plan.streaming_not_ready_fallback_reason
+                : backend_plan.streaming_unavailable_fallback_reason;
+        _set_instance_backend_diagnostics(InstanceBackendPolicy::STREAMING, reason,
+                has_instance_pipeline_buffers(), "atlas_emulation");
+        WARN_PRINT_ONCE(vformat("[GaussianSplatRenderer] Streaming requested but not ready (route=%s); frame skipped to preserve single-route-per-frame contract.",
                 fallback_route_uid));
+        return;
     }
-    _render_resident_frame(p_render_data, view_transform, cam_projection, render_projection, render_buffers_rd,
-            backend_plan.allow_legacy_resident_fallback);
+    // Streaming was not requested at all (explicit resident policy). Run the
+    // resident render path normally; this is not a bounce.
+    _render_resident_frame(p_render_data, view_transform, cam_projection, render_projection, render_buffers_rd);
 }
 
 void GaussianSplatRenderer::tick_streaming_only(const Transform3D &p_camera_to_world_transform, const Projection &p_projection) {

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
@@ -243,7 +243,6 @@ public:
         bool prefer_resident_backend = false;
         bool streaming_ready = false;
         bool should_attempt_streaming_bootstrap = false;
-        bool allow_legacy_resident_fallback = false;
         bool allow_primary_fallback_instance = false;
         // True when an active gsplatworld submission owns this renderer's
         // streaming path. Suppresses the synthetic primary-data fallback so
@@ -675,12 +674,12 @@ public:
             String *r_reason = nullptr);
     bool _try_render_resident_frame(RenderDataRD *p_render_data, const Transform3D &p_world_to_camera_transform,
             const Projection &p_projection, const Projection &p_render_projection,
-            RenderSceneBuffersRD *p_render_buffers, bool p_allow_legacy_resident_fallback,
+            RenderSceneBuffersRD *p_render_buffers,
             String *r_reason = nullptr);
     void _reset_legacy_streaming_data_path_state();
     void _render_resident_frame(RenderDataRD *p_render_data, const Transform3D &p_world_to_camera_transform,
             const Projection &p_projection, const Projection &p_render_projection,
-            RenderSceneBuffersRD *p_render_buffers, bool p_allow_legacy_resident_fallback);
+            RenderSceneBuffersRD *p_render_buffers);
     const Gaussian *_get_streamed_gaussian(uint32_t p_index) const;
     SortStageSummary sort_gaussians_for_view(const Transform3D &p_world_to_camera_transform,
             IndexDomain p_input_domain = IndexDomain::UNKNOWN);

--- a/modules/gaussian_splatting/renderer/render_debug_state_orchestrator.h
+++ b/modules/gaussian_splatting/renderer/render_debug_state_orchestrator.h
@@ -17,9 +17,6 @@ struct RenderRouteUID {
 	static constexpr const char *COMMON_FAIL_SORT_FAILED = "COMMON.FAIL.SORT_FAILED";
 	static constexpr const char *COMMON_FAIL_NO_OUTPUT = "COMMON.FAIL.NO_OUTPUT";
 
-	static constexpr const char *RESIDENT_SELECTED = "RESIDENT.SELECTED";
-
-	static constexpr const char *INSTANCE_ENTRY_INSTANCED_FAST = "INSTANCE.ENTRY.INSTANCED_FAST";
 	static constexpr const char *INSTANCE_RESIDENT = "INSTANCE.RESIDENT";
 	static constexpr const char *INSTANCE_STREAMING = "INSTANCE.STREAMING";
 	static constexpr const char *INSTANCE_CULL_GPU = "INSTANCE.CULL.GPU";
@@ -31,7 +28,6 @@ struct RenderRouteUID {
 	static constexpr const char *INSTANCE_SORT_GPU = "INSTANCE.SORT.GPU";
 	static constexpr const char *INSTANCE_SORT_CPU_FALLBACK = "INSTANCE.SORT.CPU_FALLBACK";
 	static constexpr const char *INSTANCE_SORT_CACHED = "INSTANCE.SORT.CACHED";
-	static constexpr const char *INSTANCE_SORT_IDENTITY_FALLBACK = "INSTANCE.SORT.IDENTITY_FALLBACK";
 	static constexpr const char *INSTANCE_RASTER_COMPUTE = "INSTANCE.RASTER.COMPUTE";
 	static constexpr const char *INSTANCE_RASTER_FRAGMENT = "INSTANCE.RASTER.FRAGMENT";
 	static constexpr const char *INSTANCE_RASTER_CACHED = "INSTANCE.RASTER.CACHED";

--- a/modules/gaussian_splatting/renderer/render_route_labels.cpp
+++ b/modules/gaussian_splatting/renderer/render_route_labels.cpp
@@ -236,12 +236,6 @@ String describe_route_uid(const String &p_route_uid) {
 	if (!common.is_empty()) {
 		return common;
 	}
-	if (route_uid == String(RenderRouteUID::RESIDENT_SELECTED)) {
-		return "Selected the resident backend";
-	}
-	if (route_uid == String(RenderRouteUID::INSTANCE_ENTRY_INSTANCED_FAST)) {
-		return "Entered the shared instance pipeline";
-	}
 	if (route_uid == String(RenderRouteUID::INSTANCE_RESIDENT)) {
 		return "Resident instanced path";
 	}
@@ -277,9 +271,6 @@ String describe_sort_route_uid(const String &p_sort_route_uid) {
 	}
 	if (sort_route_uid == String(RenderRouteUID::INSTANCE_SORT_CACHED)) {
 		return "Reused cached sort order";
-	}
-	if (sort_route_uid == String(RenderRouteUID::INSTANCE_SORT_IDENTITY_FALLBACK)) {
-		return "Used the incoming cull order without a fresh sort";
 	}
 	return "Using an unrecognized sort route";
 }

--- a/modules/gaussian_splatting/renderer/render_sorting_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_sorting_orchestrator.cpp
@@ -991,43 +991,6 @@ GaussianRenderState::SortStageSummary RenderSortingOrchestrator::sort_gaussians_
 		}
 	}
 
-		auto publish_instance_identity_fallback = [&](const String &p_reason) -> bool {
-			if (!GaussianSplatting::allow_instance_identity_fallback_in_orchestrator(
-						strict_global_sort, instance_pipeline_active, sorting_pipeline != nullptr, instance_visible_splats)) {
-				// Correctness-first mode must never publish an unsorted identity frame.
-				return false;
-			}
-
-			sorting_state.sort_index_bytes.resize(instance_visible_splats * sizeof(uint32_t));
-			uint32_t *indices_ptr = reinterpret_cast<uint32_t *>(sorting_state.sort_index_bytes.ptrw());
-			for (uint32_t i = 0; i < instance_visible_splats; i++) {
-				indices_ptr[i] = i;
-			}
-			_bind_sort_pipeline_host_context(sorting_pipeline, renderer);
-			sorting_pipeline->ensure_sort_buffers(instance_visible_splats);
-			RID sort_indices_buffer = sorting_pipeline->get_sort_indices_buffer();
-			if (!sort_indices_buffer.is_valid()) {
-				return false;
-			}
-			RenderingDevice *target_device = renderer->get_resource_owner(sort_indices_buffer, renderer->get_device_state().rd);
-			if (!target_device) {
-				target_device = renderer->get_device_state().rd;
-			}
-			if (!target_device) {
-				return false;
-			}
-			target_device->buffer_update(sort_indices_buffer, 0,
-					sorting_state.sort_index_bytes.size(),
-					sorting_state.sort_index_bytes.ptr());
-			sorting_state.sorted_splat_count = instance_visible_splats;
-			_publish_rendered_splat_count(frame_state, performance_state, instance_visible_splats);
-			debug_state.sort_route_uid = RenderRouteUID::INSTANCE_SORT_IDENTITY_FALLBACK;
-			sorting_state.last_sort_transform_valid = false;
-			set_active_sort_algorithm("GPU (identity fallback)", p_reason);
-			GS_LOG_WARN_DEFAULT(vformat("[GPU Sort] %s; publishing identity order for instance sort domain", p_reason));
-			return true;
-		};
-
 	if (!need_sort) {
 		const bool can_reuse_previous_sorted =
 				sorting_pipeline &&
@@ -1040,49 +1003,14 @@ GaussianRenderState::SortStageSummary RenderSortingOrchestrator::sort_gaussians_
 			const uint32_t reused_count = instance_pipeline_active ? sorting_state.sorted_splat_count : available_splats;
 			sorting_state.sorted_splat_count = reused_count;
 			_publish_rendered_splat_count(frame_state, performance_state, reused_count);
-		} else if (publish_instance_identity_fallback("Missing previous sorted buffer on camera-stable frame")) {
-			reset_sort_metrics();
-			return build_summary();
-		} else if (GaussianSplatting::allow_camera_stable_cull_order_bootstrap_in_orchestrator(
-						   strict_global_sort, instance_pipeline_active, !cull_state.culled_indices.is_empty(), sorting_pipeline != nullptr)) {
-			// Last resort bootstrap: if the previous sorted buffer is unavailable,
-			// keep rendering progress with current cull order instead of showing zero splats.
-			// Strict mode is excluded above because correctness-first mode must never
-			// publish approximate ordering.
-			const uint32_t copy_count = MIN<uint32_t>(available_splats,
-					static_cast<uint32_t>(cull_state.culled_indices.size()));
-			if (copy_count > 0) {
-				sorting_state.sort_index_bytes.resize(copy_count * sizeof(uint32_t));
-				uint32_t *indices_ptr = reinterpret_cast<uint32_t *>(sorting_state.sort_index_bytes.ptrw());
-				for (uint32_t i = 0; i < copy_count; i++) {
-					indices_ptr[i] = cull_state.culled_indices[i];
-				}
-				_bind_sort_pipeline_host_context(sorting_pipeline, renderer);
-				sorting_pipeline->ensure_sort_buffers(copy_count);
-				RID sort_indices_buffer = sorting_pipeline->get_sort_indices_buffer();
-				if (sort_indices_buffer.is_valid()) {
-					RenderingDevice *target_device = renderer->get_resource_owner(sort_indices_buffer, renderer->get_device_state().rd);
-					if (!target_device) {
-						target_device = renderer->get_device_state().rd;
-					}
-					if (target_device) {
-						target_device->buffer_update(sort_indices_buffer, 0,
-								sorting_state.sort_index_bytes.size(),
-								sorting_state.sort_index_bytes.ptr());
-					}
-				}
-				sorting_state.sorted_splat_count = copy_count;
-				_publish_rendered_splat_count(frame_state, performance_state, copy_count);
-				// Force a real re-sort on the next frame; this bootstrap order is not depth-sorted.
-				sorting_state.last_sort_transform_valid = false;
-			}
-		} else if (strict_global_sort && available_splats > 0) {
-			// Strict mode cannot publish fallback ordering. If the stable-frame fast path
-			// has no reusable sorted buffer, force a real sort this frame instead of
-			// returning with stale/invalid state.
+		} else if (available_splats > 0) {
+			// No reusable sorted buffer on a camera-stable frame. Publishing an
+			// unsorted identity order or seeding from current cull order would
+			// produce depth-incorrect frames, so force a real sort this frame
+			// instead of returning with stale/invalid state.
 			need_sort = true;
 			sorting_state.last_sort_transform_valid = false;
-			GS_LOG_WARN_DEFAULT("[GPU Sort] Strict mode missing previous sorted buffer on camera-stable frame; forcing immediate re-sort");
+			GS_LOG_WARN_DEFAULT("[GPU Sort] Missing previous sorted buffer on camera-stable frame; forcing immediate re-sort");
 		}
 		if (!need_sort) {
 			refresh_cull_signature_tracking();
@@ -1266,12 +1194,6 @@ GaussianRenderState::SortStageSummary RenderSortingOrchestrator::sort_gaussians_
 				switch (policy.actions[i]) {
 				case GaussianSplatting::SortFallbackAction::REUSE_PREVIOUS_SORT:
 					if (reuse_previous_sort(p_reason, reuse_route_uid)) {
-						return;
-					}
-					break;
-				case GaussianSplatting::SortFallbackAction::PUBLISH_INSTANCE_IDENTITY:
-					if (publish_instance_identity_fallback(p_reason)) {
-						reset_sort_metrics();
 						return;
 					}
 					break;

--- a/modules/gaussian_splatting/renderer/sort_fallback_policy.h
+++ b/modules/gaussian_splatting/renderer/sort_fallback_policy.h
@@ -7,9 +7,8 @@ namespace GaussianSplatting {
 
 enum class SortFallbackAction : uint8_t {
 	REUSE_PREVIOUS_SORT = 0,
-	PUBLISH_INSTANCE_IDENTITY = 1,
-	RUN_CPU_SORT = 2,
-	FAIL = 3,
+	RUN_CPU_SORT = 1,
+	FAIL = 2,
 };
 
 enum class SortFallbackScenario : uint8_t {
@@ -29,27 +28,19 @@ struct SortFallbackPolicyDecision {
 	bool cpu_sort_forced = false;
 };
 
-static inline bool allow_unsorted_fallback_publication(bool p_strict_global_sort) {
-	return !p_strict_global_sort;
-}
-
-static inline bool allow_instance_identity_fallback_in_orchestrator(
-		bool p_strict_global_sort, bool p_instance_pipeline_active, bool p_has_sorting_pipeline, uint32_t p_instance_visible_splats) {
-	return !p_strict_global_sort && p_instance_pipeline_active && p_has_sorting_pipeline && p_instance_visible_splats > 0;
-}
-
-static inline bool allow_camera_stable_cull_order_bootstrap_in_orchestrator(
-		bool p_strict_global_sort, bool p_instance_pipeline_active, bool p_has_culled_indices, bool p_has_sorting_pipeline) {
-	return !p_strict_global_sort && !p_instance_pipeline_active && p_has_culled_indices && p_has_sorting_pipeline;
-}
-
+// CPU fallback for the global sort domain is still the correctness-preserving
+// path when positions are available. Strict mode hard-fails the case where the
+// CPU fallback would have to publish unsorted cull order because positions are
+// not yet produced.
 static inline bool allow_unsorted_cpu_fallback_in_orchestrator(bool p_strict_global_sort, bool p_positions_ready) {
 	return p_positions_ready || !p_strict_global_sort;
 }
 
-// Keep fallback behavior deterministic across force_cpu and GPU failure paths.
+// Sort fallback policy. The instance domain has no safe unsorted fallback, so
+// the only options are reuse-previous or fail. The global domain keeps the CPU
+// sort as the correctness-preserving fallback when the GPU sort fails.
 static inline SortFallbackPolicyDecision build_sort_fallback_policy(
-		SortFallbackScenario p_scenario, bool p_instance_pipeline_active, bool p_strict_global_sort = false) {
+		SortFallbackScenario p_scenario, bool p_instance_pipeline_active, bool /*p_strict_global_sort*/ = false) {
 	SortFallbackPolicyDecision decision;
 	auto push_action = [&](SortFallbackAction p_action) {
 		if (decision.action_count < 4) {
@@ -61,9 +52,6 @@ static inline SortFallbackPolicyDecision build_sort_fallback_policy(
 		case SortFallbackScenario::FORCE_CPU_OVERRIDE: {
 			if (p_instance_pipeline_active) {
 				push_action(SortFallbackAction::REUSE_PREVIOUS_SORT);
-				if (allow_unsorted_fallback_publication(p_strict_global_sort)) {
-					push_action(SortFallbackAction::PUBLISH_INSTANCE_IDENTITY);
-				}
 				push_action(SortFallbackAction::FAIL);
 			} else {
 				decision.cpu_sort_forced = true;
@@ -74,11 +62,7 @@ static inline SortFallbackPolicyDecision build_sort_fallback_policy(
 		case SortFallbackScenario::SORTER_UNAVAILABLE:
 		case SortFallbackScenario::GPU_SORT_FAILED: {
 			push_action(SortFallbackAction::REUSE_PREVIOUS_SORT);
-			if (p_instance_pipeline_active) {
-				if (allow_unsorted_fallback_publication(p_strict_global_sort)) {
-					push_action(SortFallbackAction::PUBLISH_INSTANCE_IDENTITY);
-				}
-			} else {
+			if (!p_instance_pipeline_active) {
 				push_action(SortFallbackAction::RUN_CPU_SORT);
 			}
 			push_action(SortFallbackAction::FAIL);

--- a/modules/gaussian_splatting/tests/test_gaussian_data.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_data.h
@@ -10,6 +10,7 @@
 
 #include "../core/gaussian_data.h"
 #include "core/io/dir_access.h"
+#include "core/io/file_access.h"
 #include "core/math/math_defs.h"
 #include "core/math/random_number_generator.h"
 #include "core/os/os.h"
@@ -269,6 +270,26 @@ TEST_CASE("[GaussianSplatting] GaussianData load_from_file invalidates storage-d
 
 	DirAccess::remove_absolute(path_a);
 	DirAccess::remove_absolute(path_b);
+}
+
+TEST_CASE("[GaussianSplatting] GaussianData::load_from_file hard-fails on unknown raw extensions") {
+	// Behavior change: unknown raw extensions previously fell through to the PLY loader.
+	// They now hard-fail with ERR_FILE_UNRECOGNIZED instead of probing loosely.
+	const String path = _make_gaussian_data_fixture_path("unknown_ext", ".xyz");
+
+	{
+		Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE);
+		REQUIRE(f.is_valid());
+		f->store_string("not a real splat file");
+	}
+
+	Ref<::GaussianData> data;
+	data.instantiate();
+	Error err = data->load_from_file(path);
+	CHECK_MESSAGE(err == ERR_FILE_UNRECOGNIZED,
+			"GaussianData::load_from_file must hard-fail on unknown raw extensions, not probe as PLY.");
+
+	DirAccess::remove_absolute(path);
 }
 
 TEST_CASE("[GaussianSplatting] GaussianData GPU payload validation rejects non-finite and out-of-range values") {

--- a/modules/gaussian_splatting/tests/test_gaussian_importer.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_importer.h
@@ -1196,6 +1196,66 @@ TEST_CASE("[GaussianSplatting][Importer] PLY loader keeps legacy DC encoding") {
     _remove_user_file(source_path);
 }
 
+TEST_CASE("[GaussianSplatting][Importer] PLY ASCII loader hard-fails on malformed rows") {
+    // Behavior change: previously a project-setting could downgrade malformed-row
+    // handling to a warn-and-skip. That path has been removed — malformed ASCII
+    // rows now always return ERR_FILE_CORRUPT.
+    const String source_path = "user://gaussian_ply_malformed_row.ply";
+
+    static const char *k_malformed_ascii_ply = R"(ply
+format ascii 1.0
+element vertex 2
+property float x
+property float y
+property float z
+property float scale_0
+property float scale_1
+property float scale_2
+property float rot_0
+property float rot_1
+property float rot_2
+property float rot_3
+property float opacity
+property float f_dc_0
+property float f_dc_1
+property float f_dc_2
+end_header
+0 0 0 0 0 0 1 0 0 0 0 0.25 0.5 0.75
+0 0 0 1 2 3
+)";
+
+    Ref<FileAccess> file = FileAccess::open(source_path, FileAccess::WRITE);
+    REQUIRE(file.is_valid());
+    file->store_string(k_malformed_ascii_ply);
+    file.unref();
+
+    Ref<PLYLoader> loader;
+    loader.instantiate();
+    Error load_err = loader->load_file(source_path);
+    CHECK_MESSAGE(load_err == ERR_FILE_CORRUPT,
+            "PLY ASCII loader must reject malformed rows with ERR_FILE_CORRUPT (no more silent row skipping).");
+
+    _remove_user_file(source_path);
+}
+
+TEST_CASE("[GaussianSplatting][Importer] GaussianSplatAsset::load_from_file hard-fails on unknown raw extensions") {
+    // Behavior change: unknown raw extensions previously fell through to the PLY loader.
+    // They now hard-fail with ERR_FILE_UNRECOGNIZED instead of probing loosely.
+    const String source_path = "user://gaussian_asset_unknown_ext.xyz";
+    Ref<FileAccess> file = FileAccess::open(source_path, FileAccess::WRITE);
+    REQUIRE(file.is_valid());
+    file->store_string("not a real splat file");
+    file.unref();
+
+    Ref<GaussianSplatAsset> asset;
+    asset.instantiate();
+    const Error err = asset->load_from_file(source_path);
+    CHECK_MESSAGE(err == ERR_FILE_UNRECOGNIZED,
+            "GaussianSplatAsset::load_from_file must hard-fail on unknown raw extensions, not probe as PLY.");
+
+    _remove_user_file(source_path);
+}
+
 TEST_CASE("[GaussianSplatting][Renderer] SH metadata preserves DC encoding mode") {
     SHCompressionMetrics metrics;
     PackedGaussian packed = {};

--- a/modules/gaussian_splatting/tests/test_gaussian_importer.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_importer.h
@@ -358,6 +358,34 @@ Error _write_binary_file(const String &p_path, const PackedByteArray &p_bytes) {
     return OK;
 }
 
+Error _write_text_file(const String &p_path, const String &p_text) {
+    Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE);
+    if (file.is_null()) {
+        return ERR_CANT_CREATE;
+    }
+
+    file->store_string(p_text);
+    file.unref();
+    return OK;
+}
+
+Ref<Image> _make_thumbnail_test_image() {
+    Ref<Image> image = Image::create_empty(2, 2, false, Image::FORMAT_RGBA8);
+    image->fill(Color(0.0f, 0.0f, 0.0f, 0.0f));
+    image->set_pixel(0, 0, Color(0.9f, 0.2f, 0.1f, 1.0f));
+    image->set_pixel(1, 0, Color(0.1f, 0.8f, 0.3f, 1.0f));
+    image->set_pixel(0, 1, Color(0.2f, 0.4f, 0.9f, 1.0f));
+    image->set_pixel(1, 1, Color(1.0f, 0.9f, 0.2f, 1.0f));
+    return image;
+}
+
+bool _color_approx_eq(const Color &p_a, const Color &p_b, float p_epsilon = 0.01f) {
+    return Math::abs(p_a.r - p_b.r) <= p_epsilon &&
+            Math::abs(p_a.g - p_b.g) <= p_epsilon &&
+            Math::abs(p_a.b - p_b.b) <= p_epsilon &&
+            Math::abs(p_a.a - p_b.a) <= p_epsilon;
+}
+
 Ref<GaussianSplatAsset> _make_thumbnail_fixture_asset(int p_splat_count = 6) {
     Ref<GaussianSplatAsset> asset;
     asset.instantiate();
@@ -417,10 +445,7 @@ Ref<GaussianSplatAsset> _make_thumbnail_fixture_asset(int p_splat_count = 6) {
 
 } // namespace
 
-TEST_CASE("[GaussianSplatting][Importer][RequiresGPU] PLY importer produces metadata and thumbnails") {
-    // Thumbnail generation requires a functional RenderingDevice for ImageTexture.
-    REQUIRE_GPU_DEVICE();
-
+TEST_CASE("[GaussianSplatting][Importer] PLY importer produces metadata and preview images") {
     const String source_path = "user://test_fixture_metadata_thumb.ply";
     {
         Error ply_err = _write_minimal_ascii_ply(source_path);
@@ -463,7 +488,7 @@ TEST_CASE("[GaussianSplatting][Importer][RequiresGPU] PLY importer produces meta
     CHECK(asset->get_splat_count() > 0);
     CHECK(asset->get_import_quality_preset() == String("desktop"));
     CHECK((asset->get_compression_flags() & GaussianSplatAsset::COMPRESSION_POSITIONS) != 0);
-    CHECK_MESSAGE(asset->get_thumbnail().is_valid(), "Importer should generate a thumbnail for the Gaussian asset.");
+    CHECK_MESSAGE(asset->get_preview_image().is_valid(), "Importer should store a preview image for the Gaussian asset.");
     CHECK(asset->get_source_path() == source_path);
 
     Dictionary metadata = metadata_variant;
@@ -480,10 +505,7 @@ TEST_CASE("[GaussianSplatting][Importer][RequiresGPU] PLY importer produces meta
     _remove_user_file(source_path);
 }
 
-TEST_CASE("[GaussianSplatting][Importer][RequiresGPU] Reimport updates quality options") {
-    // First import generates a thumbnail which requires a GPU device.
-    REQUIRE_GPU_DEVICE();
-
+TEST_CASE("[GaussianSplatting][Importer] Reimport updates quality options") {
     const String source_path = "user://test_fixture_reimport.ply";
     {
         Error ply_err = _write_minimal_ascii_ply(source_path);
@@ -529,7 +551,7 @@ TEST_CASE("[GaussianSplatting][Importer][RequiresGPU] Reimport updates quality o
     }
 
     CHECK(asset->get_import_quality_preset() == String("mobile"));
-    CHECK(!asset->get_thumbnail().is_valid());
+    CHECK(!asset->get_preview_image().is_valid());
 
     Dictionary metadata = second_metadata_variant;
     CHECK(String(metadata.get(StringName("quality_preset"), String())) == String("mobile"));
@@ -747,10 +769,7 @@ TEST_CASE("[GaussianSplatting][Importer] Missing required PLY properties fail co
     _remove_user_file(save_base_path + ".tres");
 }
 
-TEST_CASE("[GaussianSplatting][Thumbnail][RequiresGPU] Generator produces textures for each style") {
-    // Thumbnail generation creates ImageTextures which require a GPU device.
-    REQUIRE_GPU_DEVICE();
-
+TEST_CASE("[GaussianSplatting][Thumbnail] Generator produces preview images for each style") {
     Ref<GaussianSplatAsset> asset = _make_thumbnail_fixture_asset();
     const int splat_count = asset->get_splat_count();
 
@@ -758,27 +777,24 @@ TEST_CASE("[GaussianSplatting][Thumbnail][RequiresGPU] Generator produces textur
     generator.instantiate();
 
     for (int style = 0; style < 4; style++) {
-        Ref<Texture2D> texture = generator->generate_thumbnail(asset, 96,
+        Ref<Image> image = generator->generate_thumbnail_image(asset, 96,
                 GaussianThumbnailGenerator::style_from_int(style));
-        CHECK_MESSAGE(texture.is_valid(), "Thumbnail generator should return a valid texture for each style.");
+        CHECK_MESSAGE(image.is_valid(), "Thumbnail generator should return a valid image for each style.");
     }
 
     Dictionary memory = generator->compute_memory_statistics(splat_count, GaussianSplatAsset::COMPRESSION_NONE, false);
     CHECK(float(memory.get(StringName("total_mb"), 0.0)) > 0.0f);
 }
 
-TEST_CASE("[GaussianSplatting][Thumbnail][RequiresGPU] Generator caches deterministic asset+settings keys") {
-    // Thumbnail generation creates ImageTextures which require a GPU device.
-    REQUIRE_GPU_DEVICE();
-
+TEST_CASE("[GaussianSplatting][Thumbnail] Generator caches deterministic asset+settings keys") {
     Ref<GaussianSplatAsset> asset = _make_thumbnail_fixture_asset();
 
     Ref<GaussianThumbnailGenerator> generator;
     generator.instantiate();
 
-    Ref<Texture2D> first = generator->generate_thumbnail(asset, 96, GaussianThumbnailGenerator::THUMBNAIL_STYLE_COLOR);
-    Ref<Texture2D> second = generator->generate_thumbnail(asset, 96, GaussianThumbnailGenerator::THUMBNAIL_STYLE_COLOR);
-    Ref<Texture2D> alternate_style = generator->generate_thumbnail(asset, 96, GaussianThumbnailGenerator::THUMBNAIL_STYLE_HEATMAP);
+    Ref<Image> first = generator->generate_thumbnail_image(asset, 96, GaussianThumbnailGenerator::THUMBNAIL_STYLE_COLOR);
+    Ref<Image> second = generator->generate_thumbnail_image(asset, 96, GaussianThumbnailGenerator::THUMBNAIL_STYLE_COLOR);
+    Ref<Image> alternate_style = generator->generate_thumbnail_image(asset, 96, GaussianThumbnailGenerator::THUMBNAIL_STYLE_HEATMAP);
     CHECK(first.is_valid());
     CHECK(second.is_valid());
     CHECK(alternate_style.is_valid());
@@ -790,11 +806,122 @@ TEST_CASE("[GaussianSplatting][Thumbnail][RequiresGPU] Generator caches determin
     CHECK(int64_t(stats.get(StringName("misses"), int64_t(0))) >= 2);
 
     asset->set_source_path("res://thumbnail_fixture_reimported.ply");
-    Ref<Texture2D> after_source_change = generator->generate_thumbnail(asset, 96, GaussianThumbnailGenerator::THUMBNAIL_STYLE_COLOR);
+    Ref<Image> after_source_change = generator->generate_thumbnail_image(asset, 96, GaussianThumbnailGenerator::THUMBNAIL_STYLE_COLOR);
     CHECK(after_source_change.is_valid());
 
     stats = generator->get_cache_statistics();
     CHECK(int(stats.get(StringName("entries"), 0)) == 3);
+}
+
+TEST_CASE("[GaussianSplatting][Importer] GaussianSplatAsset serializes preview images without ImageTexture state") {
+    const String save_path = "user://gaussian_asset_preview_image_roundtrip.tres";
+
+    Ref<GaussianSplatAsset> asset;
+    asset.instantiate();
+    asset->set_splat_count(1);
+    asset->set_source_path("res://preview_image_fixture.ply");
+    asset->set_preview_image(_make_thumbnail_test_image());
+
+    const Error save_err = ResourceSaver::save(asset, save_path);
+    CHECK_MESSAGE(save_err == OK, "Saving a GaussianSplatAsset with a preview image should succeed.");
+    if (save_err != OK) {
+        _remove_user_file(save_path);
+        return;
+    }
+
+    const String saved_text = _load_text_fixture_or_empty(save_path);
+    CHECK_MESSAGE(saved_text.contains("import/thumbnail = SubResource("),
+            "Serialized GaussianSplatAsset should persist the preview image property.");
+    CHECK_MESSAGE(!saved_text.contains("type=\"ImageTexture\""),
+            "Serialized GaussianSplatAsset should not embed an ImageTexture subresource.");
+    CHECK_MESSAGE(!saved_text.contains("rid://"),
+            "Serialized GaussianSplatAsset should not persist texture RID state.");
+
+    Ref<GaussianSplatAsset> loaded = ResourceLoader::load(save_path, "GaussianSplatAsset");
+    CHECK_MESSAGE(loaded.is_valid(), "Roundtripped GaussianSplatAsset should load from disk.");
+    if (loaded.is_valid()) {
+        Ref<Image> preview = loaded->get_preview_image();
+        CHECK(preview.is_valid());
+        if (preview.is_valid()) {
+            CHECK(preview->get_width() == 2);
+            CHECK(preview->get_height() == 2);
+            CHECK(_color_approx_eq(preview->get_pixel(0, 0), Color(0.9f, 0.2f, 0.1f, 1.0f)));
+        }
+    }
+
+    _remove_user_file(save_path);
+}
+
+TEST_CASE("[GaussianSplatting][Importer][RequiresGPU] GaussianSplatAsset loads legacy ImageTexture thumbnails") {
+    REQUIRE_GPU_DEVICE();
+
+    const String modern_path = "user://gaussian_asset_preview_modern.tres";
+    const String legacy_path = "user://gaussian_asset_preview_legacy.tres";
+
+    Ref<GaussianSplatAsset> asset;
+    asset.instantiate();
+    asset->set_splat_count(1);
+    asset->set_source_path("res://legacy_preview_fixture.ply");
+    asset->set_preview_image(_make_thumbnail_test_image());
+
+    const Error save_err = ResourceSaver::save(asset, modern_path);
+    CHECK_MESSAGE(save_err == OK, "Saving the modern preview-image asset should succeed.");
+    if (save_err != OK) {
+        _remove_user_file(modern_path);
+        _remove_user_file(legacy_path);
+        return;
+    }
+
+    String legacy_text = _load_text_fixture_or_empty(modern_path);
+    const String property_prefix = "import/thumbnail = SubResource(\"";
+    const int property_pos = legacy_text.find(property_prefix);
+    REQUIRE_MESSAGE(property_pos >= 0, "Modern GaussianSplatAsset should serialize preview image subresources.");
+    const int id_start = property_pos + property_prefix.length();
+    const int id_end = legacy_text.find("\")", id_start);
+    REQUIRE_MESSAGE(id_end > id_start, "Modern preview image subresource id should be parseable.");
+    const String image_id = legacy_text.substr(id_start, id_end - id_start);
+
+    legacy_text = legacy_text.replace(String("import/thumbnail = SubResource(\"") + image_id + "\")",
+            "import/thumbnail = SubResource(\"ImageTexture_legacy_preview\")");
+
+    const int resource_pos = legacy_text.find("[resource]");
+    REQUIRE_MESSAGE(resource_pos >= 0, "Modern GaussianSplatAsset text resource should contain a [resource] block.");
+    const String legacy_subresource =
+            "[sub_resource type=\"ImageTexture\" id=\"ImageTexture_legacy_preview\"]\n"
+            "image = SubResource(\"" + image_id + "\")\n\n";
+    legacy_text = legacy_text.insert(resource_pos, legacy_subresource);
+
+    const Error legacy_write_err = _write_text_file(legacy_path, legacy_text);
+    CHECK_MESSAGE(legacy_write_err == OK, "Writing the legacy ImageTexture fixture should succeed.");
+    if (legacy_write_err != OK) {
+        _remove_user_file(modern_path);
+        _remove_user_file(legacy_path);
+        return;
+    }
+
+    Ref<GaussianSplatAsset> loaded = ResourceLoader::load(legacy_path, "GaussianSplatAsset");
+    CHECK_MESSAGE(loaded.is_valid(), "Legacy ImageTexture-backed GaussianSplatAsset should still load.");
+    if (loaded.is_valid()) {
+        Ref<Image> preview = loaded->get_preview_image();
+        CHECK(preview.is_valid());
+        if (preview.is_valid()) {
+            CHECK(_color_approx_eq(preview->get_pixel(1, 1), Color(1.0f, 0.9f, 0.2f, 1.0f)));
+        }
+
+        const String resaved_path = "user://gaussian_asset_preview_legacy_resaved.tres";
+        const Error resave_err = ResourceSaver::save(loaded, resaved_path);
+        CHECK_MESSAGE(resave_err == OK, "Resaving a legacy GaussianSplatAsset should migrate the preview to Image storage.");
+        if (resave_err == OK) {
+            const String resaved_text = _load_text_fixture_or_empty(resaved_path);
+            CHECK(!resaved_text.contains("type=\"ImageTexture\""));
+            _remove_user_file(resaved_path);
+        } else {
+            _remove_user_file(resaved_path);
+        }
+    }
+
+    _remove_user_file(modern_path);
+    _remove_user_file(legacy_path);
 }
 
 TEST_CASE("[GaussianSplatting][Editor] Import dialog respects metadata baselines") {

--- a/modules/gaussian_splatting/tests/test_gaussian_splat_container.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splat_container.h
@@ -179,4 +179,38 @@ TEST_CASE("[GaussianSplatting][Container][SceneTree] Merged child splats preserv
     memdelete(container);
 }
 
+TEST_CASE("[GaussianSplatting][Container][SceneTree] apply_to_node pushes merged asset into a GaussianSplatNode3D target") {
+    // Regression guard for the apply_to_renderer() deletion: apply_to_node() must
+    // continue to be the canonical tooling handoff into the scene surface.
+    SceneTree *tree = SceneTree::get_singleton();
+    REQUIRE_MESSAGE(tree != nullptr, "SceneTree singleton required");
+
+    Window *root = tree->get_root();
+    REQUIRE_MESSAGE(root != nullptr, "SceneTree root window required");
+
+    GaussianSplatContainer *container = memnew(GaussianSplatContainer);
+    container->set_chunk_size(5.0f);
+    root->add_child(container);
+
+    GaussianSplatNode3D *source = memnew(GaussianSplatNode3D);
+    source->set_splat_asset(create_single_splat_asset(Vector3(0, 0, 0)));
+    container->add_child(source);
+
+    GaussianSplatNode3D *target = memnew(GaussianSplatNode3D);
+    root->add_child(target);
+
+    tree->process(0.0);
+    container->merge_children();
+
+    const Error apply_err = container->apply_to_node(target);
+    CHECK_MESSAGE(apply_err == OK, "apply_to_node should succeed with a GaussianSplatNode3D target.");
+    CHECK_MESSAGE(target->get_splat_asset().is_valid(),
+            "apply_to_node must populate the target node's splat_asset.");
+
+    root->remove_child(target);
+    memdelete(target);
+    root->remove_child(container);
+    memdelete(container);
+}
+
 #endif // TESTS_ENABLED || TOOLS_ENABLED

--- a/modules/gaussian_splatting/tests/test_persistence_roundtrip.h
+++ b/modules/gaussian_splatting/tests/test_persistence_roundtrip.h
@@ -4,6 +4,7 @@
 #include "../persistence/gaussian_scene_serializer.h"
 #include "../persistence/incremental_saver.h"
 #include "../core/gaussian_splat_world.h"
+#include "../core/streaming_chunk_payload_source.h"
 
 #include "core/io/file_access.h"
 #include "core/io/dir_access.h"
@@ -186,6 +187,207 @@ TEST_CASE("[GaussianSplatting][Persistence] GSF round-trip serialization") {
     }
 
     _remove_persistence_fixture(path);
+}
+
+TEST_CASE("[GaussianSplatting][Persistence] GSF round-trip preserves first-order SH metadata and payload") {
+    // First-order SH lives inside the persisted `Gaussian` struct (sh_1[3]) and
+    // must survive a round-trip. The reconstruction path must also rebuild
+    // GaussianData::get_sh_first_order_count() so downstream consumers see a
+    // non-zero SH metadata count.
+    const String path = _make_persistence_fixture_path("test_sh_first_order_roundtrip");
+    const bool fixture_dir_ready = _ensure_persistence_fixture_dir(path);
+    CHECK_MESSAGE(fixture_dir_ready, "Persistence fixture directory should be available");
+    if (!fixture_dir_ready) {
+        return;
+    }
+
+    Ref<GaussianData> original_data;
+    original_data.instantiate();
+
+    Vector<Gaussian> gaussians;
+    gaussians.resize(4);
+    for (int i = 0; i < 4; i++) {
+        Gaussian &g = gaussians.write[i];
+        g.position = Vector3(i, 0, 0);
+        g.scale = Vector3(1, 1, 1);
+        g.rotation = Quaternion();
+        g.opacity = 1.0f;
+        g.sh_dc = Color(0.5f, 0.5f, 0.5f, 1.0f);
+        // Populate all three first-order SH bands with non-zero values so the
+        // derived sh_first_order_count is exactly 3.
+        g.sh_1[0] = Vector3(0.10f + 0.01f * i, 0.20f, 0.30f);
+        g.sh_1[1] = Vector3(-0.15f, 0.25f + 0.01f * i, -0.05f);
+        g.sh_1[2] = Vector3(0.08f, -0.12f, 0.40f + 0.01f * i);
+    }
+    original_data->set_gaussians(gaussians);
+    CHECK_MESSAGE(original_data->get_sh_first_order_count() == 3,
+            "Source data should advertise sh_first_order_count == 3 before save");
+
+    GaussianSplatting::GaussianSceneSerializer serializer;
+    Error save_err = serializer.save_scene(path, original_data.ptr(), nullptr, Dictionary());
+    CHECK_MESSAGE(save_err == OK, "GSF save should succeed");
+    if (save_err != OK) {
+        _remove_persistence_fixture(path);
+        return;
+    }
+
+    Ref<GaussianData> loaded_data;
+    loaded_data.instantiate();
+    Error load_err = serializer.load_scene(path, loaded_data.ptr(), nullptr, nullptr);
+    CHECK_MESSAGE(load_err == OK, "GSF load should succeed");
+
+    if (load_err == OK) {
+        CHECK_MESSAGE(loaded_data->get_sh_first_order_count() == 3,
+                "Reconstructed GaussianData must report sh_first_order_count == 3");
+        CHECK_EQ(loaded_data->get_count(), 4);
+        for (int i = 0; i < loaded_data->get_count(); i++) {
+            Gaussian g = loaded_data->get_gaussian(i);
+            CHECK(g.sh_1[0].is_equal_approx(Vector3(0.10f + 0.01f * i, 0.20f, 0.30f)));
+            CHECK(g.sh_1[1].is_equal_approx(Vector3(-0.15f, 0.25f + 0.01f * i, -0.05f)));
+            CHECK(g.sh_1[2].is_equal_approx(Vector3(0.08f, -0.12f, 0.40f + 0.01f * i)));
+        }
+    }
+
+    _remove_persistence_fixture(path);
+}
+
+TEST_CASE("[GaussianSplatting][Persistence] GSF load documents high-order SH loss explicitly") {
+    // The GAUSSIAN_DATA chunk format only carries per-splat `Gaussian` struct
+    // bytes; it does NOT persist the `sh_high_order_coefficients` sidecar.
+    // This test pins that limitation: after a save/load round-trip the loaded
+    // GaussianData reports sh_high_order_count == 0 regardless of the source
+    // data. If a future format revision starts persisting the sidecar, this
+    // test should be updated (and the reconstruction path in
+    // _read_gaussian_data_chunk must pass the sidecar to set_gaussian_payload).
+    const String path = _make_persistence_fixture_path("test_sh_high_order_loss");
+    const bool fixture_dir_ready = _ensure_persistence_fixture_dir(path);
+    CHECK_MESSAGE(fixture_dir_ready, "Persistence fixture directory should be available");
+    if (!fixture_dir_ready) {
+        return;
+    }
+
+    Ref<GaussianData> original_data;
+    original_data.instantiate();
+
+    LocalVector<Gaussian> gaussians;
+    gaussians.resize(2);
+    for (uint32_t i = 0; i < gaussians.size(); i++) {
+        Gaussian &g = gaussians[i];
+        g.position = Vector3(i, 0, 0);
+        g.scale = Vector3(1, 1, 1);
+        g.rotation = Quaternion();
+        g.opacity = 1.0f;
+        g.sh_dc = Color(1, 1, 1, 1);
+        g.sh_1[0] = Vector3(0.1f, 0.2f, 0.3f);
+    }
+
+    LocalVector<Vector3> high_order;
+    const uint32_t high_order_per_splat = 5;
+    high_order.resize(gaussians.size() * high_order_per_splat);
+    for (uint32_t i = 0; i < high_order.size(); i++) {
+        high_order[i] = Vector3(float(i) * 0.01f, 0.0f, 0.0f);
+    }
+
+    original_data->set_gaussian_payload(gaussians, high_order, 1, high_order_per_splat, false);
+    CHECK_MESSAGE(original_data->get_sh_high_order_count() == high_order_per_splat,
+            "Source data should carry high-order SH before save");
+
+    GaussianSplatting::GaussianSceneSerializer serializer;
+    Error save_err = serializer.save_scene(path, original_data.ptr(), nullptr, Dictionary());
+    CHECK_MESSAGE(save_err == OK, "GSF save should succeed");
+    if (save_err != OK) {
+        _remove_persistence_fixture(path);
+        return;
+    }
+
+    Ref<GaussianData> loaded_data;
+    loaded_data.instantiate();
+    Error load_err = serializer.load_scene(path, loaded_data.ptr(), nullptr, nullptr);
+    CHECK_MESSAGE(load_err == OK, "GSF load should succeed");
+    if (load_err == OK) {
+        CHECK_MESSAGE(loaded_data->get_sh_high_order_count() == 0,
+                "High-order SH is not carried by the GAUSSIAN_DATA chunk format and must reset to 0 on load");
+        CHECK_MESSAGE(loaded_data->get_sh_high_order_coefficients_ptr() == nullptr,
+                "High-order SH sidecar must be empty after reconstruction");
+        // First-order SH still survives because it is embedded in the Gaussian struct bytes.
+        CHECK_MESSAGE(loaded_data->get_sh_first_order_count() == 1,
+                "First-order SH metadata should be recovered from the persisted Gaussian bytes");
+    }
+
+    _remove_persistence_fixture(path);
+}
+
+TEST_CASE("[GaussianSplatting][Persistence] GSF load clears pre-existing state on the target GaussianData") {
+    // Loading into a GaussianData that already carries derived/overlay state
+    // must funnel through the canonical invalidation path so leftover high-order
+    // SH / overlays / octree state do not survive into the loaded resource.
+    const String path = _make_persistence_fixture_path("test_load_clears_state");
+    const bool fixture_dir_ready = _ensure_persistence_fixture_dir(path);
+    CHECK_MESSAGE(fixture_dir_ready, "Persistence fixture directory should be available");
+    if (!fixture_dir_ready) {
+        return;
+    }
+
+    Ref<GaussianSplatWorld> world = create_test_world();
+    Ref<GaussianData> source_data = world->get_gaussian_data();
+    CHECK(source_data.is_valid());
+
+    GaussianSplatting::GaussianSceneSerializer serializer;
+    Error save_err = serializer.save_scene(path, source_data.ptr(), nullptr, Dictionary());
+    CHECK_MESSAGE(save_err == OK, "GSF save should succeed");
+    if (save_err != OK) {
+        _remove_persistence_fixture(path);
+        return;
+    }
+
+    Ref<GaussianData> loaded_data;
+    loaded_data.instantiate();
+
+    // Seed the target with leftover high-order SH + an overlay modification
+    // that must be wiped on load.
+    LocalVector<Gaussian> seed_gaussians;
+    seed_gaussians.resize(5);
+    LocalVector<Vector3> seed_high_order;
+    seed_high_order.resize(seed_gaussians.size() * 3);
+    loaded_data->set_gaussian_payload(seed_gaussians, seed_high_order, 0, 3, false);
+    loaded_data->set_runtime_position(0, Vector3(42.0f, 0.0f, 0.0f));
+    CHECK_MESSAGE(loaded_data->has_modifications(),
+            "Seeded data should carry a runtime overlay modification before load");
+    CHECK_MESSAGE(loaded_data->get_sh_high_order_count() == 3,
+            "Seeded data should carry high-order SH before load");
+
+    Error load_err = serializer.load_scene(path, loaded_data.ptr(), nullptr, nullptr);
+    CHECK_MESSAGE(load_err == OK, "GSF load should succeed");
+    if (load_err == OK) {
+        CHECK_EQ(loaded_data->get_count(), source_data->get_count());
+        CHECK_MESSAGE(!loaded_data->has_modifications(),
+                "Runtime overlays must be cleared when load replaces storage");
+        CHECK_MESSAGE(loaded_data->get_sh_high_order_count() == 0,
+                "Stale high-order SH must be cleared when load replaces storage");
+    }
+
+    _remove_persistence_fixture(path);
+}
+
+TEST_CASE("[GaussianSplatting][WorldLifetime] GaussianSplatWorld::clear() drops chunk_payload_source") {
+    Ref<GaussianSplatWorld> world = create_test_world();
+    Ref<GaussianData> data = world->get_gaussian_data();
+    CHECK(data.is_valid());
+
+    Ref<InMemoryChunkPayloadSource> payload_source;
+    payload_source.instantiate();
+    payload_source->set_data(data);
+
+    world->set_chunk_payload_source(payload_source);
+    CHECK_MESSAGE(world->get_chunk_payload_source().is_valid(),
+            "Sanity: payload source should be attached before clear()");
+
+    world->clear();
+
+    CHECK_MESSAGE(world->get_gaussian_data().is_null(),
+            "clear() must drop gaussian_data");
+    CHECK_MESSAGE(world->get_chunk_payload_source().is_null(),
+            "clear() must drop chunk_payload_source");
 }
 
 TEST_CASE("[GaussianSplatting][Persistence] validate_file accepts valid GSF") {

--- a/modules/gaussian_splatting/tests/test_renderer_pipeline.h
+++ b/modules/gaussian_splatting/tests/test_renderer_pipeline.h
@@ -1412,6 +1412,74 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] Missing renderer data publishes an e
     renderer.unref();
 }
 
+TEST_CASE("[GaussianSplatting][RequiresGPU] Streaming-requested failure hard-fails without bouncing to resident render") {
+    // When route_policy is STREAMING and the streaming system is unavailable,
+    // render_scene_instance must publish a typed COMMON.SKIP.STREAMING_NOT_READY.*
+    // route and must not silently fall through to INSTANCE.RESIDENT. This is the
+    // terminal streaming -> resident bounce contract.
+    RenderingServer *rs = RenderingServer::get_singleton();
+    if (rs == nullptr) {
+        MESSAGE("Skipping test - Rendering server unavailable");
+        return;
+    }
+
+    ProjectSettings *project_settings = ProjectSettings::get_singleton();
+    if (project_settings == nullptr) {
+        MESSAGE("Skipping test - ProjectSettings unavailable");
+        return;
+    }
+
+    const String route_policy_setting = "rendering/gaussian_splatting/streaming/route_policy";
+    ScopedProjectSetting route_guard(project_settings, route_policy_setting);
+    project_settings->set_setting(route_policy_setting, int64_t(gs::settings::GS_ROUTE_STREAMING));
+
+    ScopedGaussianManagerPipeline manager_scope;
+    GaussianSplatManager *manager = manager_scope.get();
+    if (manager == nullptr) {
+        MESSAGE("Skipping test - GaussianSplatManager unavailable");
+        return;
+    }
+
+    ScopedRenderingDeviceLease device_lease;
+    RenderingDevice *primary_rd = device_lease.acquire(rs, manager);
+    if (primary_rd == nullptr) {
+        MESSAGE("Skipping test - Rendering device unavailable");
+        return;
+    }
+
+    Ref<GaussianSplatRenderer> renderer;
+    renderer.instantiate(primary_rd);
+    CHECK(renderer.is_valid());
+    if (!renderer.is_valid()) {
+        return;
+    }
+    renderer->initialize();
+    renderer->test_release_current_streaming_system();
+
+    RenderSceneDataRD scene_data;
+    scene_data.cam_transform = Transform3D(Basis(), Vector3(0.0f, 0.0f, 5.0f));
+    scene_data.cam_projection.set_perspective(70.0f, 1.0f, 0.1f, 100.0f);
+
+    RenderDataRD render_data;
+    render_data.scene_data = &scene_data;
+    render_data.render_buffers = Ref<RenderSceneBuffersRD>();
+
+    renderer->render_scene_instance(&render_data);
+
+    const String route_uid = renderer->get_debug_state().route_uid;
+    CHECK_MESSAGE(route_uid.begins_with("COMMON.SKIP.STREAMING_NOT_READY."),
+            vformat("Expected streaming-requested failure to publish a typed streaming-not-ready route, got '%s'", route_uid));
+    CHECK_MESSAGE(route_uid != String(RenderRouteUID::INSTANCE_RESIDENT),
+            "Streaming-requested failure must not bounce to INSTANCE.RESIDENT");
+
+    const Dictionary stats = renderer->get_render_stats();
+    const String cull_route_uid = stats.get("cull_route_uid", String());
+    CHECK_MESSAGE(cull_route_uid != String(RenderRouteUID::INSTANCE_RESIDENT),
+            "Streaming-requested failure must not produce a resident cull route");
+
+    renderer.unref();
+}
+
 TEST_CASE("[GaussianSplatting][RequiresGPU] Static layout fallback publishes typed validator-aligned diagnostics") {
     RenderingServer *rs = RenderingServer::get_singleton();
     if (rs == nullptr) {
@@ -2090,7 +2158,11 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] CPU fallback publishes unsorted cull
     renderer.unref();
 }
 
-TEST_CASE("[GaussianSplatting][RequiresGPU] Camera-stable instance path publishes identity fallback when strict sort is disabled") {
+TEST_CASE("[GaussianSplatting][RequiresGPU] Camera-stable instance path never publishes identity fallback") {
+    // Instance-domain identity fallback has been deleted. When the camera is
+    // stable, the instance pipeline is active, and no reusable sorted buffer
+    // exists, the orchestrator must either produce a real sort or hard-fail the
+    // frame — it must never emit INSTANCE.SORT.IDENTITY_FALLBACK.
     RenderingServer *rs = RenderingServer::get_singleton();
     if (rs == nullptr) {
         MESSAGE("Skipping test - Rendering server unavailable");
@@ -2103,6 +2175,8 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] Camera-stable instance path publishe
         return;
     }
 
+    // Flip strict_global_sort off explicitly to prove that even the pre-existing
+    // escape hatch no longer revives the identity fallback path.
     const String force_cpu_setting = "rendering/gaussian_splatting/sorting/force_cpu_sort";
     const String strict_sort_setting = "rendering/gaussian_splatting/sorting/strict_global_sort";
     ScopedGpuSortingConfigReload strict_reload_guard;
@@ -2150,16 +2224,10 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] Camera-stable instance path publishe
     sorting_state.last_sort_transform_valid = true;
     renderer->get_subsystem_state().gpu_culler->get_config().cull_params_dirty = false;
 
-    GaussianSplatRenderer::SortStageSummary summary =
-            renderer->test_sort_for_view(Transform3D(), GaussianRenderState::IndexDomain::CHUNK_REF);
+    renderer->test_sort_for_view(Transform3D(), GaussianRenderState::IndexDomain::CHUNK_REF);
 
-    CHECK_FALSE(summary.did_execute);
-    CHECK(summary.sorted_count == 1);
-    CHECK(renderer->get_debug_state().sort_route_uid == String(RenderRouteUID::INSTANCE_SORT_IDENTITY_FALLBACK));
-    CHECK(renderer->get_visible_splat_count() == 1);
-    const Vector<uint32_t> sorted_indices = read_renderer_sort_indices(renderer, 1);
-    REQUIRE(sorted_indices.size() == 1);
-    CHECK(sorted_indices[0] == 0);
+    const String sort_route = renderer->get_debug_state().sort_route_uid;
+    CHECK(sort_route != "INSTANCE.SORT.IDENTITY_FALLBACK");
 
     renderer.unref();
 }
@@ -3760,7 +3828,6 @@ TEST_CASE("[GaussianSplatting] frame backend plan centralizes streaming bootstra
 	CHECK_FALSE(backend_plan.prefer_resident_backend);
 	CHECK_FALSE(backend_plan.streaming_ready);
 	CHECK(backend_plan.should_attempt_streaming_bootstrap);
-	CHECK_FALSE(backend_plan.allow_legacy_resident_fallback);
 	CHECK(backend_plan.allow_primary_fallback_instance);
 }
 
@@ -3784,7 +3851,6 @@ TEST_CASE("[GaussianSplatting] frame backend plan preserves resident request sem
 	CHECK_FALSE(backend_plan.streaming_requested);
 	CHECK(backend_plan.prefer_resident_backend);
 	CHECK_FALSE(backend_plan.should_attempt_streaming_bootstrap);
-	CHECK(backend_plan.allow_legacy_resident_fallback);
 	CHECK_FALSE(backend_plan.allow_primary_fallback_instance);
 	CHECK(backend_plan.resident_backend_reason == String("requested_resident_policy"));
 }

--- a/modules/gaussian_splatting/tests/test_scene_director_submission_scaffolding.h
+++ b/modules/gaussian_splatting/tests/test_scene_director_submission_scaffolding.h
@@ -273,8 +273,6 @@ TEST_CASE("[GaussianSplatting][SceneDirector][WorldSubmission] Same-owner resubm
 			baseline_renderer_state.streaming_overrides.vram_budget_config.max_chunks);
 	CHECK(restored_renderer_state.streaming_overrides.override_io_source ==
 			baseline_renderer_state.streaming_overrides.override_io_source);
-	CHECK(restored_renderer_state.streaming_overrides.io_source_path ==
-			baseline_renderer_state.streaming_overrides.io_source_path);
 	CHECK(restored_renderer_state.has_active_world_submission == baseline_renderer_state.has_active_world_submission);
 	CHECK(restored_renderer_state.has_desired_residency_hint == baseline_renderer_state.has_desired_residency_hint);
 	CHECK(restored_renderer_state.desired_residency_hint == baseline_renderer_state.desired_residency_hint);
@@ -479,7 +477,9 @@ TEST_CASE("[GaussianSplatting][World][SceneTree] World node forwards desired ove
 	CHECK(int64_t(streaming_overrides[StringName("vram_min_chunks")]) == 2);
 	CHECK(int64_t(streaming_overrides[StringName("vram_max_chunks")]) == 32);
 	CHECK((bool)streaming_overrides[StringName("override_io_source")]);
-	CHECK(streaming_overrides[StringName("io_source_path")] == String("res://stage1b_world.gsplatworld"));
+	// io_source_path was removed: only the override_io_source flag is published now. Any string
+	// payload is dropped by the director because no runtime consumer reads it.
+	CHECK(!streaming_overrides.has(StringName("io_source_path")));
 
 	if (renderer.is_valid()) {
 		int32_t residency_hint = GaussianSplatSceneDirector::SUBMISSION_RESIDENCY_HINT_STREAMING;
@@ -536,8 +536,6 @@ TEST_CASE("[GaussianSplatting][World][SceneTree] World node forwards desired ove
 				baseline_renderer_state.streaming_overrides.vram_budget_config.max_chunks);
 		CHECK(restored_renderer_state.streaming_overrides.override_io_source ==
 				baseline_renderer_state.streaming_overrides.override_io_source);
-		CHECK(restored_renderer_state.streaming_overrides.io_source_path ==
-				baseline_renderer_state.streaming_overrides.io_source_path);
 		CHECK(restored_renderer_state.has_active_world_submission == baseline_renderer_state.has_active_world_submission);
 		CHECK(restored_renderer_state.has_desired_residency_hint == baseline_renderer_state.has_desired_residency_hint);
 		CHECK(restored_renderer_state.desired_residency_hint == baseline_renderer_state.desired_residency_hint);

--- a/modules/gaussian_splatting/tests/test_sort_fallback_policy.h
+++ b/modules/gaussian_splatting/tests/test_sort_fallback_policy.h
@@ -11,10 +11,9 @@ using namespace GaussianSplatting;
 TEST_CASE("[GaussianSplatting][SortFallback] force_cpu_sort policy stays deterministic across domains") {
 	const SortFallbackPolicyDecision instance_policy =
 			build_sort_fallback_policy(SortFallbackScenario::FORCE_CPU_OVERRIDE, true);
-	CHECK(instance_policy.action_count == 3);
+	CHECK(instance_policy.action_count == 2);
 	CHECK(instance_policy.actions[0] == SortFallbackAction::REUSE_PREVIOUS_SORT);
-	CHECK(instance_policy.actions[1] == SortFallbackAction::PUBLISH_INSTANCE_IDENTITY);
-	CHECK(instance_policy.actions[2] == SortFallbackAction::FAIL);
+	CHECK(instance_policy.actions[1] == SortFallbackAction::FAIL);
 	CHECK(!instance_policy.cpu_sort_forced);
 
 	const SortFallbackPolicyDecision global_policy =
@@ -25,14 +24,13 @@ TEST_CASE("[GaussianSplatting][SortFallback] force_cpu_sort policy stays determi
 	CHECK(global_policy.cpu_sort_forced);
 }
 
-TEST_CASE("[GaussianSplatting][SortFallback] GPU fallback policy prefers reuse then identity/CPU") {
+TEST_CASE("[GaussianSplatting][SortFallback] GPU fallback policy reuses then CPU-sorts or fails") {
 	for (SortFallbackScenario scenario : { SortFallbackScenario::SORTER_UNAVAILABLE, SortFallbackScenario::GPU_SORT_FAILED }) {
 		SUBCASE(scenario == SortFallbackScenario::SORTER_UNAVAILABLE ? "sorter unavailable" : "gpu sort failed") {
 			const SortFallbackPolicyDecision instance_policy = build_sort_fallback_policy(scenario, true);
-			CHECK(instance_policy.action_count == 3);
+			CHECK(instance_policy.action_count == 2);
 			CHECK(instance_policy.actions[0] == SortFallbackAction::REUSE_PREVIOUS_SORT);
-			CHECK(instance_policy.actions[1] == SortFallbackAction::PUBLISH_INSTANCE_IDENTITY);
-			CHECK(instance_policy.actions[2] == SortFallbackAction::FAIL);
+			CHECK(instance_policy.actions[1] == SortFallbackAction::FAIL);
 			CHECK(!instance_policy.cpu_sort_forced);
 
 			const SortFallbackPolicyDecision global_policy = build_sort_fallback_policy(scenario, false);
@@ -45,38 +43,27 @@ TEST_CASE("[GaussianSplatting][SortFallback] GPU fallback policy prefers reuse t
 	}
 }
 
-TEST_CASE("[GaussianSplatting][SortFallback] strict mode suppresses unsorted instance fallback publication") {
-	CHECK(allow_unsorted_fallback_publication(false));
-	CHECK_FALSE(allow_unsorted_fallback_publication(true));
-
-	const SortFallbackPolicyDecision strict_force_cpu_instance_policy =
-			build_sort_fallback_policy(SortFallbackScenario::FORCE_CPU_OVERRIDE, true, true);
-	CHECK(strict_force_cpu_instance_policy.action_count == 2);
-	CHECK(strict_force_cpu_instance_policy.actions[0] == SortFallbackAction::REUSE_PREVIOUS_SORT);
-	CHECK(strict_force_cpu_instance_policy.actions[1] == SortFallbackAction::FAIL);
-	CHECK(!strict_force_cpu_instance_policy.cpu_sort_forced);
-
-	const SortFallbackPolicyDecision strict_gpu_failure_instance_policy =
-			build_sort_fallback_policy(SortFallbackScenario::GPU_SORT_FAILED, true, true);
-	CHECK(strict_gpu_failure_instance_policy.action_count == 2);
-	CHECK(strict_gpu_failure_instance_policy.actions[0] == SortFallbackAction::REUSE_PREVIOUS_SORT);
-	CHECK(strict_gpu_failure_instance_policy.actions[1] == SortFallbackAction::FAIL);
-	CHECK(!strict_gpu_failure_instance_policy.cpu_sort_forced);
+TEST_CASE("[GaussianSplatting][SortFallback] instance domain never schedules an unsorted fallback") {
+	// Identity publication and cull-order bootstrap have been removed. The
+	// instance domain must only ever see REUSE_PREVIOUS_SORT followed by FAIL,
+	// regardless of scenario or strict-mode flag.
+	for (SortFallbackScenario scenario : { SortFallbackScenario::FORCE_CPU_OVERRIDE,
+				 SortFallbackScenario::SORTER_UNAVAILABLE,
+				 SortFallbackScenario::GPU_SORT_FAILED }) {
+		for (bool strict : { false, true }) {
+			const SortFallbackPolicyDecision policy = build_sort_fallback_policy(scenario, true, strict);
+			for (uint32_t i = 0; i < policy.action_count; i++) {
+				CHECK(policy.actions[i] != SortFallbackAction::RUN_CPU_SORT);
+				// No stand-in for the deleted PUBLISH_INSTANCE_IDENTITY survives in
+				// the enum, so simply verify the remaining set is just reuse / fail.
+				CHECK((policy.actions[i] == SortFallbackAction::REUSE_PREVIOUS_SORT ||
+						policy.actions[i] == SortFallbackAction::FAIL));
+			}
+		}
+	}
 }
 
-TEST_CASE("[GaussianSplatting][SortFallback] orchestrator guards block unsorted strict-mode fallbacks") {
-	CHECK(allow_instance_identity_fallback_in_orchestrator(false, true, true, 1));
-	CHECK_FALSE(allow_instance_identity_fallback_in_orchestrator(true, true, true, 1));
-	CHECK_FALSE(allow_instance_identity_fallback_in_orchestrator(false, false, true, 1));
-	CHECK_FALSE(allow_instance_identity_fallback_in_orchestrator(false, true, false, 1));
-	CHECK_FALSE(allow_instance_identity_fallback_in_orchestrator(false, true, true, 0));
-
-	CHECK(allow_camera_stable_cull_order_bootstrap_in_orchestrator(false, false, true, true));
-	CHECK_FALSE(allow_camera_stable_cull_order_bootstrap_in_orchestrator(true, false, true, true));
-	CHECK_FALSE(allow_camera_stable_cull_order_bootstrap_in_orchestrator(false, true, true, true));
-	CHECK_FALSE(allow_camera_stable_cull_order_bootstrap_in_orchestrator(false, false, false, true));
-	CHECK_FALSE(allow_camera_stable_cull_order_bootstrap_in_orchestrator(false, false, true, false));
-
+TEST_CASE("[GaussianSplatting][SortFallback] strict mode gates unsorted CPU fallback when positions are unavailable") {
 	CHECK(allow_unsorted_cpu_fallback_in_orchestrator(false, false));
 	CHECK(allow_unsorted_cpu_fallback_in_orchestrator(true, true));
 	CHECK_FALSE(allow_unsorted_cpu_fallback_in_orchestrator(true, false));


### PR DESCRIPTION
## Summary
This lands Wave 1 of the gaussian_splatting cleanup in three scoped commits:

1. Remove loader fallback and dead container paths
2. Fix world payload lifetime and serializer rebuild
3. Remove legacy renderer fallback branches

## What changed
- deleted `GaussianSplatContainer::apply_to_renderer()` and cleaned up its docs/bindings
- hard-failed unknown raw loader extensions instead of permissive fallback dispatch
- hard-failed malformed ASCII PLY rows instead of silently skipping them
- removed dead `streaming_overrides.io_source_path` plumbing
- relabeled compressed `.gsplatworld` as resident-only compatibility
- fixed `GaussianSplatWorld::clear()` to drop `chunk_payload_source`
- replaced serializer `resize()+set_gaussian()` reconstruction with the canonical bulk path and added persistence coverage
- removed the terminal streaming -> resident bounce
- removed identity-sort fallback and cull-order bootstrap branches
- removed the legacy resident fallback branch from the resident path
- cleaned up dead route UIDs/labels left behind by the renderer changes

## Validation
- full `scons` build succeeded after clearing one unrelated corrupt cached OpenXR object file
- targeted Wave 1 validation passed: `32/32` test cases, `197/197` assertions
- two `[RequiresGPU]` tests still self-skip under the `--test` harness because it does not initialize a `RenderingServer`; this is a pre-existing harness limitation, not a Wave 1 regression

## Reviewer note
The one user-visible semantic change is that explicit resident policy with an unpublishable resident contract now yields no output instead of falling back to the legacy cull/sort pipeline. That is the intended outcome of the renderer kill pass.

## Follow-up
Wave 2 will handle node-surface cleanup and data-authority hardening.
