### PR TITLE
gaussian_splatting: unify receiver bias across binning and resolve

### DIFF
--- a/modules/gaussian_splatting/shaders/includes/gs_lighting_common.glsl
+++ b/modules/gaussian_splatting/shaders/includes/gs_lighting_common.glsl
@@ -22,6 +22,23 @@ bool gs_use_clustered_lights() {
     return (params.light_counts.z != 0u) && (params.cluster_config.z != 0u);
 }
 
+// Computes the canonical receiver bias for shadow sampling.
+// Per the contract documented in gs_render_params.glsl:77-80 and
+// gaussian_gpu_layout.h:456-459: shadow_bias_config.x is the
+// scale-by-radius multiplier, .y is the minimum bias, .z is the
+// optional maximum clamp (>0.0 enables it).
+//
+// Pass representative_radius = max(g.scale.x, g.scale.y, g.scale.z)
+// from the per-splat path. Pass 0.0 from paths without a radius
+// source — the result collapses to the .y minimum, clamped by .z.
+float gs_compute_receiver_bias(float representative_radius) {
+    float bias = max(params.shadow_bias_config.y, params.shadow_bias_config.x * representative_radius);
+    if (params.shadow_bias_config.z > 0.0) {
+        bias = min(bias, params.shadow_bias_config.z);
+    }
+    return bias;
+}
+
 void gs_get_cluster_params(vec2 pixel_pos, vec3 view_pos, out uint cluster_offset, out uint cluster_z,
         out uint cluster_type_size, out uint max_cluster_element_count_div_32) {
     uint cluster_shift = params.cluster_config.x;

--- a/modules/gaussian_splatting/shaders/tile_binning.glsl
+++ b/modules/gaussian_splatting/shaders/tile_binning.glsl
@@ -1140,10 +1140,7 @@ void main() {
 
     // Per-splat receiver bias to reduce self-shadowing (scaled by splat radius).
     float splat_radius = max(g.scale.x, max(g.scale.y, g.scale.z));
-    float receiver_bias = max(params.shadow_bias_config.y, params.shadow_bias_config.x * splat_radius);
-    if (params.shadow_bias_config.z > 0.0) {
-        receiver_bias = min(receiver_bias, params.shadow_bias_config.z);
-    }
+    float receiver_bias = gs_compute_receiver_bias(splat_radius);
 
     uint lighting_mode = params.lighting_mode.x;
     float sh_base_scale = (lighting_mode == 0u) ? 1.0 : params.lighting_config.y;

--- a/modules/gaussian_splatting/shaders/tile_resolve.glsl
+++ b/modules/gaussian_splatting/shaders/tile_resolve.glsl
@@ -207,7 +207,7 @@ void main() {
         for (uint i = 0u; i < dir_count; ++i) {
             if (directional_lights.data[i].shadow_opacity > 0.001) {
                 has_dir = true;
-                float receiver_bias = params.shadow_bias_config.x;
+                float receiver_bias = gs_compute_receiver_bias(0.0);
                 float s = gs_directional_shadow(i, view_pos, normal, scene_data_block.data.taa_frame_count, receiver_bias);
                 dir_shadow = min(dir_shadow, s);
             }
@@ -330,10 +330,7 @@ void main() {
         hvec3 specular_light = hvec3(0.0);
         half alpha = half(color.a);
         hvec3 energy_compensation = hvec3(1.0);
-        float receiver_bias = params.shadow_bias_config.y;
-        if (params.shadow_bias_config.z > 0.0) {
-            receiver_bias = min(receiver_bias, params.shadow_bias_config.z);
-        }
+        float receiver_bias = gs_compute_receiver_bias(0.0);
 
         uint light_mask = params.light_counts.w;
         gs_accumulate_directional_lights(view_pos, normal, receiver_bias, shadow_sampling_enabled,

--- a/modules/gaussian_splatting/tests/lighting_bias_cpu_mirror.h
+++ b/modules/gaussian_splatting/tests/lighting_bias_cpu_mirror.h
@@ -1,0 +1,42 @@
+#pragma once
+
+// CPU-side mirror of the receiver-bias helper in
+// `modules/gaussian_splatting/shaders/includes/gs_lighting_common.glsl`
+// (`gs_compute_receiver_bias`). The shader is the production code path;
+// this header exists so doctests can exercise the same math without a
+// GPU. Any edit to the shader helper must be reflected here (and
+// vice-versa), or the tests in `test_lighting_bias.h` will drift from
+// the shader and become misleading.
+//
+// Contract (mirrored from gs_render_params.glsl:77-80 and
+// gaussian_gpu_layout.h:456-459):
+//   shadow_bias_config.x = receiver_bias_scale (per-splat radius multiplier)
+//   shadow_bias_config.y = receiver_bias_min
+//   shadow_bias_config.z = receiver_bias_max (0.0 disables the clamp)
+//
+// Resolve paths without a per-pixel representative radius pass 0.0,
+// which intentionally collapses to the .y minimum (clamped by .z).
+
+#include "core/math/math_funcs.h"
+
+namespace GaussianSplatting {
+namespace LightingBiasCPUMirror {
+
+// shadow_bias_config laid out exactly like the shader's vec4: x=scale,
+// y=min, z=max (>0 enables clamp), w=reserved.
+struct ShadowBiasConfig {
+	float scale;
+	float min_bias;
+	float max_bias;
+};
+
+inline float gs_compute_receiver_bias(const ShadowBiasConfig &cfg, float representative_radius) {
+	float bias = MAX(cfg.min_bias, cfg.scale * representative_radius);
+	if (cfg.max_bias > 0.0f) {
+		bias = MIN(bias, cfg.max_bias);
+	}
+	return bias;
+}
+
+} // namespace LightingBiasCPUMirror
+} // namespace GaussianSplatting

--- a/modules/gaussian_splatting/tests/test_gaussian_splatting.cpp
+++ b/modules/gaussian_splatting/tests/test_gaussian_splatting.cpp
@@ -10,6 +10,7 @@
 #include "test_ply_importer.h"
 #include "test_animation_interpolation.h"
 #include "test_deformation_math.h"
+#include "test_lighting_bias.h"
 #include "test_persistence_roundtrip.h"
 #include "synthetic_splat_generators.h"
 

--- a/modules/gaussian_splatting/tests/test_lighting_bias.h
+++ b/modules/gaussian_splatting/tests/test_lighting_bias.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "test_macros.h"
+#include "lighting_bias_cpu_mirror.h"
+
+#include "core/math/math_funcs.h"
+
+// Tests for the CPU mirror of `gs_compute_receiver_bias` in
+// gs_lighting_common.glsl. The mirror lives in lighting_bias_cpu_mirror.h
+// and must stay in lockstep with the shader. Shader changes without a
+// mirror update (or vice-versa) will make these tests misleading —
+// review both files together.
+//
+// Issue #295 background: three GLSL paths previously computed
+// receiver_bias differently (see commit message). All three now route
+// through the same helper. These tests pin its semantics so the call
+// sites stay correct.
+
+#ifdef TESTS_ENABLED
+
+TEST_CASE("[GaussianSplatting][LightingBias] per-splat path scales by radius and clamps to min") {
+	using namespace GaussianSplatting::LightingBiasCPUMirror;
+
+	// Config matches a typical scene: scale=0.1 (10% of radius added),
+	// min=0.005 floor, max disabled (0.0 sentinel).
+	ShadowBiasConfig cfg{ 0.1f, 0.005f, 0.0f };
+
+	// Tiny radius -> scale*radius below the min floor; min wins.
+	CHECK(Math::is_equal_approx(gs_compute_receiver_bias(cfg, 0.01f), 0.005f));
+
+	// Medium radius (0.1) -> scale*radius = 0.01 > min; bias scales.
+	CHECK(Math::is_equal_approx(gs_compute_receiver_bias(cfg, 0.1f), 0.01f));
+
+	// Large radius (1.0) -> scale*radius = 0.1; still uses scaled value.
+	CHECK(Math::is_equal_approx(gs_compute_receiver_bias(cfg, 1.0f), 0.1f));
+}
+
+TEST_CASE("[GaussianSplatting][LightingBias] resolve path (radius=0) collapses to min") {
+	using namespace GaussianSplatting::LightingBiasCPUMirror;
+
+	// The resolve directional/full-lighting paths pass radius=0 because
+	// no per-pixel representative radius is plumbed through yet. Result
+	// must be exactly the documented minimum (the regression: the bug
+	// fixed by #295 returned cfg.scale instead — i.e. 0.1 here, far
+	// from the intended 0.005 floor).
+	ShadowBiasConfig cfg{ 0.1f, 0.005f, 0.0f };
+	CHECK(Math::is_equal_approx(gs_compute_receiver_bias(cfg, 0.0f), 0.005f));
+
+	// Different config: ensure the result tracks .y, not .x.
+	ShadowBiasConfig cfg2{ 0.25f, 0.002f, 0.0f };
+	CHECK(Math::is_equal_approx(gs_compute_receiver_bias(cfg2, 0.0f), 0.002f));
+}
+
+TEST_CASE("[GaussianSplatting][LightingBias] max clamp engages only when max > 0") {
+	using namespace GaussianSplatting::LightingBiasCPUMirror;
+
+	// Max=0.05 enabled (>0). Large radius would push bias to 0.5, but
+	// the clamp pins it to 0.05.
+	ShadowBiasConfig cfg{ 0.5f, 0.001f, 0.05f };
+	CHECK(Math::is_equal_approx(gs_compute_receiver_bias(cfg, 1.0f), 0.05f));
+
+	// Same cfg, tiny radius -> min still wins under the clamp.
+	CHECK(Math::is_equal_approx(gs_compute_receiver_bias(cfg, 0.0f), 0.001f));
+
+	// Max=0.0 sentinel disables the clamp; bias scales unbounded.
+	ShadowBiasConfig cfg_no_max{ 0.5f, 0.001f, 0.0f };
+	CHECK(Math::is_equal_approx(gs_compute_receiver_bias(cfg_no_max, 1.0f), 0.5f));
+}
+
+TEST_CASE("[GaussianSplatting][LightingBias] fix for #295 — resolve no longer leaks the scale value as bias") {
+	using namespace GaussianSplatting::LightingBiasCPUMirror;
+
+	// Pre-fix Path 2 (tile_resolve.glsl:210) used
+	//     receiver_bias = params.shadow_bias_config.x;
+	// directly — i.e. the radius multiplier (typically 0.05–0.5) was
+	// fed into shadow sampling as if it were a world-space bias. With
+	// realistic scale values that produces grossly over-biased shadows
+	// (no contact, "floating" splats). The corrected Path 2 calls the
+	// shared helper with radius=0 and gets the documented .y minimum.
+	ShadowBiasConfig cfg{ 0.25f, 0.005f, 0.05f };
+	const float fixed = gs_compute_receiver_bias(cfg, 0.0f);
+	const float pre_fix_buggy_value = cfg.scale; // would have been 0.25
+	CHECK(Math::is_equal_approx(fixed, 0.005f));
+	CHECK_FALSE(Math::is_equal_approx(fixed, pre_fix_buggy_value));
+}
+
+#endif // TESTS_ENABLED


### PR DESCRIPTION
## Summary

Closes #295. Receiver-bias is currently computed three different ways across the binning vs resolve paths. Path 2 in particular misuses `shadow_bias_config.x` (the radius scale-multiplier) directly as the bias value, producing different shadow acne / peter-panning behavior than the canonical formula.

This PR introduces one shared GLSL helper and routes all three call sites through it.

### Helper

`gs_compute_receiver_bias(float representative_radius)` in `shaders/includes/gs_lighting_common.glsl` mirrors the canonical contract documented at `gaussian_gpu_layout.h:456-459` and `shaders/includes/gs_render_params.glsl:77-80`:

```
bias = max(.y, .x * representative_radius)
if (.z > 0.0) bias = min(bias, .z)
```

### Call sites

- `tile_binning.glsl:1142-1145` → `gs_compute_receiver_bias(splat_radius)` (per-splat path; passes the actual splat radius).
- `tile_resolve.glsl:210-211` → `gs_compute_receiver_bias(0.0)` (fixes the Path 2 bug — was using `.x` directly).
- `tile_resolve.glsl:333-339` → `gs_compute_receiver_bias(0.0)` (resolve directional full-lighting; previously used `.y`-with-clamp form).

Resolve paths pass `representative_radius = 0.0` deliberately — collapses to the documented minimum-bias fallback. Plumbing per-pixel representative radius through the resolve payload is a separate concern.

### Out of scope

Omni / spot helpers (`gs_omni_shadow_factor`, `gs_spot_shadow_factor`) do not take `receiver_bias` and are intentionally untouched.

### Test addition

`tests/lighting_bias_cpu_mirror.h` mirrors the GLSL helper in C++ exactly. `tests/test_lighting_bias.h` covers the per-splat radius case, the resolve `radius=0.0` collapse, the optional max-clamp, and a regression case that pins the old Path 2 bug (uses `cfg.scale=0.25` vs `cfg.min_bias=0.005` so the old behavior would be detectable by assertion).

## Validated

Single Codex review pass — ship as-is. Helper placement (`gs_lighting_common.glsl` vs `gs_lighting_bridge.glsl`), formula, all three call-site updates, omni/spot non-touch, CPU-mirror correctness, and `.gen.h` regeneration approach all ACCEPT.

See `docs/reports/triage_audit_2026-04-26.md` for the multi-agent triage that surfaced this work.

## Test plan
- [x] CPU-mirror doctest: passes; regression case pins Path 2 bug.
- [ ] CI shader-validation lane recompiles affected `.gen.h` files.
- [ ] CI doctest lanes pass on this branch.