### PR TITLE
gaussian_splatting: lower EWA low-pass default from 0.35 to 0.05

### DIFF
--- a/modules/gaussian_splatting/core/gaussian_splat_manager.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_manager.cpp
@@ -1033,9 +1033,21 @@ void GaussianSplatManager::initialize_module() {
     GLOBAL_DEF("rendering/gaussian_splatting/culling/cluster_culling_enabled", true);
     GLOBAL_DEF("rendering/gaussian_splatting/culling/cluster_target_size", 128);       // Splats per cluster (32-256)
     GLOBAL_DEF("rendering/gaussian_splatting/culling/cluster_frustum_slack", 2.0f);    // AABB expansion factor
-    // Projection anti-aliasing floor (adds minimum covariance variance in tile binning).
-    // Lower values are sharper but can re-introduce subpixel holes; 0.35 balances sharpness/stability.
-    GLOBAL_DEF("rendering/gaussian_splatting/rasterization/low_pass_filter", 0.35f);
+    // Projection anti-aliasing floor (added to cov2d diagonal in tile binning).
+    // 0.05 matches the Inria 3DGS reference sharpness. The previous default of
+    // 0.35 was an over-aggressive Mip-Splatting-style dilation we ship without
+    // the matching alpha-rescale companion (alpha *= sqrt(det_orig/det_filtered)),
+    // which fattened thin splats by up to ~6x screen-space radius and produced
+    // a uniform soft / fuzzy halo on edges. The PROPERTY_HINT_RANGE floor
+    // matches the runtime clamp at painterly_renderer.cpp:1776 and
+    // tile_render_stages.cpp:252 so the editor UI cannot expose a value the
+    // runtime would clamp away.
+    GLOBAL_DEF_RST(
+            PropertyInfo(Variant::FLOAT,
+                    "rendering/gaussian_splatting/rasterization/low_pass_filter",
+                    PROPERTY_HINT_RANGE,
+                    "0.05,1.0,0.01"),
+            0.05f);
 
 	// Opacity-aware bounding (FlashGS optimization) - reduces tile-Gaussian pairs by ~94%
 	// When enabled, splat radii are calculated based on opacity: r = sqrt(2 * ln(alpha/tau) * lambda)


### PR DESCRIPTION
## Summary

- The projection anti-aliasing floor at `tile_binning.glsl:608-613` adds `low_pass_filter` to the cov2d diagonal. Reference Inria 3DGS treats 0.3 only as an *inversion epsilon*, not added to the diagonal. Mip-Splatting (which the 0.35 default mimics) requires a matching `alpha *= sqrt(det_orig/det_filtered)` shrink to compensate — **we don't apply that companion**, so the dilation becomes pure fattening, especially on thin / coplanar splats.
- Lower default to **0.05**, matching the existing runtime clamp floor at `painterly_renderer.cpp:1776` and `tile_render_stages.cpp:252`.
- Promote `GLOBAL_DEF` -> `GLOBAL_DEF_RST` with `PROPERTY_HINT_RANGE` so editor UI matches runtime clamp.

## Numerical effect (radius growth `sqrt(λ) -> sqrt(λ + low_pass)`)

| Splat eigenvalue λ | At 0.35 | At 0.05 | Δ vs reference (0.0) |
|---|---|---|---|
| 0.01 (paper-thin leaf) | 0.60 px | 0.24 px | +0.14 px |
| 0.5 (typical thin) | 0.92 px | 0.74 px | +0.03 px |
| 4 (medium) | 2.09 px | 2.01 px | +0.01 px |

At 0.35 a paper-thin splat fattens 6×; at 0.05 the fattening is sub-pixel for almost every practical splat.

## Test plan
- [x] Local Windows editor build clean (dev_build=yes, optimize=speed_trace, tests=yes)
- [x] 33/33 GaussianSplatting Importer tests pass (203 assertions) — no regression
- [ ] Visual A/B: thin features (leaves, edges, wires, foliage) noticeably sharper without halo

## Land order
This PR is the third in the SuperSplat-parity / dense-tile-flicker series:
1. **#311** SH bands 1-3 propagation through PLY/SPZ importers (dominant quality fix)
2. **#312** deterministic tile sort tie-break (must land before this PR — sharpening uncovers any pre-existing tile flicker)
3. **this PR** EWA low-pass default lowered to match Inria sharpness

## Deferred follow-up
fp32 screen-position promotion at `tile_projection_common.glsl:17` (currently fp16, ~1 px ulp at HD) is a structurally larger change worth doing later. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)