### PR TITLE
gaussian_splatting: propagate instance_grading_buffer RID through contract publish

### DIFF
--- a/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
@@ -1801,6 +1801,23 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 			buffers.instance_count_buffer = resource_state_mut.instance_count_buffer;
 		}
 
+		// Propagate the persistent per-renderer instance_grading_buffer RID
+		// into the local `buffers` snapshot before it is handed to
+		// publish_instance_pipeline_contract(). Every other persistent SSBO
+		// above (splat_ref, counter, chunk_dispatch, indirect_count,
+		// instance_count) is forwarded the same way; grading was the only
+		// one whose RID lived only on `instance_pipeline_buffers` via
+		// update_instance_grading_buffer() (gaussian_splat_renderer.cpp:2720),
+		// which runs inside the `upload_changed` branch. When a contract
+		// republish landed with `upload_changed == false` — or when
+		// clear_instance_pipeline_buffers() had zeroed the pipeline buffers
+		// between a prior world teardown and the next world bind — the
+		// grading RID never made it back into instance_pipeline_buffers,
+		// tripping first_raster_violation()'s
+		// RASTER_INSTANCE_GRADING_BUFFER_MISSING check on the next readiness
+		// evaluation even though atlas/cull/sort were valid.
+		buffers.instance_grading_buffer = resource_state_mut.instance_grading_buffer;
+
 		GPUSortingPipeline *sorting_pipeline = state_view.get_subsystem_state_view().sorting_pipeline.ptr();
 		if (sorting_pipeline) {
 			// Instance pipeline may need more sort capacity than the per-instance

--- a/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
+++ b/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
@@ -595,6 +595,16 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 	}
 	buffers.instance_count_buffer = resource_state.instance_count_buffer;
 
+	// Mirror the render_streaming_orchestrator pattern: forward the persistent
+	// per-renderer instance_grading_buffer RID through the local `buffers`
+	// snapshot so it survives publish_instance_pipeline_contract() below. The
+	// subsequent update_instance_grading_buffer() call (~line 687) refreshes
+	// the GPU contents; this line ensures the RID itself lands in
+	// instance_pipeline_buffers even on paths that hit clear-then-republish
+	// sequences, so first_raster_violation() doesn't read a stale RID() in
+	// the gap before update_instance_grading_buffer() runs.
+	buffers.instance_grading_buffer = resource_state.instance_grading_buffer;
+
 	Ref<GPUSortingPipeline> sorting_pipeline = p_renderer->get_subsystem_state().sorting_pipeline;
 	if (sorting_pipeline.is_null()) {
 		if (r_reason) {


### PR DESCRIPTION
Stacks on **PR #282** (`fix/stress-residency-telemetry`). Do not merge before #282.

## Root cause

`instance_pipeline_buffers.instance_grading_buffer` had only a single writer — `update_instance_grading_buffer()` at `gaussian_splat_renderer.cpp:2720`. Every other persistent per-renderer SSBO (`splat_ref`, `counter`, `chunk_dispatch`, `indirect_count`, `instance_count`) gets pulled out of `resource_state` into the local `buffers` snapshot and rides through `publish_instance_pipeline_contract(buffers, …)` (which does `instance_pipeline_buffers = p_buffers` at `gaussian_splat_renderer.cpp:2575`). Grading was the asymmetric one.

That meant any sequence where the pipeline buffers got cleared (`clear_instance_pipeline_buffers()`) and then a contract republish landed with `upload_changed == false` left `instance_pipeline_buffers.instance_grading_buffer = RID()` while atlas/cull/sort were valid. `first_raster_violation()` (`instance_pipeline_contract.h:373-398`) then tripped `RASTER_INSTANCE_GRADING_BUFFER_MISSING`, the streaming orchestrator hard-failed at line 2052, the tile rasterizer's `ERR_FAIL_COND` at `tile_render_binning.cpp:226` triggered, and the process crashed with `STATUS_ACCESS_VIOLATION`.

This is exactly the bug PR #282's teardown barrier exposed on `tier_2_5m`. Pre-barrier, `tier_1m` aborted before the renderer's grading state could advance; post-barrier, `tier_1m` runs to completion, the next world's `_ensure_renderer()` re-binds the same shared renderer mid-clear, and the asymmetric grading plumbing fell through.

## Fix

Two lines (with detailed comments) — one in the streaming orchestrator, one in the resident publisher — that copy `resource_state.instance_grading_buffer` into `buffers.instance_grading_buffer` just before contract publish, mirroring the existing pattern for the other persistent SSBOs.

`update_instance_grading_buffer()` still runs in the upload branch and refreshes GPU contents when instance rows change. This patch only ensures the RID itself rides the contract so the readiness check can't read a stale `RID()` in the gap before the upload branch runs. If `resource_state.instance_grading_buffer` is genuinely unallocated (first ever frame) the readiness check still correctly reports missing and the upload path lazily creates one.

## Validation (Windows dev harness, three consecutive runs of `test_gpu_streaming_stress.gd`)

|              | residency_ratio | budget_failures           | grading-missing | crash |
|--------------|-----------------|---------------------------|-----------------|-------|
| tier_250k    | 1.0             | [\"frame_p95_exceeded\"]    | no              | no    |
| tier_1m      | 1.0             | [\"frame_p95_exceeded\"]    | no              | no    |
| tier_2_5m    | 1.0             | [\"frame_p95_exceeded\"]    | no              | no    |

No `raster_instance_grading_buffer_missing`. No invariant hard-fail. No `Storage buffer supplied (binding: 1) is invalid`. No GPU-cull uniform-set failure. No `STATUS_ACCESS_VIOLATION`. Process exits cleanly with code 1 due to the residual `tier_1m frame_p95_exceeded` — same separate timing-budget question PR #282 already documents and not addressed here.

## What this is **not**

- Not a renderer perf change.
- Not a budget tuning change.
- Not a behavioral workaround. Removes a real asymmetric plumbing gap.
- Not stacked on PR #281. Stacked on PR #282 only, because the teardown barrier is what makes this bug reproducible.

## Test plan
- [ ] Self-hosted Windows runner: run `test_gpu_streaming_stress.gd`, confirm no `raster_instance_grading_buffer_missing` and no `STATUS_ACCESS_VIOLATION` exit.
- [ ] Confirm tier_1m / tier_2_5m residency stays 1.0.
- [ ] Confirm `Storage buffer supplied (binding: 1) is invalid` and `Failed to create instance cull uniform set` do not appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)