### PR TITLE
gaussian_splatting: propagate SH bands 1-3 through PLY and SPZ importers

### DIFF
--- a/modules/gaussian_splatting/io/resource_importer_ply.cpp
+++ b/modules/gaussian_splatting/io/resource_importer_ply.cpp
@@ -100,12 +100,16 @@ static int _compute_final_splat_count(int p_original_count, int p_max_splats, do
 }
 
 static Gaussian _merge_gaussian_range(const Ref<::GaussianData> &p_data, const int *p_indices,
-        int p_start, int p_end, bool p_normalize_opacity) {
+        int p_start, int p_end, bool p_normalize_opacity, int *r_source_index = nullptr) {
     // Density multiplier is a subsampling factor; pick a representative splat
     // instead of averaging to avoid "hole" artifacts from blended positions.
     const int count = MAX(1, p_end - p_start);
     const int sample_index = CLAMP(p_start + (count / 2), p_start, p_end - 1);
-    Gaussian g = p_data->get_gaussian(p_indices[sample_index]);
+    const int source_index = p_indices[sample_index];
+    if (r_source_index) {
+        *r_source_index = source_index;
+    }
+    Gaussian g = p_data->get_gaussian(source_index);
     if (p_normalize_opacity) {
         g.opacity = CLAMP(g.opacity, 0.0f, 1.0f);
     }
@@ -333,18 +337,38 @@ Error ResourceImporterPLY::import(ResourceUID::ID p_source_id, const String &p_s
     scales.resize(final_count * 3);
     rotations.resize(final_count * 4);
 
+    // View-dependent SH bands. The PLY loader already parsed up to 48 SH floats
+    // per splat into `Gaussian::sh_1[]` and `GaussianData::sh_high_order_coefficients`;
+    // mirror them into the asset so the renderer evaluates beyond the DC term.
+    // Layout per gaussian_splat_asset.cpp:1411-1428: per-splat, per-term, RGB triplet.
+    const uint32_t sh_first_terms = gaussian_data->get_sh_first_order_count();
+    const uint32_t sh_high_terms = gaussian_data->get_sh_high_order_count();
+    const Vector3 *sh_high_src = gaussian_data->get_sh_high_order_coefficients_ptr();
+
+    PackedFloat32Array sh_first_order;
+    PackedFloat32Array sh_high_order;
+    if (sh_first_terms > 0) {
+        sh_first_order.resize(int(final_count) * int(sh_first_terms) * 3);
+    }
+    if (sh_high_terms > 0 && sh_high_src != nullptr) {
+        sh_high_order.resize(int(final_count) * int(sh_high_terms) * 3);
+    }
+
     float *positions_ptr = positions.ptrw();
     Color *colors_ptr = colors.ptrw();
     float *scales_ptr = scales.ptrw();
     float *rotations_ptr = rotations.ptrw();
+    float *sh_first_ptr = sh_first_order.ptrw();
+    float *sh_high_ptr = sh_high_order.ptrw();
 
     for (int i = 0; i < final_count; i++) {
         int start = merge_density ? int(Math::floor(double(i) * merge_stride)) : i;
         int end = merge_density ? int(Math::floor(double(i + 1) * merge_stride)) : i + 1;
         start = CLAMP(start, 0, original_count - 1);
         end = CLAMP(end, start + 1, original_count);
-        Gaussian g = merge_density ? _merge_gaussian_range(gaussian_data, indices_ptr, start, end, normalize_opacity)
-                                   : gaussian_data->get_gaussian(indices_ptr[start]);
+        int source_index = indices_ptr[start];
+        Gaussian g = merge_density ? _merge_gaussian_range(gaussian_data, indices_ptr, start, end, normalize_opacity, &source_index)
+                                   : gaussian_data->get_gaussian(source_index);
         int pos_base = i * 3;
         positions_ptr[pos_base + 0] = g.position.x;
         positions_ptr[pos_base + 1] = g.position.y;
@@ -364,6 +388,29 @@ Error ResourceImporterPLY::import(ResourceUID::ID p_source_id, const String &p_s
         rotations_ptr[rot_base + 1] = g.rotation.x;
         rotations_ptr[rot_base + 2] = g.rotation.y;
         rotations_ptr[rot_base + 3] = g.rotation.z;
+
+        if (sh_first_terms > 0 && sh_first_ptr != nullptr) {
+            const int first_base = i * int(sh_first_terms) * 3;
+            for (uint32_t term = 0; term < sh_first_terms && term < 3; term++) {
+                const Vector3 &coeff = g.sh_1[term];
+                const int term_base = first_base + int(term) * 3;
+                sh_first_ptr[term_base + 0] = coeff.x;
+                sh_first_ptr[term_base + 1] = coeff.y;
+                sh_first_ptr[term_base + 2] = coeff.z;
+            }
+        }
+
+        if (sh_high_terms > 0 && sh_high_src != nullptr && sh_high_ptr != nullptr) {
+            const int high_base = i * int(sh_high_terms) * 3;
+            const size_t src_row = size_t(source_index) * size_t(sh_high_terms);
+            for (uint32_t term = 0; term < sh_high_terms; term++) {
+                const Vector3 &coeff = sh_high_src[src_row + term];
+                const int term_base = high_base + int(term) * 3;
+                sh_high_ptr[term_base + 0] = coeff.x;
+                sh_high_ptr[term_base + 1] = coeff.y;
+                sh_high_ptr[term_base + 2] = coeff.z;
+            }
+        }
     }
 
     Ref<GaussianSplatAsset> asset;
@@ -373,6 +420,12 @@ Error ResourceImporterPLY::import(ResourceUID::ID p_source_id, const String &p_s
     asset->set_colors(colors);
     asset->set_scales(scales);
     asset->set_rotations(rotations);
+    if (sh_first_terms > 0) {
+        asset->set_sh_first_order_coefficients(sh_first_order);
+    }
+    if (sh_high_terms > 0) {
+        asset->set_sh_high_order_coefficients(sh_high_order);
+    }
     asset->set_import_quality_preset(preset_name);
 
     uint32_t compression_flags = _build_compression_flags(quantize_positions, quantize_colors, quantize_scales, quantize_rotations);

--- a/modules/gaussian_splatting/io/resource_importer_ply.h
+++ b/modules/gaussian_splatting/io/resource_importer_ply.h
@@ -42,7 +42,12 @@ public:
     //   v3: preview thumbnails now serialize as Image resources instead of
     //       ImageTexture to avoid threaded importer deadlocks under
     //       `--headless --import`.
-    virtual int get_format_version() const override { return 3; }
+    //   v4: SH bands 1-3 are now propagated into the asset. Caches written by
+    //       v1-v3 carry only DC color; the renderer fell back to flat per-splat
+    //       RGB and lost view-dependent specular / fresnel detail. v4 caches
+    //       carry full per-splat sh_first_order / sh_high_order arrays sized
+    //       splat_count * sh_terms * 3.
+    virtual int get_format_version() const override { return 4; }
 
     // Validation helpers
     Error validate_ply_properties(const Ref<class PLYLoader> &p_loader) const;

--- a/modules/gaussian_splatting/io/resource_importer_spz.cpp
+++ b/modules/gaussian_splatting/io/resource_importer_spz.cpp
@@ -80,12 +80,16 @@ static int _compute_final_splat_count(int p_original_count, int p_max_splats, do
 }
 
 static Gaussian _merge_gaussian_range(const Ref<::GaussianData> &p_data, const int *p_indices,
-        int p_start, int p_end, bool p_normalize_opacity) {
+        int p_start, int p_end, bool p_normalize_opacity, int *r_source_index = nullptr) {
     // Density multiplier is a subsampling factor; pick a representative splat
     // instead of averaging to avoid "hole" artifacts from blended positions.
     const int count = MAX(1, p_end - p_start);
     const int sample_index = CLAMP(p_start + (count / 2), p_start, p_end - 1);
-    Gaussian g = p_data->get_gaussian(p_indices[sample_index]);
+    const int source_index = p_indices[sample_index];
+    if (r_source_index) {
+        *r_source_index = source_index;
+    }
+    Gaussian g = p_data->get_gaussian(source_index);
     if (p_normalize_opacity) {
         g.opacity = CLAMP(g.opacity, 0.0f, 1.0f);
     }
@@ -298,10 +302,29 @@ Error ResourceImporterSPZ::import(ResourceUID::ID p_source_id, const String &p_s
     scales.resize(final_count * 3);
     rotations.resize(final_count * 4);
 
+    // View-dependent SH bands. The SPZ loader already parsed bands 1..3 into
+    // `Gaussian::sh_1[]` and `GaussianData::sh_high_order_coefficients`; mirror
+    // them into the asset so the renderer evaluates beyond the DC term. Layout
+    // per gaussian_splat_asset.cpp:1411-1428: per-splat, per-term, RGB triplet.
+    const uint32_t sh_first_terms = gaussian_data->get_sh_first_order_count();
+    const uint32_t sh_high_terms = gaussian_data->get_sh_high_order_count();
+    const Vector3 *sh_high_src = gaussian_data->get_sh_high_order_coefficients_ptr();
+
+    PackedFloat32Array sh_first_order;
+    PackedFloat32Array sh_high_order;
+    if (sh_first_terms > 0) {
+        sh_first_order.resize(int(final_count) * int(sh_first_terms) * 3);
+    }
+    if (sh_high_terms > 0 && sh_high_src != nullptr) {
+        sh_high_order.resize(int(final_count) * int(sh_high_terms) * 3);
+    }
+
     float *positions_ptr = positions.ptrw();
     Color *colors_ptr = colors.ptrw();
     float *scales_ptr = scales.ptrw();
     float *rotations_ptr = rotations.ptrw();
+    float *sh_first_ptr = sh_first_order.ptrw();
+    float *sh_high_ptr = sh_high_order.ptrw();
 
     for (int i = 0; i < final_count; i++) {
         int start = merge_density ? int(Math::floor(double(i) * merge_stride)) : i;
@@ -309,8 +332,9 @@ Error ResourceImporterSPZ::import(ResourceUID::ID p_source_id, const String &p_s
         start = CLAMP(start, 0, original_count - 1);
         end = CLAMP(end, start + 1, original_count);
         int pos_base = i * 3;
-        Gaussian g = merge_density ? _merge_gaussian_range(gaussian_data, indices_ptr, start, end, normalize_opacity)
-                                   : gaussian_data->get_gaussian(indices_ptr[start]);
+        int source_index = indices_ptr[start];
+        Gaussian g = merge_density ? _merge_gaussian_range(gaussian_data, indices_ptr, start, end, normalize_opacity, &source_index)
+                                   : gaussian_data->get_gaussian(source_index);
 
         positions_ptr[pos_base + 0] = g.position.x;
         positions_ptr[pos_base + 1] = g.position.y;
@@ -330,6 +354,29 @@ Error ResourceImporterSPZ::import(ResourceUID::ID p_source_id, const String &p_s
         rotations_ptr[rot_base + 1] = g.rotation.x;
         rotations_ptr[rot_base + 2] = g.rotation.y;
         rotations_ptr[rot_base + 3] = g.rotation.z;
+
+        if (sh_first_terms > 0 && sh_first_ptr != nullptr) {
+            const int first_base = i * int(sh_first_terms) * 3;
+            for (uint32_t term = 0; term < sh_first_terms && term < 3; term++) {
+                const Vector3 &coeff = g.sh_1[term];
+                const int term_base = first_base + int(term) * 3;
+                sh_first_ptr[term_base + 0] = coeff.x;
+                sh_first_ptr[term_base + 1] = coeff.y;
+                sh_first_ptr[term_base + 2] = coeff.z;
+            }
+        }
+
+        if (sh_high_terms > 0 && sh_high_src != nullptr && sh_high_ptr != nullptr) {
+            const int high_base = i * int(sh_high_terms) * 3;
+            const size_t src_row = size_t(source_index) * size_t(sh_high_terms);
+            for (uint32_t term = 0; term < sh_high_terms; term++) {
+                const Vector3 &coeff = sh_high_src[src_row + term];
+                const int term_base = high_base + int(term) * 3;
+                sh_high_ptr[term_base + 0] = coeff.x;
+                sh_high_ptr[term_base + 1] = coeff.y;
+                sh_high_ptr[term_base + 2] = coeff.z;
+            }
+        }
     }
 
     // Create asset
@@ -340,6 +387,12 @@ Error ResourceImporterSPZ::import(ResourceUID::ID p_source_id, const String &p_s
     asset->set_colors(colors);
     asset->set_scales(scales);
     asset->set_rotations(rotations);
+    if (sh_first_terms > 0) {
+        asset->set_sh_first_order_coefficients(sh_first_order);
+    }
+    if (sh_high_terms > 0) {
+        asset->set_sh_high_order_coefficients(sh_high_order);
+    }
     asset->set_import_quality_preset(preset_name);
 
     uint32_t compression_flags = _build_compression_flags(quantize_positions, quantize_colors, quantize_scales, quantize_rotations);

--- a/modules/gaussian_splatting/io/resource_importer_spz.h
+++ b/modules/gaussian_splatting/io/resource_importer_spz.h
@@ -38,7 +38,8 @@ public:
 
     // See ResourceImporterPLY::get_format_version() for the bump rationale.
     // SPZ assets share the GaussianSplatAsset deserialization path.
-    virtual int get_format_version() const override { return 3; }
+    //   v4: SH bands 1-3 propagated into the asset (same fix applied to PLY at v4).
+    virtual int get_format_version() const override { return 4; }
 
     ResourceImporterSPZ();
 };

--- a/modules/gaussian_splatting/tests/test_gaussian_importer.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_importer.h
@@ -109,6 +109,78 @@ end_header
     return OK;
 }
 
+// PLY fixture with one splat that carries DC plus full Inria SH3 layout
+// (45 f_rest_* properties). The PLY loader (ply_loader.cpp:797-826) treats
+// f_rest_* as channel-major with stride SH_REST_COMPONENTS / 3 = 15, then
+// repacks into coefficient-major RGB triplets. Only band 1 (terms 0/1/2) is
+// populated with non-zero values; bands 2-3 are zero but declared so the
+// `present` map flags them and the loader infers high_order_count = 12.
+//
+// Channel layout in this fixture (45 floats):
+//   R band-1 (terms 0,1,2):  f_rest_0..2  = 0.10 0.20 0.30
+//   R band-2..3:             f_rest_3..14 = 0
+//   G band-1:                f_rest_15..17 = 0.40 0.50 0.60
+//   G band-2..3:             f_rest_18..29 = 0
+//   B band-1:                f_rest_30..32 = 0.70 0.80 0.90
+//   B band-2..3:             f_rest_33..44 = 0
+// After loader repack:
+//   g.sh_1[0] = (0.10, 0.40, 0.70)
+//   g.sh_1[1] = (0.20, 0.50, 0.80)
+//   g.sh_1[2] = (0.30, 0.60, 0.90)
+Error _write_ascii_ply_with_first_order_sh(const String &p_path) {
+    Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE);
+    if (file.is_null()) {
+        return ERR_CANT_CREATE;
+    }
+
+    String header;
+    header += "ply\n";
+    header += "format ascii 1.0\n";
+    header += "element vertex 1\n";
+    header += "property float x\n";
+    header += "property float y\n";
+    header += "property float z\n";
+    header += "property float scale_0\n";
+    header += "property float scale_1\n";
+    header += "property float scale_2\n";
+    header += "property float rot_0\n";
+    header += "property float rot_1\n";
+    header += "property float rot_2\n";
+    header += "property float rot_3\n";
+    header += "property float opacity\n";
+    header += "property float f_dc_0\n";
+    header += "property float f_dc_1\n";
+    header += "property float f_dc_2\n";
+    for (int i = 0; i < 45; i++) {
+        header += vformat("property float f_rest_%d\n", i);
+    }
+    header += "end_header\n";
+
+    String row = "0 0 0 0 0 0 1 0 0 0 0 0.25 0.5 0.75";
+    for (int i = 0; i < 45; i++) {
+        float value = 0.0f;
+        // R channel band-1 lives at f_rest_0..2.
+        if (i == 0) value = 0.10f;
+        else if (i == 1) value = 0.20f;
+        else if (i == 2) value = 0.30f;
+        // G channel band-1 lives at f_rest_15..17.
+        else if (i == 15) value = 0.40f;
+        else if (i == 16) value = 0.50f;
+        else if (i == 17) value = 0.60f;
+        // B channel band-1 lives at f_rest_30..32.
+        else if (i == 30) value = 0.70f;
+        else if (i == 31) value = 0.80f;
+        else if (i == 32) value = 0.90f;
+        row += " " + String::num(value, 2);
+    }
+    row += "\n";
+
+    file->store_string(header);
+    file->store_string(row);
+    file.unref();
+    return OK;
+}
+
 Error _write_invalid_gsplatworld(const String &p_path) {
     Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE);
     if (file.is_null()) {
@@ -1194,6 +1266,62 @@ TEST_CASE("[GaussianSplatting][Importer] PLY loader keeps legacy DC encoding") {
     CHECK(gaussian_get_dc_encoding(g.render_meta) == GAUSSIAN_DC_ENCODING_LEGACY_BIAS);
 
     _remove_user_file(source_path);
+}
+
+TEST_CASE("[GaussianSplatting][Importer] PLY importer propagates SH band-1 coefficients into asset") {
+    const String source_path = "user://gaussian_ply_first_order_sh.ply";
+    const String save_base_path = "user://gaussian_ply_first_order_sh_imported";
+    Error write_err = _write_ascii_ply_with_first_order_sh(source_path);
+    REQUIRE_MESSAGE(write_err == OK, "Failed to write band-1 SH PLY fixture");
+
+    Ref<ResourceImporterPLY> importer;
+    importer.instantiate();
+
+    HashMap<StringName, Variant> options;
+    options.insert(StringName("quality/preset"), String("ultra"));
+    options.insert(StringName("preview/generate_thumbnail"), false);
+
+    const Error import_err = importer->import(ResourceUID::INVALID_ID, source_path, save_base_path, options,
+            nullptr, nullptr, nullptr);
+    REQUIRE_MESSAGE(import_err == OK, "PLY importer should succeed for band-1 SH fixture");
+
+    Ref<GaussianSplatAsset> asset = ResourceLoader::load(save_base_path + ".tres");
+    REQUIRE_MESSAGE(asset.is_valid(), "PLY importer should emit a loadable GaussianSplatAsset");
+
+    // Band 1 = 3 first-order terms; layout is per-splat, per-term, RGB triplet.
+    const PackedFloat32Array first_order = asset->get_sh_first_order_coefficients();
+    REQUIRE_MESSAGE(first_order.size() == 1 * 3 * 3,
+            "Asset should carry 9 floats of first-order SH for one splat with 3 terms");
+
+    // Inria channel-major -> coefficient-major repack:
+    //   PLY input: [R0 R1 R2 G0 G1 G2 B0 B1 B2] = [0.10 0.20 0.30 0.40 0.50 0.60 0.70 0.80 0.90]
+    //   Asset out: [R0 G0 B0 R1 G1 B1 R2 G2 B2] = [0.10 0.40 0.70 0.20 0.50 0.80 0.30 0.60 0.90]
+    CHECK(Math::is_equal_approx(first_order[0], 0.10f));
+    CHECK(Math::is_equal_approx(first_order[1], 0.40f));
+    CHECK(Math::is_equal_approx(first_order[2], 0.70f));
+    CHECK(Math::is_equal_approx(first_order[3], 0.20f));
+    CHECK(Math::is_equal_approx(first_order[4], 0.50f));
+    CHECK(Math::is_equal_approx(first_order[5], 0.80f));
+    CHECK(Math::is_equal_approx(first_order[6], 0.30f));
+    CHECK(Math::is_equal_approx(first_order[7], 0.60f));
+    CHECK(Math::is_equal_approx(first_order[8], 0.90f));
+
+    Ref<::GaussianData> data;
+    data.instantiate();
+    REQUIRE_MESSAGE(data->populate_from_asset(asset) == OK,
+            "populate_from_asset should accept SH-enriched PLY asset");
+    REQUIRE_MESSAGE(data->get_count() == 1, "Imported PLY asset should materialize one gaussian");
+    CHECK(data->get_sh_first_order_count() == 3u);
+
+    const Gaussian round_tripped = data->get_gaussian(0);
+    CHECK(Math::is_equal_approx(round_tripped.sh_1[0].x, 0.10f));
+    CHECK(Math::is_equal_approx(round_tripped.sh_1[0].y, 0.40f));
+    CHECK(Math::is_equal_approx(round_tripped.sh_1[0].z, 0.70f));
+    CHECK(Math::is_equal_approx(round_tripped.sh_1[2].x, 0.30f));
+    CHECK(Math::is_equal_approx(round_tripped.sh_1[2].z, 0.90f));
+
+    _remove_user_file(source_path);
+    _remove_user_file(save_base_path + ".tres");
 }
 
 TEST_CASE("[GaussianSplatting][Importer] PLY ASCII loader hard-fails on malformed rows") {


### PR DESCRIPTION
## Summary

- The PLY and SPZ resource importers silently dropped 45 of the 48 SH coefficients per splat. Loaders correctly parsed every band into `GaussianData`, but the importer bodies copied only positions/colors/scales/rotations into `GaussianSplatAsset`. The renderer fell back to DC-only at `gaussian_splat_asset.cpp:498-507`.
- Visible effect: same PLY renders cleanly in SuperSplat (16-coefficient view-dependent eval) but fuzzy/washed-out in our editor (1 coefficient, no view-dependent specular / fresnel / edge highlights).
- Both importers now propagate `g.sh_1[0..2]` and the matching high-order row using the source index returned by `_merge_gaussian_range`. Layout is per-splat, per-term, RGB triplet — same as `populate_from_gaussian_data` already produces, so the GPU upload path is unchanged.
- ResourceImporter format versions bumped: PLY 3 -> 4, SPZ 3 -> 4. Caches from previous versions carry only DC and must be re-imported; Godot's resource scanner triggers this automatically on next editor open.

## Cost
- Per-splat asset payload grows ~60 bytes for full SH3 (3 first-order + 12 high-order Vector3 fp32).
- Existing `enable_sh_amortization` (active on every quality tier, divisor 2-8) bounds the per-frame eval cost; expected +0.5-2 ms/frame on dense scenes.

## Test plan
- [x] New regression test `[GaussianSplatting][Importer] PLY importer propagates SH band-1 coefficients into asset` (writes a full Inria-format PLY with 45 f_rest properties, imports, asserts layout + round-trip)
- [x] All 34 existing GaussianSplatting importer tests pass (224 assertions)
- [x] Container/merge tests pass (12 cases, 1102 assertions) — covers mixed DC encoding propagation
- [x] Local Windows editor build clean (dev_build=yes, optimize=speed_trace, tests=yes)
- [ ] Visual A/B vs SuperSplat on the user's reference PLY after re-import

🤖 Generated with [Claude Code](https://claude.com/claude-code)