### PR TITLE
gaussian_splatting: address Codex review comments on PR #281 / #282

### DIFF
--- a/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
@@ -216,6 +216,27 @@ bool GaussianSplatAsset::_runtime_mutation_permitted(const char *p_method) const
     return false;
 }
 
+Error GaussianSplatAsset::copy_from(const Ref<Resource> &p_resource) {
+    // ResourceLoader's CACHE_MODE_REPLACE path applies replacements via
+    // Resource::copy_from(), which iterates storage properties and writes
+    // them back through set(...) (core/io/resource.cpp:225-252). Our packed
+    // setters refuse mutations once payload_sealed is true (post first
+    // get_gaussian_data()), so a replace-load on a previously hot asset
+    // would silently drop every data/* property and the engine-driven
+    // hot-reload would be a no-op. Unseal here so the engine's reload
+    // semantics still work; the next get_gaussian_data() call re-seals
+    // naturally on the next runtime hand-out.
+    const bool previous_seal = payload_sealed;
+    payload_sealed = false;
+    const Error err = Resource::copy_from(p_resource);
+    if (err != OK) {
+        // Restore seal on failure so a rejected copy (null/incompatible
+        // resource) does not leave a runtime-authoritative asset mutable.
+        payload_sealed = previous_seal;
+    }
+    return err;
+}
+
 void GaussianSplatAsset::_invalidate_bounds_metadata() {
     import_metadata.erase(StringName("bounds"));
     import_metadata[StringName("bounds_dirty")] = true;

--- a/modules/gaussian_splatting/core/gaussian_splat_asset.h
+++ b/modules/gaussian_splatting/core/gaussian_splat_asset.h
@@ -93,6 +93,15 @@ public:
     // Returns true when the asset has been populated with splat data (splat_count > 0).
     bool is_loaded() const { return splat_count > 0; }
 
+    // Override Resource::copy_from so engine-driven hot-reload via
+    // ResourceLoader::load(..., CACHE_MODE_REPLACE) can repopulate a sealed
+    // asset. The base implementation iterates storage properties and writes
+    // them back through set(...) (core/io/resource.cpp:225-252); without
+    // this override, a sealed GaussianSplatAsset would silently drop every
+    // data/* setter and reload would appear to succeed while leaving stale
+    // arrays in place.
+    virtual Error copy_from(const Ref<Resource> &p_resource) override;
+
     void set_asset_type(AssetType p_type);
     AssetType get_asset_type() const { return asset_type; }
 

--- a/modules/gaussian_splatting/core/gaussian_streaming.cpp
+++ b/modules/gaussian_splatting/core/gaussian_streaming.cpp
@@ -2665,8 +2665,14 @@ void GaussianStreamingSystem::_evict_for_vram_budget(uint32_t &evictions_left, b
     while (budget.loaded_chunks_count > 0 &&
             budget.vram_regulator->should_trigger_eviction(_get_total_vram_usage_bytes()) &&
             evictions_left > 0) {
-        if (_evict_non_primary_lru()) {
-            // Non-primary-first eviction keeps primary visible residency stable under budget pressure.
+        // Non-primary-first eviction keeps primary visible residency stable
+        // under budget pressure. _evict_non_primary_lru() now returns
+        // EvictionResult and does NOT internally record (matches
+        // _evict_least_recently_used()'s contract), so we record here.
+        EvictionResult non_primary_result = _evict_non_primary_lru();
+        if (non_primary_result == EvictionResult::EvictedNonVisible ||
+                non_primary_result == EvictionResult::EvictedVisible) {
+            eviction_controller.record_eviction_result(non_primary_result);
             evictions_left--;
             continue;
         }
@@ -2688,6 +2694,22 @@ void GaussianStreamingSystem::_evict_for_vram_budget(uint32_t &evictions_left, b
 GaussianStreamingSystem::EvictionResult GaussianStreamingSystem::_evict_for_admission_gate(
         const ResidencyBudgetController::AdmissionGate &p_admission_gate, bool &r_visible_fallback_attempted) {
     r_visible_fallback_attempted = false;
+
+    // Prefer evicting a non-primary-asset chunk first under atlas-slot
+    // pressure. `_evict_least_recently_used()` walks `system.chunks`
+    // (the primary-asset chunk list), so without this preliminary pass an
+    // atlas-slot shortage triggered by a non-primary-asset load would
+    // either evict primary chunks or report SkippedAllVisible even when
+    // non-primary chunks are available, stalling multi-asset streaming.
+    // Mirrors the VRAM-budget path in `_evict_for_vram_budget()` (~line 2668).
+    // _evict_non_primary_lru() returns the actual EvictionResult; propagate it
+    // so callers record visible-vs-nonvisible counts correctly (the previous
+    // hardcoded EvictedNonVisible under-counted visible evictions).
+    EvictionResult non_primary_result = _evict_non_primary_lru();
+    if (non_primary_result == EvictionResult::EvictedNonVisible ||
+            non_primary_result == EvictionResult::EvictedVisible) {
+        return non_primary_result;
+    }
 
     EvictionResult result = _evict_least_recently_used(false);
     if (result == EvictionResult::SkippedAllVisible &&
@@ -3515,7 +3537,7 @@ GaussianStreamingSystem::EvictionResult GaussianStreamingSystem::_evict_least_re
     return eviction_controller.evict_least_recently_used(*this, p_allow_visible_eviction);
 }
 
-bool GaussianStreamingSystem::_evict_non_primary_lru() {
+GaussianStreamingSystem::EvictionResult GaussianStreamingSystem::_evict_non_primary_lru() {
     return eviction_controller.evict_non_primary_lru(*this);
 }
 

--- a/modules/gaussian_splatting/core/gaussian_streaming.h
+++ b/modules/gaussian_splatting/core/gaussian_streaming.h
@@ -440,7 +440,7 @@ private:
     EvictionResult _evict_for_admission_gate(
             const ResidencyBudgetController::AdmissionGate &p_admission_gate,
             bool &r_visible_fallback_attempted);
-    bool _evict_non_primary_lru();
+    EvictionResult _evict_non_primary_lru();
 
     // Distance-based LOD (Octree-GS) helpers
     void _update_chunk_lod_parameters(const Vector3 &camera_pos);

--- a/modules/gaussian_splatting/core/streaming_eviction_controller.cpp
+++ b/modules/gaussian_splatting/core/streaming_eviction_controller.cpp
@@ -126,9 +126,15 @@ StreamingEvictionController::EvictionResult StreamingEvictionController::evict_l
     return EvictionResult::NoEviction;
 }
 
-bool StreamingEvictionController::evict_non_primary_lru(GaussianStreamingSystem &system) {
+StreamingEvictionController::EvictionResult StreamingEvictionController::evict_non_primary_lru(GaussianStreamingSystem &system) {
+    // Contract: this returns EvictionResult and does NOT internally call
+    // record_eviction_result(). Callers are responsible for recording the
+    // result so per-frame eviction-budget bookkeeping stays single-source.
+    // (Previously this function returned bool and self-recorded, which made
+    // it incompatible with helpers like _evict_for_admission_gate() whose
+    // callers also record — producing double-counts.)
     if (max_evictions_per_frame > 0 && chunks_evicted_this_frame >= max_evictions_per_frame) {
-        return false;
+        return EvictionResult::NoEviction;
     }
 
     if (cached_non_primary_lru_frame != system.total_frame_count) {
@@ -192,9 +198,8 @@ bool StreamingEvictionController::evict_non_primary_lru(GaussianStreamingSystem 
 
         const bool was_visible = asset_chunks[candidate.chunk_id].is_visible;
         system._unload_chunk(candidate.asset_id, candidate.chunk_id);
-        record_eviction_result(was_visible ? EvictionResult::EvictedVisible : EvictionResult::EvictedNonVisible);
-        return true;
+        return was_visible ? EvictionResult::EvictedVisible : EvictionResult::EvictedNonVisible;
     }
 
-    return false;
+    return EvictionResult::NoEviction;
 }

--- a/modules/gaussian_splatting/core/streaming_eviction_controller.h
+++ b/modules/gaussian_splatting/core/streaming_eviction_controller.h
@@ -33,7 +33,11 @@ public:
     uint32_t get_visible_chunks_evicted_this_frame() const { return visible_chunks_evicted_this_frame; }
 
     EvictionResult evict_least_recently_used(GaussianStreamingSystem &system, bool p_allow_visible_eviction);
-    bool evict_non_primary_lru(GaussianStreamingSystem &system);
+    // Returns EvictionResult and does NOT internally call record_eviction_result(),
+    // matching the contract of evict_least_recently_used() so callers can drive
+    // bookkeeping explicitly. Returns NoEviction when nothing was evicted (either
+    // budget exhausted or no eligible candidates).
+    EvictionResult evict_non_primary_lru(GaussianStreamingSystem &system);
 
 private:
     uint64_t chunk_load_counter = 0;

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -1685,8 +1685,19 @@ void GaussianSplatNode3D::_load_asset() {
     if (!asset_resource_path.is_empty()) {
         reloaded_asset = ResourceLoader::load(asset_resource_path, "GaussianSplatAsset",
                 ResourceFormatLoader::CACHE_MODE_REPLACE);
-        if (reloaded_asset.is_null()) {
+        // Two failure cases the engine returns as "non-null but useless":
+        //   1. Disk read failure under CACHE_MODE_REPLACE returns the
+        //      previously cached resource (core/io/resource_loader.cpp
+        //      ~471-484), so a corrupt/missing .gaussiansplat looks like
+        //      a successful reload of stale cached data.
+        //   2. A successfully-parsed but empty asset (splat_count == 0)
+        //      can happen for stale or partially-imported resources.
+        // Treat both as reload failure so the asset_source_path fallback
+        // below can re-import from .ply/.spz instead of silently swapping
+        // the node payload to empty/stale data and emitting `asset_loaded`.
+        if (reloaded_asset.is_null() || reloaded_asset->get_splat_count() == 0) {
             load_error_message = vformat("Failed to reload GaussianSplatAsset resource: %s", asset_resource_path);
+            reloaded_asset.unref();
         }
     }
 

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
@@ -1404,6 +1404,25 @@ GaussianSplatRenderer::FrameBackendPlan GaussianSplatRenderer::build_frame_backe
     plan.has_active_world_submission = any_world_submission;
     plan.resident_backend_reason = plan.runtime_policy.backend_preference_reason;
     plan.streaming_backend_reason = plan.runtime_policy.backend_preference_reason;
+
+    // Direct-data callers (`set_gaussian_data()` on a standalone renderer
+    // without any SceneDirector / world submission, e.g. tests, tools,
+    // editor preview) have no instance to populate
+    // `instance_pipeline_instance_cache`. Under the default streaming route
+    // policy the streaming backend would then run with an empty instance
+    // cache and emit zero splats — the fallback bootstrap instance that
+    // used to cover this case was removed when the synthetic-instance shim
+    // was pruned (commit de71685b08). Force resident here when we observe
+    // direct data on the renderer with no submission, so callers don't
+    // need to manually pin `route_policy=resident`.
+    if (!plan.prefer_resident_backend && !any_world_submission) {
+        const Ref<::GaussianData> &direct_data = get_scene_state().gaussian_data;
+        if (direct_data.is_valid() && direct_data->get_count() > 0) {
+            plan.prefer_resident_backend = true;
+            plan.resident_backend_reason = "direct_data_no_submission";
+            plan.should_attempt_streaming_bootstrap = false;
+        }
+    }
     return plan;
 }
 

--- a/scripts/bake_gsplatworld.gd
+++ b/scripts/bake_gsplatworld.gd
@@ -80,7 +80,14 @@ func _bake_from_scene(args: Dictionary) -> GaussianSplatWorld:
         return null
 
     _apply_chunk_size(container, args)
-    _ensure_container_assets(container)
+    if not _ensure_container_assets(container):
+        # _ensure_container_assets() prints per-child diagnostics. Aborting
+        # here keeps an incomplete bake (where merge_children silently drops
+        # null-asset children) from producing a half-empty .gsplatworld
+        # with a zero exit code, which would corrupt downstream content/test
+        # pipelines that trust the artifact.
+        printerr("Bake aborted: one or more GaussianSplatNode3D children are missing splat_asset.")
+        return null
     container.merge_children()
 
     var world := container.export_world_resource()
@@ -140,7 +147,8 @@ func _find_container(root: Node, container_path: String) -> GaussianSplatContain
         return null
     return matches[0] as GaussianSplatContainer
 
-func _ensure_container_assets(container: GaussianSplatContainer) -> void:
+func _ensure_container_assets(container: GaussianSplatContainer) -> bool:
+    var ok := true
     var count := container.get_child_count()
     for i in range(count):
         var child := container.get_child(i)
@@ -149,6 +157,8 @@ func _ensure_container_assets(container: GaussianSplatContainer) -> void:
             continue
         if splat_node.get_splat_asset() == null:
             printerr("GaussianSplatNode3D is missing splat_asset: %s" % splat_node.get_path())
+            ok = false
+    return ok
 
 func _load_asset(path: String) -> GaussianSplatAsset:
     var ext := path.get_extension().to_lower()

--- a/tests/runtime/test_gpu_streaming_5m_probe.gd
+++ b/tests/runtime/test_gpu_streaming_5m_probe.gd
@@ -110,12 +110,31 @@ func _setup_world_scene(dataset: GaussianData) -> bool:
     return true
 
 func _teardown_world_scene() -> void:
-    if scene_root != null:
-        scene_root.queue_free()
+    var pending := scene_root
+    if pending != null:
+        pending.queue_free()
     scene_root = null
     camera = null
     world_node = null
     renderer = null
+    if pending == null:
+        return
+    # Wait until the queued scene root has actually exited the tree and been
+    # freed before returning. GaussianSplatWorld3D releases its shared-renderer
+    # submission ownership only on NOTIFICATION_EXIT_TREE
+    # (gaussian_splat_world_3d.cpp:113), and the shared renderer is re-bound
+    # whenever a new GaussianSplatWorld3D enters the tree via
+    # `_ensure_renderer()` (line 92). Without this barrier the next probe
+    # tier's `_setup_world_scene()` would run synchronously after
+    # `queue_free()` in the same frame, and the new world would bind the
+    # same shared renderer while the old world's submission was still
+    # resident — causing cross-tier residency / sort metric bleed. Same
+    # pattern as test_gpu_streaming_stress.gd. Bound the wait so a stuck
+    # free cannot hang CI.
+    for _i in range(8):
+        if not is_instance_valid(pending):
+            break
+        await process_frame
 
 func _read_int(stats: Dictionary, keys: Array[String], default_value: int = 0) -> int:
     for key in keys:
@@ -173,7 +192,7 @@ func _run_tier(name: String, size: int) -> Dictionary:
 
     if renderer == null:
         _record_failure("renderer unavailable after world apply", {"tier": name, "size": size})
-        _teardown_world_scene()
+        await _teardown_world_scene()
         return {"name": name, "size": size, "set_error": ERR_UNAVAILABLE}
 
     if renderer.get_max_splats() < size:
@@ -387,7 +406,7 @@ func _run_tier(name: String, size: int) -> Dictionary:
         "last_total_splats": _read_int(last_stats, ["total_splats", "uploaded_splat_count", "buffer_manager_count"]),
         "last_sort_avg_ms": _read_float(last_stats, ["gpu_sorter_avg_sort_ms", "gpu_sorter_avg_sort_time_ms"])
     }
-    _teardown_world_scene()
+    await _teardown_world_scene()
     return result
 
 func _run() -> void:


### PR DESCRIPTION
Stacked on **PR #281** (`fix/parallel-ply-spz-import`). Six focused commits, one per review comment cluster. Each commit cites the comment it addresses and the file/line of the underlying bug.

## Summary

| # | Commit | Priority | Comment |
|---|---|---|---|
| 1 | unseal asset payload on `Resource::copy_from` | **P1** | PR #281 `gaussian_splat_asset.cpp:234` + PR #282 `:210` (same bug) |
| 2 | non-primary eviction first in atlas-slot admission | **P1** | PR #281 `gaussian_streaming.cpp:2693` |
| 3 | force resident backend for direct-data renderers | **P1** | PR #282 `gaussian_splat_renderer.cpp:1387` + `render_streaming_orchestrator.cpp:1554` (same root cause) |
| 4 | reject empty / cached-stale assets on node reload | P2 | PR #282 `gaussian_splat_node_3d.cpp:1688` + `:1690` (same `_load_asset()` gap) |
| 5 | fail bake when a child node has no `splat_asset` | P2 | PR #282 `bake_gsplatworld.gd:151` |
| 6 | barrier 5m probe teardown on world `EXIT_TREE` | P2 | PR #282 `test_gpu_streaming_5m_probe.gd:114` (mirrors PR #282 `9d2caafd3e` stress-test fix) |

## Verification

- Local Windows build (dev_build=yes tests=yes) — clean.
- Doctest `[Node]` lane: 17 tests / 172 assertions / **all pass**.
- Doctest `[Importer]` + `[Persistence]` + `[DataAuthority]` lanes (most relevant to the asset/copy_from change): 55 tests / 353 assertions / **all pass**.

## Scope discipline

Each commit:
- Targets exactly one comment or one comment cluster sharing a root cause.
- Does **not** introduce new behavior beyond what the comment asks for.
- Does **not** touch any unrelated subsystems.
- Includes a comment block at the call site explaining the why and citing the upstream code reference (e.g. `core/io/resource.cpp:225-252`, `core/io/resource_loader.cpp:471-484`).

## Test plan

- [ ] Self-hosted Windows runner: full Module Build + Runtime Harness clean post-merge into PR #281.
- [ ] No regression in `[Importer]` / `[Persistence]` / `[DataAuthority]` / `[Node]` doctest lanes.
- [ ] Direct-data renderer test (if any) verifies forced-resident path produces non-zero rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)