### PR TITLE
gaussian_splatting: default DC encoding to linear_rgb to match Inria reference

### DIFF
--- a/modules/gaussian_splatting/core/gaussian_data_io.cpp
+++ b/modules/gaussian_splatting/core/gaussian_data_io.cpp
@@ -84,11 +84,11 @@ static bool _validate_asset_buffer_size(const char *p_label, int p_actual_size, 
 static GaussianDCEncoding _resolve_dc_encoding_from_metadata(const Dictionary &p_import_metadata) {
     if (p_import_metadata.has(StringName("dc_encoding"))) {
         const String dc_encoding = String(p_import_metadata[StringName("dc_encoding")]).to_lower();
-        if (dc_encoding == "linear_rgb") {
-            return GAUSSIAN_DC_ENCODING_LINEAR_RGB;
+        if (dc_encoding == "legacy_bias") {
+            return GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
         }
     }
-    return GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
+    return GAUSSIAN_DC_ENCODING_LINEAR_RGB;
 }
 
 } // namespace

--- a/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
@@ -1256,9 +1256,9 @@ bool GaussianSplatAsset::populate_gaussian_data(Ref<::GaussianData> &r_data) con
     }
     if (asset_metadata.has(StringName("dc_encoding"))) {
         const String dc_encoding = String(asset_metadata[StringName("dc_encoding")]).to_lower();
-        GaussianDCEncoding staged_dc_encoding = GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
-        if (dc_encoding == "linear_rgb") {
-            staged_dc_encoding = GAUSSIAN_DC_ENCODING_LINEAR_RGB;
+        GaussianDCEncoding staged_dc_encoding = GAUSSIAN_DC_ENCODING_LINEAR_RGB;
+        if (dc_encoding == "legacy_bias") {
+            staged_dc_encoding = GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
         }
         for (int i = 0; i < r_data->get_count(); i++) {
             Gaussian g = r_data->get_gaussian(i);
@@ -1333,7 +1333,7 @@ Error GaussianSplatAsset::populate_from_gaussian_data(const Ref<::GaussianData> 
     bool bounds_initialized = false;
     Vector3 min_pos;
     Vector3 max_pos;
-    GaussianDCEncoding asset_dc_encoding = GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
+    GaussianDCEncoding asset_dc_encoding = GAUSSIAN_DC_ENCODING_LINEAR_RGB;
     bool asset_dc_encoding_initialized = false;
     bool mixed_dc_encoding = false;
 

--- a/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
@@ -20,6 +20,16 @@ static double _elapsed_msec(uint64_t p_start_usec) {
 	return double(now - p_start_usec) / 1000.0;
 }
 
+static GaussianDCEncoding _resolve_dc_encoding_from_metadata(const Dictionary &p_import_metadata) {
+	if (p_import_metadata.has(StringName("dc_encoding"))) {
+		const String dc_encoding = String(p_import_metadata[StringName("dc_encoding")]).to_lower();
+		if (dc_encoding == "legacy_bias") {
+			return GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
+		}
+	}
+	return GAUSSIAN_DC_ENCODING_LINEAR_RGB;
+}
+
 static Dictionary _build_runtime_load_timing(const String &p_stage,
 		bool p_cache_hit,
 		double p_source_ms,
@@ -1254,17 +1264,11 @@ bool GaussianSplatAsset::populate_gaussian_data(Ref<::GaussianData> &r_data) con
     if (asset_metadata.has(StringName("gaussian_2d_mode"))) {
         r_data->set_2d_mode((bool)asset_metadata[StringName("gaussian_2d_mode")]);
     }
-    if (asset_metadata.has(StringName("dc_encoding"))) {
-        const String dc_encoding = String(asset_metadata[StringName("dc_encoding")]).to_lower();
-        GaussianDCEncoding staged_dc_encoding = GAUSSIAN_DC_ENCODING_LINEAR_RGB;
-        if (dc_encoding == "legacy_bias") {
-            staged_dc_encoding = GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
-        }
-        for (int i = 0; i < r_data->get_count(); i++) {
-            Gaussian g = r_data->get_gaussian(i);
-            g.render_meta = gaussian_set_dc_encoding(g.render_meta, staged_dc_encoding);
-            r_data->set_gaussian(i, g);
-        }
+    const GaussianDCEncoding staged_dc_encoding = _resolve_dc_encoding_from_metadata(asset_metadata);
+    for (int i = 0; i < r_data->get_count(); i++) {
+        Gaussian g = r_data->get_gaussian(i);
+        g.render_meta = gaussian_set_dc_encoding(g.render_meta, staged_dc_encoding);
+        r_data->set_gaussian(i, g);
     }
 
     return true;

--- a/modules/gaussian_splatting/core/gaussian_splat_merge_utils.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_merge_utils.cpp
@@ -24,19 +24,19 @@ static Quaternion _safe_quaternion_from_asset(const TypedArray<Quaternion> &p_ro
 
 static GaussianDCEncoding _resolve_asset_dc_encoding(const Ref<GaussianSplatAsset> &p_asset) {
     if (p_asset.is_null()) {
-        return GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
+        return GAUSSIAN_DC_ENCODING_LINEAR_RGB;
     }
 
     const Dictionary import_metadata = p_asset->get_import_metadata();
     if (!import_metadata.has(StringName("dc_encoding"))) {
-        return GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
+        return GAUSSIAN_DC_ENCODING_LINEAR_RGB;
     }
 
     const String dc_encoding = String(import_metadata[StringName("dc_encoding")]).to_lower();
-    if (dc_encoding == "linear_rgb") {
-        return GAUSSIAN_DC_ENCODING_LINEAR_RGB;
+    if (dc_encoding == "legacy_bias") {
+        return GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
     }
-    return GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
+    return GAUSSIAN_DC_ENCODING_LINEAR_RGB;
 }
 
 static void _rebuild_chunk_cache(const Ref<GaussianData> &p_data, float p_chunk_size,

--- a/modules/gaussian_splatting/core/streaming_global_atlas_registry.cpp
+++ b/modules/gaussian_splatting/core/streaming_global_atlas_registry.cpp
@@ -41,7 +41,7 @@ void _clear_dirty_flags(LocalVector<uint8_t> &flags) {
 
 GaussianDCEncoding _resolve_data_dc_encoding(const Ref<GaussianData> &p_data) {
 	if (p_data.is_null() || p_data->get_count() <= 0) {
-		return GAUSSIAN_DC_ENCODING_LEGACY_BIAS;
+		return GAUSSIAN_DC_ENCODING_LINEAR_RGB;
 	}
 	return gaussian_get_dc_encoding(p_data->get_gaussian(0).render_meta);
 }

--- a/modules/gaussian_splatting/io/resource_importer_ply.cpp
+++ b/modules/gaussian_splatting/io/resource_importer_ply.cpp
@@ -413,7 +413,7 @@ Error ResourceImporterPLY::import(ResourceUID::ID p_source_id, const String &p_s
 
     Dictionary import_metadata;
     import_metadata[StringName("source_file")] = p_source_file;
-    import_metadata[StringName("dc_encoding")] = "legacy_bias";
+    import_metadata[StringName("dc_encoding")] = "linear_rgb";
     import_metadata[StringName("import_time")] = Time::get_singleton()->get_datetime_dict_from_system();
     import_metadata[StringName("original_splat_count")] = original_count;
     import_metadata[StringName("splat_count")] = final_count;

--- a/modules/gaussian_splatting/io/resource_importer_ply.h
+++ b/modules/gaussian_splatting/io/resource_importer_ply.h
@@ -42,7 +42,12 @@ public:
     //   v3: preview thumbnails now serialize as Image resources instead of
     //       ImageTexture to avoid threaded importer deadlocks under
     //       `--headless --import`.
-    virtual int get_format_version() const override { return 3; }
+    //   v4: PLY DC-encoding default flipped from `legacy_bias` (sigmoid
+    //       compression `1.5*sigmoid(x) - 0.25`) to `linear_rgb` (canonical
+    //       Inria `sh*C0 + 0.5`). Caches written by v1-v3 carry the wrong
+    //       `dc_encoding` tag and must be reimported to render with full
+    //       contrast / saturation.
+    virtual int get_format_version() const override { return 4; }
 
     // Validation helpers
     Error validate_ply_properties(const Ref<class PLYLoader> &p_loader) const;

--- a/modules/gaussian_splatting/shaders/includes/gs_sh_binning.glsl
+++ b/modules/gaussian_splatting/shaders/includes/gs_sh_binning.glsl
@@ -133,15 +133,16 @@ void compute_sh_basis_1st_order(vec3 dir, out float basis[4]) {
 // Evaluate SH color with configurable band level
 // sh_band_level: 0=DC only, 1=1st order, 2=2nd order, 3=3rd order
 vec3 evaluate_sh_with_bands(Gaussian g, vec3 view_dir, uint sh_band_level) {
-    // Decode DC term. Some datasets store DC in logit space (original 3DGS),
-    // others store linear coefficients (SPZ/converted assets).
+    // Decode DC term. The default path matches the Inria 3DGS convention
+    // (`SH2RGB(sh) = sh * C0 + 0.5`), with the C0 factor pre-baked at load.
+    // The legacy sigmoid path is retained only for assets explicitly tagged
+    // `legacy_bias`; new imports default to `linear_rgb`.
     bool dc_logit = !gaussian_get_dc_is_linear_rgb(g.sh_metadata);
     vec3 color;
     if (dc_logit) {
         vec3 dc_logit_val = g.sh_dc.rgb;
         color = 1.5 * (1.0 / (1.0 + exp(-dc_logit_val))) - 0.25;
     } else {
-        // Standard 3DGS: DC already linear (scaled by SH_C0 in source).
         color = g.sh_dc.rgb + 0.5;
     }
 

--- a/modules/gaussian_splatting/tests/test_gaussian_importer.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_importer.h
@@ -1391,6 +1391,24 @@ TEST_CASE("[GaussianSplatting][Importer] populate_gaussian_data restores DC enco
     CHECK(gaussian_get_dc_encoding(g.render_meta) == GAUSSIAN_DC_ENCODING_LINEAR_RGB);
 }
 
+TEST_CASE("[GaussianSplatting][Importer] populate_gaussian_data defaults missing DC metadata to linear RGB") {
+    Ref<GaussianSplatAsset> asset = _make_thumbnail_fixture_asset(1);
+    REQUIRE_MESSAGE(asset.is_valid(), "Fixture asset must be created");
+    REQUIRE_MESSAGE(!asset->get_import_metadata().has(StringName("dc_encoding")),
+            "Fixture must not carry explicit DC metadata");
+
+    Ref<::GaussianData> data;
+    data.instantiate();
+    REQUIRE_MESSAGE(data.is_valid(), "GaussianData must instantiate");
+
+    const bool ok = asset->populate_gaussian_data(data);
+    REQUIRE_MESSAGE(ok, "populate_gaussian_data should accept fixture asset");
+    REQUIRE_MESSAGE(data->get_count() == 1, "populate_gaussian_data should materialize the fixture");
+
+    const Gaussian g = data->get_gaussian(0);
+    CHECK(gaussian_get_dc_encoding(g.render_meta) == GAUSSIAN_DC_ENCODING_LINEAR_RGB);
+}
+
 TEST_CASE("[GaussianSplatting][Importer] SPZ loader rejects oversized payload sections") {
     const String source_path = "user://gaussian_spz_oversized_payload.spz";
 

--- a/modules/gaussian_splatting/tests/test_gaussian_importer.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_importer.h
@@ -1176,24 +1176,47 @@ TEST_CASE("[GaussianSplatting][Importer] SPZ importer persists linear DC encodin
     _remove_user_file(save_base_path + ".tres");
 }
 
-TEST_CASE("[GaussianSplatting][Importer] PLY loader keeps legacy DC encoding") {
-    const String source_path = "user://gaussian_ply_legacy_dc.ply";
+TEST_CASE("[GaussianSplatting][Importer] PLY importer tags new assets as linear DC by default") {
+    // Regression guard for the DC-encoding default flip. The PLY loader itself
+    // does not tag render_meta — that tagging only happens when the asset is
+    // built through ResourceImporterPLY (which writes "dc_encoding": "linear_rgb"
+    // into import metadata) and then deserialized via populate_from_asset
+    // (which reads that metadata at gaussian_data_io.cpp:265-268). So this
+    // test must exercise the full importer round-trip rather than
+    // PLYLoader::load_file directly.
+    const String source_path = "user://gaussian_ply_default_dc.ply";
+    const String save_base_path = "user://gaussian_ply_default_dc_imported";
     Error write_err = _write_minimal_ascii_ply(source_path);
     REQUIRE_MESSAGE(write_err == OK, "Failed to write minimal PLY fixture");
 
-    Ref<PLYLoader> loader;
-    loader.instantiate();
-    Error load_err = loader->load_file(source_path);
-    REQUIRE_MESSAGE(load_err == OK, "PLY loader should accept valid minimal ASCII fixture");
+    Ref<ResourceImporterPLY> importer;
+    importer.instantiate();
 
-    Ref<::GaussianData> data = loader->get_gaussian_data();
-    REQUIRE_MESSAGE(data.is_valid(), "PLY loader must produce GaussianData");
-    REQUIRE_MESSAGE(data->get_count() == 1, "PLY loader must load the single-point payload");
+    HashMap<StringName, Variant> options;
+    options.insert(StringName("quality/preset"), String("ultra"));
+    options.insert(StringName("preview/generate_thumbnail"), false);
+
+    const Error import_err = importer->import(ResourceUID::INVALID_ID, source_path, save_base_path, options,
+            nullptr, nullptr, nullptr);
+    REQUIRE_MESSAGE(import_err == OK, "PLY importer should succeed for minimal fixture");
+
+    Ref<GaussianSplatAsset> asset = ResourceLoader::load(save_base_path + ".tres");
+    REQUIRE_MESSAGE(asset.is_valid(), "PLY importer should emit a loadable GaussianSplatAsset");
+
+    const Dictionary metadata = asset->get_import_metadata();
+    CHECK(String(metadata.get(StringName("dc_encoding"), String())) == String("linear_rgb"));
+
+    Ref<::GaussianData> data;
+    data.instantiate();
+    REQUIRE_MESSAGE(data->populate_from_asset(asset) == OK,
+            "populate_from_asset should accept default-imported PLY asset");
+    REQUIRE_MESSAGE(data->get_count() == 1, "Imported PLY asset should materialize one gaussian");
 
     const Gaussian g = data->get_gaussian(0);
-    CHECK(gaussian_get_dc_encoding(g.render_meta) == GAUSSIAN_DC_ENCODING_LEGACY_BIAS);
+    CHECK(gaussian_get_dc_encoding(g.render_meta) == GAUSSIAN_DC_ENCODING_LINEAR_RGB);
 
     _remove_user_file(source_path);
+    _remove_user_file(save_base_path + ".tres");
 }
 
 TEST_CASE("[GaussianSplatting][Importer] PLY ASCII loader hard-fails on malformed rows") {


### PR DESCRIPTION
## Summary

- The PLY importer was tagging new imports as `legacy_bias`, which routes the GPU shader through a sigmoid compressor `1.5 * sigmoid(sh_dc) - 0.25` instead of the canonical Inria decode `sh_dc + 0.5` (i.e. `sh*C0 + 0.5` after the load-time C0 multiply). The sigmoid path symmetrically compresses [0,1] toward 0.5, producing the visible "grey overlay" — blacks lifted (~0.20), whites pulled down (~0.80), chroma squeezed toward grey.
- Flips the default for new imports and the no-metadata fallback to `linear_rgb` while preserving explicit `legacy_bias` parsing so existing assets with that tag keep their (incorrect-but-stable) decode unchanged.
- Bumps `ResourceImporterPLY` format_version 3 -> 4 so any project opened with this build auto-reimports its PLY assets to pick up the corrected metadata.
- Updates the misleading comment in `gs_sh_binning.glsl` (original 3DGS does NOT store DC in logit space; it stores raw linear SH coefficients).

## Numerical effect on a typical PLY (where stored `sh_dc = SH_C0 * f_dc`)

| f_dc | Reference Inria | legacy_bias (old) | Δ |
|---|---|---|---|
| -3 (dark) | 0.0 (clamped) | 0.20 | blacks lifted +0.2 |
| 0 (mid) | 0.5 | 0.5 | 0 |
| +3 (bright) | 1.0 (clamped) | 0.80 | whites pulled -0.2 |

## Land-order conflict with #311

This PR and #311 (SH bands 1-3 propagation) both bump PLY `format_version` 3 -> 4. Whichever lands first owns v4; the second-to-land needs a one-line rebase to bump to v5 and merge the version-history comments. Either order is fine. Existing user assets re-import once on either bump.

## Test plan
- [x] Local Windows editor build clean (dev_build=yes, optimize=speed_trace, tests=yes)
- [x] 33 / 33 GaussianSplatting Importer tests pass (205 assertions)
- [x] Updated regression test `[GaussianSplatting][Importer] PLY importer tags new assets as linear DC by default` exercises the full importer round-trip (the previous version of this test incorrectly asserted on `PLYLoader::load_file` directly, which doesn't tag `render_meta` — tagging only happens via the importer's metadata path at `gaussian_data_io.cpp:265-268`)
- [ ] Visual A/B: scene rendered with the new editor should show full contrast / saturation after re-import

🤖 Generated with [Claude Code](https://claude.com/claude-code)