### PR TITLE
gaussian_splatting: harden PLY loader header parsing and binary swaps

### DIFF
--- a/modules/gaussian_splatting/io/ply_loader.cpp
+++ b/modules/gaussian_splatting/io/ply_loader.cpp
@@ -147,6 +147,12 @@ Error PLYLoader::parse_header(Ref<FileAccess> file) {
 
     String current_element = ""; // Track current element type being parsed
     int vertex_property_offset = 0;
+    bool found_end_header = false;
+
+    // Practical upper bound for splat counts: 2^30 entries.  At ~248 bytes per
+    // raw vertex this already exceeds 256 GiB on disk, so anything larger is a
+    // header that overflows int sizing in resize() / chunked parsing below.
+    static constexpr int64_t PLY_MAX_VERTEX_COUNT = 1ll << 30;
 
     while (!file->eof_reached()) {
         line = file->get_line().strip_edges();
@@ -169,7 +175,14 @@ Error PLYLoader::parse_header(Ref<FileAccess> file) {
             if (parts.size() >= 2) {
                 current_element = parts[1]; // Could be "vertex", "face", etc.
                 if (current_element == "vertex" && parts.size() >= 3) {
-                    header.vertex_count = parts[2].to_int();
+                    const int64_t parsed_count = parts[2].to_int();
+                    if (parsed_count < 1 || parsed_count > PLY_MAX_VERTEX_COUNT) {
+                        GS_LOG_ERROR_DEFAULT(vformat(
+                                "[PLY] vertex count out of range: %d (must be 1..%d)",
+                                parsed_count, PLY_MAX_VERTEX_COUNT));
+                        return ERR_FILE_CORRUPT;
+                    }
+                    header.vertex_count = static_cast<int>(parsed_count);
                     vertex_property_offset = 0; // Reset offset for vertex properties
                     header.properties.clear();
                 }
@@ -199,6 +212,15 @@ Error PLYLoader::parse_header(Ref<FileAccess> file) {
                     prop.size = 4;
                 } else if (prop.type == "short" || prop.type == "int16") {
                     prop.size = 2;
+                } else if (prop.type == "uint" || prop.type == "uint32") {
+                    prop.size = 4;
+                } else if (prop.type == "char" || prop.type == "int8") {
+                    prop.size = 1;
+                } else {
+                    GS_LOG_ERROR_DEFAULT(vformat(
+                            "[PLY] unknown property type '%s' for property '%s'",
+                            prop.type, prop.name));
+                    return ERR_FILE_CORRUPT;
                 }
 
                 prop.offset = vertex_property_offset;
@@ -208,8 +230,14 @@ Error PLYLoader::parse_header(Ref<FileAccess> file) {
             }
         } else if (line == "end_header") {
             header.header_size = file->get_position();
+            found_end_header = true;
             break;
         }
+    }
+
+    if (!found_end_header) {
+        GS_LOG_ERROR_DEFAULT("[PLY] header truncated: missing end_header sentinel");
+        return ERR_FILE_CORRUPT;
     }
 
     if (header.vertex_count == 0) {
@@ -868,32 +896,22 @@ int PLYLoader::find_property_index(const String &name) const {
 
 float PLYLoader::read_float_property(const uint8_t *data, const PLYProperty &prop) const {
     if (prop.type == "float" || prop.type == "float32") {
-        float value;
-        memcpy(&value, data + prop.offset, sizeof(float));
+        uint32_t bits;
+        memcpy(&bits, data + prop.offset, sizeof(uint32_t));
         if (!header.is_little_endian) {
-            // Swap bytes for big endian
-            uint32_t *int_val = (uint32_t*)&value;
-            *int_val = ((*int_val & 0xFF000000) >> 24) |
-                      ((*int_val & 0x00FF0000) >> 8) |
-                      ((*int_val & 0x0000FF00) << 8) |
-                      ((*int_val & 0x000000FF) << 24);
+            bits = BSWAP32(bits);
         }
+        float value;
+        memcpy(&value, &bits, sizeof(float));
         return value;
     } else if (prop.type == "double" || prop.type == "float64") {
-        double value;
-        memcpy(&value, data + prop.offset, sizeof(double));
+        uint64_t bits;
+        memcpy(&bits, data + prop.offset, sizeof(uint64_t));
         if (!header.is_little_endian) {
-            // Swap bytes for big endian (64-bit)
-            uint64_t *int_val = (uint64_t*)&value;
-            *int_val = ((*int_val & 0xFF00000000000000ULL) >> 56) |
-                      ((*int_val & 0x00FF000000000000ULL) >> 40) |
-                      ((*int_val & 0x0000FF0000000000ULL) >> 24) |
-                      ((*int_val & 0x000000FF00000000ULL) >> 8) |
-                      ((*int_val & 0x00000000FF000000ULL) << 8) |
-                      ((*int_val & 0x0000000000FF0000ULL) << 24) |
-                      ((*int_val & 0x000000000000FF00ULL) << 40) |
-                      ((*int_val & 0x00000000000000FFULL) << 56);
+            bits = BSWAP64(bits);
         }
+        double value;
+        memcpy(&value, &bits, sizeof(double));
         return (float)value;
     }
     return 0.0f;
@@ -920,7 +938,8 @@ uint32_t PLYLoader::read_uint_property(const uint8_t *data, const PLYProperty &p
         }
         return value;
     } else if (prop.type == "char" || prop.type == "int8") {
-        int8_t value = *(int8_t*)(data + prop.offset);
+        int8_t value;
+        memcpy(&value, data + prop.offset, sizeof(int8_t));
         return (uint32_t)MAX(value, (int8_t)0);
     } else if (prop.type == "short" || prop.type == "int16") {
         int16_t value;
@@ -930,15 +949,13 @@ uint32_t PLYLoader::read_uint_property(const uint8_t *data, const PLYProperty &p
         }
         return (uint32_t)MAX(value, (int16_t)0);
     } else if (prop.type == "int" || prop.type == "int32") {
-        int32_t value;
-        memcpy(&value, data + prop.offset, sizeof(int32_t));
+        uint32_t bits;
+        memcpy(&bits, data + prop.offset, sizeof(uint32_t));
         if (!header.is_little_endian) {
-            uint32_t *int_val = (uint32_t*)&value;
-            *int_val = ((*int_val & 0xFF000000) >> 24) |
-                      ((*int_val & 0x00FF0000) >> 8) |
-                      ((*int_val & 0x0000FF00) << 8) |
-                      ((*int_val & 0x000000FF) << 24);
+            bits = BSWAP32(bits);
         }
+        int32_t value;
+        memcpy(&value, &bits, sizeof(int32_t));
         return (uint32_t)MAX(value, 0);
     }
     return 0;

--- a/modules/gaussian_splatting/tests/test_ply_importer.h
+++ b/modules/gaussian_splatting/tests/test_ply_importer.h
@@ -249,3 +249,154 @@ TEST_CASE("[GaussianSplatting][PLYLoader] Legacy sibling gsplatworld caches are 
     DirAccess::remove_absolute(cache_path);
     DirAccess::remove_absolute(legacy_cache_path);
 }
+
+TEST_CASE("[GaussianSplatting][PLY] reject vertex_count out of int range") {
+    const String path = _make_ply_fixture_path("oversized_count");
+
+    const char *oversized_ply = R"(ply
+format binary_little_endian 1.0
+element vertex 9999999999
+property float x
+property float y
+property float z
+end_header
+)";
+
+    Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE);
+    REQUIRE_MESSAGE(f.is_valid(), "Should create oversized PLY fixture");
+    f->store_string(oversized_ply);
+    f.unref();
+
+    PLYLoader loader;
+    Error err = loader.load_file(path);
+    CHECK_MESSAGE(err == ERR_FILE_CORRUPT,
+            "PLY with vertex_count beyond int range should be rejected");
+
+    _remove_ply_fixture(path);
+}
+
+TEST_CASE("[GaussianSplatting][PLY] reject header missing end_header sentinel") {
+    const String path = _make_ply_fixture_path("missing_end_header");
+
+    // Smoke test for F4 — exercise the load path end-to-end with a header
+    // that lacks the `end_header` sentinel. Old code without the new
+    // `found_end_header` guard would consume input until EOF in the header
+    // loop and then fail later on a short binary read, ending in
+    // ERR_FILE_CORRUPT at a different stage; the new guard catches the
+    // problem at parse_header() before binary read begins. Through the
+    // public load_file() API the two stages are not separately
+    // distinguishable, so this case asserts the outcome (corrupt file
+    // refused) rather than pinning the specific stage. A precise
+    // stage-level pin would need a parse_header() seam.
+    const char *truncated_ply = R"(ply
+format binary_little_endian 1.0
+element vertex 4
+property float x
+property float y
+property float z
+)";
+
+    Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE);
+    REQUIRE_MESSAGE(f.is_valid(), "Should create truncated PLY fixture");
+    f->store_string(truncated_ply);
+    f.unref();
+
+    PLYLoader loader;
+    Error err = loader.load_file(path);
+    CHECK_MESSAGE(err == ERR_FILE_CORRUPT,
+            "PLY without end_header sentinel should be rejected");
+
+    _remove_ply_fixture(path);
+}
+
+TEST_CASE("[GaussianSplatting][PLY] reject unknown property type token") {
+    const String path = _make_ply_fixture_path("unknown_property_type");
+
+    // Payload bytes follow so old code (which would set unknown
+    // type's size=0 and then read garbage at the wrong offsets) could
+    // otherwise complete parsing without ERR_FILE_CORRUPT. The new
+    // guard must reject at the header stage.
+    const char *unknown_type_ply = R"(ply
+format binary_little_endian 1.0
+element vertex 4
+property float x
+property custom_type y
+property float z
+end_header
+)";
+
+    Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE);
+    REQUIRE_MESSAGE(f.is_valid(), "Should create unknown-type PLY fixture");
+    f->store_string(unknown_type_ply);
+    for (int i = 0; i < 4 * 3; i++) {
+        f->store_float(0.0f);
+    }
+    f.unref();
+
+    PLYLoader loader;
+    Error err = loader.load_file(path);
+    CHECK_MESSAGE(err == ERR_FILE_CORRUPT,
+            "PLY with unknown property type should be rejected");
+
+    _remove_ply_fixture(path);
+}
+
+TEST_CASE("[GaussianSplatting][PLY] big-endian binary round-trip") {
+    const String path = _make_ply_fixture_path("big_endian");
+
+    const char *big_endian_header = R"(ply
+format binary_big_endian 1.0
+element vertex 1
+property float x
+property float y
+property float z
+property float scale_0
+property float scale_1
+property float scale_2
+property float rot_0
+property float rot_1
+property float rot_2
+property float rot_3
+property float opacity
+property float f_dc_0
+property float f_dc_1
+property float f_dc_2
+end_header
+)";
+
+    Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE);
+    REQUIRE_MESSAGE(f.is_valid(), "Should create big-endian PLY fixture");
+    f->store_string(big_endian_header);
+
+    // Native little-endian floats; we manually byte-swap each one to produce
+    // a canonical big-endian payload that the loader must un-swap.
+    const float native_values[14] = {
+        2.5f, -3.25f, 7.75f, // position
+        1.0f, 1.0f, 1.0f, // scales
+        1.0f, 0.0f, 0.0f, 0.0f, // rotation (w,x,y,z)
+        0.5f, // opacity
+        0.25f, 0.5f, 0.75f // dc
+    };
+    for (float native : native_values) {
+        uint32_t bits;
+        memcpy(&bits, &native, sizeof(uint32_t));
+        bits = BSWAP32(bits);
+        uint8_t bytes[4];
+        memcpy(bytes, &bits, sizeof(bytes));
+        f->store_buffer(bytes, sizeof(bytes));
+    }
+    f.unref();
+
+    PLYLoader loader;
+    Error err = loader.load_file(path);
+    CHECK_MESSAGE(err == OK, "Big-endian PLY load should succeed");
+
+    Ref<GaussianData> data = loader.get_gaussian_data();
+    REQUIRE(data.is_valid());
+    REQUIRE(data->get_count() == 1);
+    const Gaussian g = data->get_gaussian(0);
+    CHECK(g.position.is_equal_approx(Vector3(2.5f, -3.25f, 7.75f)));
+
+    _remove_ply_fixture(path);
+    DirAccess::remove_absolute(path.get_basename() + ".gsplatcache");
+}


### PR DESCRIPTION
## Summary

Closes #287. PLY loader correctness hardening — four bounded fixes plus regression tests, all in one file (`modules/gaussian_splatting/io/ply_loader.cpp`).

- **F1** vertex_count narrowing — `parts[2].to_int()` now reads into `int64_t`, range-checks `[1, 2^30]`, returns `ERR_FILE_CORRUPT` on out-of-range, then narrows to `int`. Prevents silent int64→int truncation that would mis-size the resize at `:317`/`:551`.
- **F2** strict-aliasing UB in endian swaps — float / double / int32 swaps now go through `BSWAP32` / `BSWAP64` (`core/typedefs.h:302-317`) with `memcpy` to integer temporaries. Same pattern applied to the `int8` reader at `:937`.
- **F3** unknown property type — trailing `else` rejects with `ERR_FILE_CORRUPT`. Whitelist now mirrors the decode side: `uint`/`uint32` and `char`/`int8` are valid type tokens (decoded by `read_uint_property()`).
- **F4** missing `end_header` sentinel — `bool found_end_header` set on the sentinel branch; loop exit without it returns `ERR_FILE_CORRUPT`.

## Validated

Three Codex independent review passes confirmed the code-level fixes and the test-pinning quality:
- Pass 1: F1/F2/F4 ACCEPT, F3 whitelist regression flagged + new aliasing pun at `:937`.
- Pass 2: F3 + `:937` ACCEPT; missing_end_header test scoping flagged (not separable through `load_file()` API).
- Pass 3: ship.

See `docs/reports/triage_audit_2026-04-26.md` for the full multi-agent triage that surfaced this work.

## Test plan
- [x] Local Windows editor build with `tests=yes`: clean.
- [x] `*[PLY]*,*[PLYLoader]*` doctest filter: 8 cases / 40 assertions, 0 failures.
- [x] Big-endian binary round-trip uses `BSWAP32`-encoded payload (proves the F2 fix functionally, not just safer).
- [ ] CI Linux/Windows lanes pass on this branch.