### PR TITLE
gaussian_splatting: rename render_directional_shadow_map, document frame_plan borrow, warn on memory_stream null-owner RID drop

### DIFF
--- a/docs/architecture/lighting-system.md
+++ b/docs/architecture/lighting-system.md
@@ -77,7 +77,7 @@ Shadow factors are computed per light type in [../../modules/gaussian_splatting/
 
 Directional shadow maps are rendered and blitted through:
 
-- `GaussianSplatRenderer::render_directional_shadow_map`
+- `GaussianSplatRenderer::render_shadow_depth_map`
 - shadow output compositor setup
 - shadow blit pipeline resources
 

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
@@ -1701,21 +1701,21 @@ bool GaussianSplatRenderer::_blit_shadow_depth(RID p_source_depth, RID p_shadow_
     return true;
 }
 
-bool GaussianSplatRenderer::render_directional_shadow_map(const Projection &p_light_projection, const Transform3D &p_light_transform,
+bool GaussianSplatRenderer::render_shadow_depth_map(const Projection &p_light_projection, const Transform3D &p_light_transform,
         const Rect2i &p_atlas_rect, RID p_shadow_framebuffer, bool p_flip_y) {
     static bool logged_once = false;
     if (!logged_once) {
         logged_once = true;
         float z_near = p_light_projection.get_z_near();
         float z_far = p_light_projection.get_z_far();
-        WARN_PRINT(vformat("[GS Shadow] render_directional_shadow_map called: atlas_rect=(%d,%d,%d,%d) znear=%f zfar=%f flip_y=%s fb_valid=%s",
+        WARN_PRINT(vformat("[GS Shadow] render_shadow_depth_map called: atlas_rect=(%d,%d,%d,%d) znear=%f zfar=%f flip_y=%s fb_valid=%s",
                 p_atlas_rect.position.x, p_atlas_rect.position.y, p_atlas_rect.size.x, p_atlas_rect.size.y,
                 z_near, z_far, p_flip_y ? "true" : "false", p_shadow_framebuffer.is_valid() ? "true" : "false"));
     }
     if (p_atlas_rect.size.x <= 0 || p_atlas_rect.size.y <= 0) {
         return false;
     }
-    if (!ensure_rendering_device("render_directional_shadow_map")) {
+    if (!ensure_rendering_device("render_shadow_depth_map")) {
         return false;
     }
     RenderingDevice *rd = get_device_state().rd;
@@ -1776,13 +1776,13 @@ bool GaussianSplatRenderer::render_directional_shadow_map(const Projection &p_li
     subsystem_state.output_compositor = saved_output_compositor;
 
     if (!subsystem_state.rasterizer.is_valid()) {
-        WARN_PRINT_ONCE("[GS Shadow] render_directional_shadow_map: rasterizer not valid after render_sorted_splats");
+        WARN_PRINT_ONCE("[GS Shadow] render_shadow_depth_map: rasterizer not valid after render_sorted_splats");
         return false;
     }
     RID depth_texture = subsystem_state.rasterizer->get_depth_texture();
     RenderingDevice *depth_owner = subsystem_state.rasterizer->get_depth_texture_owner();
     if (!depth_texture.is_valid() || !depth_owner) {
-        WARN_PRINT_ONCE(vformat("[GS Shadow] render_directional_shadow_map: depth invalid: tex=%s owner=%s",
+        WARN_PRINT_ONCE(vformat("[GS Shadow] render_shadow_depth_map: depth invalid: tex=%s owner=%s",
                 depth_texture.is_valid() ? "valid" : "null", depth_owner ? "valid" : "null"));
         return false;
     }

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
@@ -385,6 +385,9 @@ public:
                 ERR_FAIL_NULL_V_MSG(output_compositor, false, "FrameDeps: output_compositor is null");
                 ERR_FAIL_NULL_V_MSG(gpu_culler, false, "FrameDeps: gpu_culler is null");
                 // frame_plan validated separately (set later in some paths).
+                // NOTE: frame_plan is a borrowed pointer to a stack local owned by the caller
+                // scope (see render_pipeline_stages.cpp / render_instancing_orchestrator.cpp).
+                // Consumers must not store or defer it past the originating scope.
                 // painterly_renderer and jacobian_debug are optional.
                 return true;
             }
@@ -1489,7 +1492,7 @@ public:
      * @param p_flip_y Whether the atlas rect should be sampled with a Y flip.
      * @return True if shadow depth was rendered and blitted.
      */
-    bool render_directional_shadow_map(const Projection &p_light_projection, const Transform3D &p_light_transform,
+    bool render_shadow_depth_map(const Projection &p_light_projection, const Transform3D &p_light_transform,
             const Rect2i &p_atlas_rect, RID p_shadow_framebuffer, bool p_flip_y);
 
     /**

--- a/modules/gaussian_splatting/renderer/gpu_memory_stream.cpp
+++ b/modules/gaussian_splatting/renderer/gpu_memory_stream.cpp
@@ -265,6 +265,8 @@ void GaussianMemoryStream::_destroy_buffer(StreamBuffer &buffer) {
             allocation_device->free(buffer.gpu_buffer);
             buffer.gpu_buffer = RID();
         } else {
+            WARN_PRINT_ONCE(vformat("[MemoryStream] _destroy_buffer: GPU buffer RID %s exists but neither device_manager nor allocation_device is resolvable; dropping stale RID handle.",
+                    String::num_uint64(static_cast<uint64_t>(buffer.gpu_buffer.get_id()))));
             buffer.gpu_buffer = RID();
         }
     }

--- a/modules/gaussian_splatting/renderer/render_instancing_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_instancing_orchestrator.cpp
@@ -166,6 +166,10 @@ void RenderInstancingOrchestrator::render_instanced(RenderDataRD *p_render_data,
 				instance_buffers, renderer->get_instance_backend_policy(), frame_state_view.get_resource_state_view(), frame_state_view.get_subsystem_state_view(), frame_state_view.get_pipeline_features(),
 				true, String(), String(), GaussianSplatRenderer::RenderFallbackReason::NONE,
 				GaussianSplatRenderer::RenderFallbackReason::NONE, false, false);
+		// Borrow invariant: `frame_plan` is a stack local; it must outlive every consumer of
+		// `frame_context.deps.frame_plan`. Do not store, defer, or async-pass this pointer --
+		// `RenderFrameDeps::validate()` exempts `frame_plan` (see gaussian_splat_renderer.h:387-389),
+		// so a use-after-scope here will not be caught by the validator.
 		frame_context.deps.frame_plan = &frame_plan;
 		DEV_ASSERT(frame_context.deps.frame_plan);
 		ERR_FAIL_COND(!frame_context.deps.validate());

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -860,6 +860,10 @@ void RenderPipelineStages::execute_frame_entry(const RenderFrameContext &p_frame
 			p_clear_cull_state_on_skip);
 
 	// Update deps with the frame_plan BEFORE constructing provider.
+	// Borrow invariant: `frame_plan` is a stack local; it must outlive every consumer of
+	// `frame_context.deps.frame_plan`. Do not store, defer, or async-pass this pointer --
+	// `RenderFrameDeps::validate()` exempts `frame_plan` (see gaussian_splat_renderer.h:387-389),
+	// so a use-after-scope here will not be caught by the validator.
 	frame_context.deps.frame_plan = &frame_plan;
 
 	// This path copies RenderFrameContext before attaching frame_plan, so any incoming

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -200,7 +200,7 @@ static void _gaussian_shadow_submit(const LocalVector<Ref<GaussianSplatRenderer>
 	for (int renderer_index = 0; renderer_index < p_renderers.size(); renderer_index++) {
 		const Ref<GaussianSplatRenderer> &renderer = p_renderers[renderer_index];
 		if (renderer.is_valid()) {
-			renderer->render_directional_shadow_map(p_dispatch.projection, p_dispatch.transform, p_dispatch.rect, p_dispatch.framebuffer, p_dispatch.flip_y);
+			renderer->render_shadow_depth_map(p_dispatch.projection, p_dispatch.transform, p_dispatch.rect, p_dispatch.framebuffer, p_dispatch.flip_y);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

**Closes #296.** Three small unrelated cleanups bundled into one PR.

### A. Rename `render_directional_shadow_map` → `render_shadow_depth_map`

The function at `renderer/gaussian_splat_renderer.cpp:1704` (declared at `gaussian_splat_renderer.h:1492`) is dispatched from `servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp:203` for **all** Gaussian shadow types — directional, spot, omni dual-paraboloid, omni cube — via `_gaussian_shadow_submit()`. The "directional" in the name is misleading.

Renamed at:
- declaration in `gaussian_splat_renderer.h:1492`
- definition + internal log strings in `gaussian_splat_renderer.cpp:1704+`
- call site in `render_forward_clustered.cpp:203`
- one prose mention in `docs/architecture/lighting-system.md`

### B. Document the `frame_plan` borrow invariant

`render_pipeline_stages.cpp:856-863` and `render_instancing_orchestrator.cpp:152-170` both store a pointer to a stack-local `frame_plan` into `frame_context.deps.frame_plan`. Today this is safe — execution is synchronous and `frame_context` doesn't escape the stack. But there's no static guarantee, and `RenderFrameDeps::validate()` at `gaussian_splat_renderer.h:387-389` explicitly **does not** validate `frame_plan` (it's exempt). Future refactors that capture or defer the context will silently produce a use-after-scope bug.

Comment-only fix at all three sites (the two assignment sites plus the `validate()` exemption) explicitly stating the borrow invariant. No rename, no owned storage, no wrapper type.

### C. `WARN_PRINT` on `gpu_memory_stream` null-owner RID drop

`gpu_memory_stream.cpp:267-268` resets a `RID` to `RID()` when neither `device_manager` nor `allocation_device` resolves. This was the only RID-drop branch in the file without a diagnostic. `gaussian_streaming.cpp:745-747` already had a `WARN_PRINT` on the same condition; mirrored that format here.

**Not** added: `track_resource(... pending_free=true)` — Codex verified that signature does not exist (`render_device_manager.h:32-35`, implementation early-returns on null device at `:257-259`). Just a warning, then the existing reset.

## Non-goals

- No new abstractions (no manager class, no RAII handle, no `Optional`/`Result` rewrite).
- No semantic change to shadow rendering — pure rename.
- No async/deferred frame-plan storage refactor.
- No `track_resource` API change.

## Validated

Codex review of the diff before commit. Build will be verified by CI on this branch.

## Test plan
- [ ] Module Build + Runtime Harness passes (catches engine-side rename reference).
- [ ] No remaining grep hits for `render_directional_shadow_map`.