### PR TITLE
gaussian_splatting: ci tests=yes for linux dev release + register StreamingPipeline + drop dead defrag metric

### DIFF
--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -211,7 +211,7 @@ jobs:
           if [[ "${{ needs.release_metadata.outputs.channel }}" == "stable" ]]; then
             scons platform=linuxbsd target=editor cache_path=.scons_cache cache_limit=10 -j"$(nproc)"
           else
-            scons platform=linuxbsd target=editor dev_build=yes cache_path=.scons_cache cache_limit=10 -j"$(nproc)"
+            scons platform=linuxbsd target=editor dev_build=yes tests=yes cache_path=.scons_cache cache_limit=10 -j"$(nproc)"
           fi
 
       - name: Resolve built binary

--- a/modules/gaussian_splatting/core/performance_monitors.cpp
+++ b/modules/gaussian_splatting/core/performance_monitors.cpp
@@ -409,8 +409,6 @@ void GaussianSplattingPerformanceMonitors::_register_monitor_definitions(Perform
                 callable_mp(this, &GaussianSplattingPerformanceMonitors::_get_memory_stream_pool_hit_rate_pct) },
         { "gaussian_splatting/memory_stream_peak_memory_mb",
                 callable_mp(this, &GaussianSplattingPerformanceMonitors::_get_memory_stream_peak_memory_mb) },
-        { "gaussian_splatting/memory_stream_defrag_count",
-                callable_mp(this, &GaussianSplattingPerformanceMonitors::_get_memory_stream_defrag_count) },
 
         // Chunk Management Monitors (Phase 3)
         { "gaussian_splatting/chunk_prefetch_hits",
@@ -1396,16 +1394,6 @@ float GaussianSplattingPerformanceMonitors::_get_memory_stream_peak_memory_mb() 
     if (!snapshot.memory_stream_valid) return 0.0f;
     const StreamingStats &stats = snapshot.memory_stream_stats;
     return stats.peak_memory_mb;
-}
-
-int GaussianSplattingPerformanceMonitors::_get_memory_stream_defrag_count() const {
-    GaussianSplatRenderer *renderer = _get_active_splat_renderer(true);
-    if (!renderer) return 0;
-    const GaussianSplatRenderer::MonitorStreamingSnapshot snapshot =
-            _streaming_snapshot_for_monitors(renderer);
-    if (!snapshot.memory_stream_valid) return 0;
-    const StreamingStats &stats = snapshot.memory_stream_stats;
-    return (int)stats.defrag_count;
 }
 
 // ============================================================================

--- a/modules/gaussian_splatting/core/performance_monitors.h
+++ b/modules/gaussian_splatting/core/performance_monitors.h
@@ -202,7 +202,6 @@ private:
     int _get_memory_stream_pool_misses() const;
     float _get_memory_stream_pool_hit_rate_pct() const;
     float _get_memory_stream_peak_memory_mb() const;
-    int _get_memory_stream_defrag_count() const;
 
     // Chunk Management Monitors (Phase 3)
     int _get_chunk_prefetch_hits() const;

--- a/modules/gaussian_splatting/register_types.cpp
+++ b/modules/gaussian_splatting/register_types.cpp
@@ -94,6 +94,7 @@ void initialize_gaussian_splatting_module(ModuleInitializationLevel p_level) {
             // Rendering components
             GDREGISTER_CLASS(GaussianSplatRenderer);
             GDREGISTER_CLASS(GaussianMemoryStream);
+            GDREGISTER_CLASS(StreamingPipeline);
             GDREGISTER_CLASS(PainterlyMaterial);
             GDREGISTER_CLASS(GPUBufferManager);
             GDREGISTER_CLASS(GaussianSplatManager);

--- a/modules/gaussian_splatting/renderer/gpu_memory_stream.cpp
+++ b/modules/gaussian_splatting/renderer/gpu_memory_stream.cpp
@@ -906,8 +906,6 @@ void GaussianMemoryStream::end_frame() {
                 current_mb, stats.peak_memory_mb, get_memory_efficiency() * 100.0f));
         GS_LOG_GPU_MEMORY_DEBUG(vformat("Upload submit: %.1f MB/s (CPU target: >10000 MB/s), Buffer switches: %d",
                 avg_bandwidth_mbps, stats.buffer_switches));
-        GS_LOG_GPU_MEMORY_DEBUG(vformat("Defragmentation: %d operations, GPU utilization target: >85%%",
-                stats.defrag_count));
         GS_LOG_GPU_MEMORY_DEBUG("==============================================================");
 
         bool performance_good = true;

--- a/modules/gaussian_splatting/renderer/gpu_memory_stream.h
+++ b/modules/gaussian_splatting/renderer/gpu_memory_stream.h
@@ -26,7 +26,6 @@ struct StreamingStats {
     uint32_t pool_misses = 0;
     float avg_upload_time_ms = 0.0f;
     float peak_memory_mb = 0.0f;
-    uint32_t defrag_count = 0;
     uint64_t sh_raw_bytes_uploaded = 0;
     uint64_t sh_compressed_bytes_uploaded = 0;
     uint64_t sh_coefficients_streamed = 0;

--- a/modules/gaussian_splatting/tests/test_gpu_integration.cpp
+++ b/modules/gaussian_splatting/tests/test_gpu_integration.cpp
@@ -243,7 +243,6 @@ void TestGPUIntegration::test_memory_stream() {
 
     // Report additional metrics from StreamingStats
     print_line(vformat("  Peak memory: %.1f MB", stats.peak_memory_mb));
-    print_line(vformat("  Defragmentation events: %d", stats.defrag_count));
     print_line(vformat("  Avg upload time: %.2f ms", stats.avg_upload_time_ms));
 
     if (stall_rate > 5.0f) {


### PR DESCRIPTION
## Summary

Three small truthfulness fixes from the 2026-04-26 triage audit. **Closes #290 and #292.**

1. **CI Linux release dev_build lane needs `tests=yes`** — `release_builds.yml:214` now mirrors the Windows dev lane at `:328`. Without this, published Linux dev binaries cannot run `--test`. Stable lane intentionally keeps `tests=yes` off (test infra not shipped).
2. **Register `StreamingPipeline`** — declared `GDCLASS` at `gpu_memory_stream.h:230` with eight `ClassDB::bind_method` exposures, but never `GDREGISTER_CLASS`'d, so invisible to scripting. Added registration adjacent to `GaussianMemoryStream`.
3. **Drop dead `defrag_count` perf metric** — the field, log line, monitor binding (`gaussian_splatting/memory_stream_defrag_count`), getter, and test print are all removed. `defragment_if_needed` doesn't actually defrag (`gpu_memory_stream.cpp:825-840` warns it's unsafe and only calls `compact_memory`); `MemoryPool::defragment` is explicitly disabled at `:1005`. Bumping the counter would have lied differently. Reintroduce only when a real safe defrag path lands.

## Validated

Codex independent review, see `docs/reports/triage_audit_2026-04-26.md` F8/F10/F11.

## Test plan
- [ ] CI passes on this branch.
- [ ] Linux dev release artifact, after merge, can run `godot --test`.