### PR TITLE
gaussian_splatting: cull/sort short-circuit + diagnostics destroy hook

### DIFF
--- a/modules/gaussian_splatting/register_types.cpp
+++ b/modules/gaussian_splatting/register_types.cpp
@@ -219,6 +219,7 @@ void uninitialize_gaussian_splatting_module(ModuleInitializationLevel p_level) {
             }
             // Cleanup Custom Performance Monitors
             GaussianSplattingPerformanceMonitors::destroy_singleton();
+            GaussianRenderingDiagnostics::destroy_singleton();
             break;
 
 #ifdef TOOLS_ENABLED

--- a/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.cpp
@@ -984,7 +984,11 @@ void RenderDiagnosticsOrchestrator::record_rendering_error(const RenderingError 
 			? GaussianSplatRenderer::ErrorRecoveryStateMachine::State::DISABLED
 			: GaussianSplatRenderer::ErrorRecoveryStateMachine::State::DIAGNOSTIC;
 	transition_recovery_state(next_state, p_error.get_message());
-	GaussianRenderingDiagnostics::ensure_singleton();
+	// Do NOT call ensure_singleton() here: after module unload calls
+	// destroy_singleton(), reviving the instance on a stray late callback would
+	// leak it (no second destroy). Module init at register_types.cpp:122 is the
+	// canonical creation point; null-guarded get_singleton() is the safe access
+	// pattern.
 	if (GaussianRenderingDiagnostics::get_singleton()) {
 		GaussianRenderingDiagnostics::get_singleton()->notify_error(renderer, p_error);
 	}
@@ -1035,7 +1039,7 @@ void RenderDiagnosticsOrchestrator::increment_frame_counter() {
 	GaussianSplatRenderer::FrameStateProvider state_provider(renderer);
 	capture_frame_timing_sample();
 	state_provider.get_frame_state_mut().frame_counter++;
-	GaussianRenderingDiagnostics::ensure_singleton();
+	// See notify_error: avoid post-destroy resurrection.
 	if (GaussianRenderingDiagnostics::get_singleton()) {
 		GaussianRenderingDiagnostics::get_singleton()->notify_frame_completed(renderer);
 	}
@@ -1046,7 +1050,7 @@ void RenderDiagnosticsOrchestrator::emit_runtime_diagnostics_if_requested() {
 	if (!diagnostics_state.runtime_diagnostics_requested) {
 		return;
 	}
-	GaussianRenderingDiagnostics::ensure_singleton();
+	// See notify_error: avoid post-destroy resurrection.
 	if (GaussianRenderingDiagnostics::get_singleton()) {
 		GaussianRenderingDiagnostics::get_singleton()->request_runtime_report();
 	}

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -934,16 +934,35 @@ void RenderPipelineStages::execute_frame_entry(const RenderFrameContext &p_frame
 		// Cull did not produce usable output (FAILED, or SKIPPED with default-zeroed
 		// CullStageOutput). is_success() returns true for SUCCESS and FALLBACK, so
 		// this short-circuit catches the cases where the sort stage would receive
-		// poison input. Stage already recorded its own metrics/route_uid; mark sort
-		// SKIPPED so the cascade is visible instead of a stale SUCCESS, then render
-		// empty. Snapshot stays at the zero-safe defaults set above.
+		// poison input. Cull stage already recorded its own metrics + route_uid;
+		// mark sort SKIPPED so the cascade is visible instead of a stale SUCCESS,
+		// preserving the cull failure reason in sort_result so downstream observers
+		// (get_render_stats, diagnostics) attribute the cascade to its real cause.
+		// Snapshot stays at the zero-safe defaults set above.
 		if (frame_context.metrics) {
 			frame_context.metrics->sort = GaussianSplatRenderer::SortStageOutput();
+			const String sort_reason = cull_result.reason.is_empty()
+					? String("Sort skipped: cull failed")
+					: vformat("Sort skipped: cull %s (%s)", _stage_status_label(cull_result.status), cull_result.reason);
 			frame_context.metrics->sort_result = _make_stage_result(
 					GaussianSplatRenderer::StageResult::StageStatus::SKIPPED,
-					"Sort skipped: cull failed",
+					sort_reason,
 					false,
-					GaussianSplatRenderer::RenderFallbackReason::NONE);
+					cull_result.fallback_reason);
+		}
+		// Set route_uid so the debug HUD reflects the cascade rather than the
+		// previous frame's value. Only attribute a FAILURE UID when cull actually
+		// failed; benign SKIPPED-with-empty-output frames (e.g. "no visible
+		// splats") should not be reclassified as failures in route-based telemetry.
+		// The cull stage's own _record_pipeline_event already sets a SKIP route
+		// UID for those, so leaving route_uid alone preserves it; we only fill the
+		// failure UID when both (a) the result is genuinely failed and (b) no
+		// stage-specific UID was recorded.
+		const bool cull_genuinely_failed = cull_result.is_error ||
+				cull_result.status == GaussianSplatRenderer::StageResult::StageStatus::FAILED;
+		if (renderer && cull_genuinely_failed &&
+				RenderRouteUID::is_route_uid_missing(renderer->get_debug_state().route_uid)) {
+			renderer->get_debug_state().route_uid = RenderRouteUID::COMMON_FAIL_SORT_FAILED;
 		}
 		update_counts_from_snapshot();
 		render_sorted_splats_with_context(frame_context);
@@ -963,8 +982,16 @@ void RenderPipelineStages::execute_frame_entry(const RenderFrameContext &p_frame
 		// Same is_success() guard as the cull short-circuit above: route FAILED and
 		// SKIPPED to the empty-render path so downstream consumers don't read poison
 		// from a default-zeroed SortStageOutput. Cull domain is preserved since cull
-		// completed successfully.
+		// completed successfully. Only attribute a FAILURE UID when sort actually
+		// failed; benign SKIPPED frames ("no visible splats") keep the sort stage's
+		// own skip-route attribution.
 		frame_context.snapshot.cull_visible_domain = cull_output.visible_domain;
+		const bool sort_genuinely_failed = sort_result.is_error ||
+				sort_result.status == GaussianSplatRenderer::StageResult::StageStatus::FAILED;
+		if (renderer && sort_genuinely_failed &&
+				RenderRouteUID::is_route_uid_missing(renderer->get_debug_state().route_uid)) {
+			renderer->get_debug_state().route_uid = RenderRouteUID::COMMON_FAIL_SORT_FAILED;
+		}
 		update_counts_from_snapshot();
 		render_sorted_splats_with_context(frame_context);
 		return;

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -929,7 +929,23 @@ void RenderPipelineStages::execute_frame_entry(const RenderFrameContext &p_frame
 		&state_view
 	};
 	GaussianSplatRenderer::CullStageOutput cull_output;
-	execute_cull_stage(cull_input, cull_output);
+	const GaussianSplatRenderer::StageResult cull_result = execute_cull_stage(cull_input, cull_output);
+	if (cull_result.is_error || cull_result.status == GaussianSplatRenderer::StageResult::StageStatus::FAILED) {
+		// Cull failed: stage already recorded its own metrics/route_uid. Mark sort
+		// SKIPPED so the failure cascade is visible instead of a stale SUCCESS,
+		// then render empty. Snapshot stays at the zero-safe defaults set above.
+		if (frame_context.metrics) {
+			frame_context.metrics->sort = GaussianSplatRenderer::SortStageOutput();
+			frame_context.metrics->sort_result = _make_stage_result(
+					GaussianSplatRenderer::StageResult::StageStatus::SKIPPED,
+					"Sort skipped: cull failed",
+					false,
+					GaussianSplatRenderer::RenderFallbackReason::NONE);
+		}
+		update_counts_from_snapshot();
+		render_sorted_splats_with_context(frame_context);
+		return;
+	}
 	GaussianSplatRenderer::SortStageInput sort_input{
 		frame_context.frame_id,
 		frame_context.world_to_camera_transform,
@@ -939,7 +955,13 @@ void RenderPipelineStages::execute_frame_entry(const RenderFrameContext &p_frame
 		cull_output.visible_domain
 	};
 	GaussianSplatRenderer::SortStageOutput sort_output;
-	execute_sort_stage(sort_input, sort_output);
+	const GaussianSplatRenderer::StageResult sort_result = execute_sort_stage(sort_input, sort_output);
+	if (sort_result.is_error || sort_result.status == GaussianSplatRenderer::StageResult::StageStatus::FAILED) {
+		frame_context.snapshot.cull_visible_domain = cull_output.visible_domain;
+		update_counts_from_snapshot();
+		render_sorted_splats_with_context(frame_context);
+		return;
+	}
 	frame_context.snapshot.cull_visible_domain = cull_output.visible_domain;
 	frame_context.snapshot.sorted_index_domain = sort_output.output_domain;
 	if (sort_output.output_domain == GaussianSplatRenderer::IndexDomain::SPLAT_REF) {

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -930,10 +930,13 @@ void RenderPipelineStages::execute_frame_entry(const RenderFrameContext &p_frame
 	};
 	GaussianSplatRenderer::CullStageOutput cull_output;
 	const GaussianSplatRenderer::StageResult cull_result = execute_cull_stage(cull_input, cull_output);
-	if (cull_result.is_error || cull_result.status == GaussianSplatRenderer::StageResult::StageStatus::FAILED) {
-		// Cull failed: stage already recorded its own metrics/route_uid. Mark sort
-		// SKIPPED so the failure cascade is visible instead of a stale SUCCESS,
-		// then render empty. Snapshot stays at the zero-safe defaults set above.
+	if (cull_result.is_error || !cull_result.is_success()) {
+		// Cull did not produce usable output (FAILED, or SKIPPED with default-zeroed
+		// CullStageOutput). is_success() returns true for SUCCESS and FALLBACK, so
+		// this short-circuit catches the cases where the sort stage would receive
+		// poison input. Stage already recorded its own metrics/route_uid; mark sort
+		// SKIPPED so the cascade is visible instead of a stale SUCCESS, then render
+		// empty. Snapshot stays at the zero-safe defaults set above.
 		if (frame_context.metrics) {
 			frame_context.metrics->sort = GaussianSplatRenderer::SortStageOutput();
 			frame_context.metrics->sort_result = _make_stage_result(
@@ -956,7 +959,11 @@ void RenderPipelineStages::execute_frame_entry(const RenderFrameContext &p_frame
 	};
 	GaussianSplatRenderer::SortStageOutput sort_output;
 	const GaussianSplatRenderer::StageResult sort_result = execute_sort_stage(sort_input, sort_output);
-	if (sort_result.is_error || sort_result.status == GaussianSplatRenderer::StageResult::StageStatus::FAILED) {
+	if (sort_result.is_error || !sort_result.is_success()) {
+		// Same is_success() guard as the cull short-circuit above: route FAILED and
+		// SKIPPED to the empty-render path so downstream consumers don't read poison
+		// from a default-zeroed SortStageOutput. Cull domain is preserved since cull
+		// completed successfully.
 		frame_context.snapshot.cull_visible_domain = cull_output.visible_domain;
 		update_counts_from_snapshot();
 		render_sorted_splats_with_context(frame_context);

--- a/modules/gaussian_splatting/renderer/rendering_diagnostics.cpp
+++ b/modules/gaussian_splatting/renderer/rendering_diagnostics.cpp
@@ -20,6 +20,13 @@ void GaussianRenderingDiagnostics::ensure_singleton() {
     }
 }
 
+void GaussianRenderingDiagnostics::destroy_singleton() {
+    if (singleton) {
+        memdelete(singleton);
+        singleton = nullptr;
+    }
+}
+
 void GaussianRenderingDiagnostics::process_command_line_requests() {
     if (command_line_processed) {
         return;

--- a/modules/gaussian_splatting/renderer/rendering_diagnostics.h
+++ b/modules/gaussian_splatting/renderer/rendering_diagnostics.h
@@ -15,6 +15,7 @@ class GaussianRenderingDiagnostics {
 public:
     static GaussianRenderingDiagnostics *get_singleton();
     static void ensure_singleton();
+    static void destroy_singleton();
 
     void process_command_line_requests();
     void register_renderer(GaussianSplatRenderer *p_renderer);

--- a/modules/gaussian_splatting/tests/test_diagnostics.h
+++ b/modules/gaussian_splatting/tests/test_diagnostics.h
@@ -35,6 +35,21 @@ TEST_CASE("[Gaussian Diagnostics] Singleton initialization is idempotent") {
     CHECK(second == first);
 }
 
+TEST_CASE("[Gaussian Diagnostics] destroy_singleton releases the instance and is idempotent") {
+    GaussianRenderingDiagnostics::ensure_singleton();
+    REQUIRE(GaussianRenderingDiagnostics::get_singleton() != nullptr);
+
+    GaussianRenderingDiagnostics::destroy_singleton();
+    CHECK(GaussianRenderingDiagnostics::get_singleton() == nullptr);
+
+    GaussianRenderingDiagnostics::destroy_singleton();
+    CHECK(GaussianRenderingDiagnostics::get_singleton() == nullptr);
+
+    // Re-arm so later tests/state in the same suite observe a live singleton again.
+    GaussianRenderingDiagnostics::ensure_singleton();
+    CHECK(GaussianRenderingDiagnostics::get_singleton() != nullptr);
+}
+
 TEST_CASE("[Gaussian Diagnostics] Null renderer notifications are safe no-ops") {
     GaussianRenderingDiagnostics::ensure_singleton();
     GaussianRenderingDiagnostics *diagnostics = GaussianRenderingDiagnostics::get_singleton();


### PR DESCRIPTION
## Summary

Two surgical audit fixes split out of closed PR #330. Smallest of three follow-up PRs; no dependencies on the others.

- **`render_pipeline_stages.cpp`** — `execute_cull_stage` / `execute_sort_stage` returned `StageResult` but the top-level caller discarded it, so cull/sort failures cascaded with default-zeroed outputs through downstream stages. Capture the result and short-circuit to an empty render on `!is_success()` (FAILED or SKIPPED); FALLBACK still proceeds as a recovered-success path. Sort gets marked SKIPPED on the cull-failure cascade so metrics observers see the chain.

- **`rendering_diagnostics.{h,cpp}` + `register_types.cpp` + `test_diagnostics.h`** — `GaussianRenderingDiagnostics::ensure_singleton()` `memnew`'d at module init but no destroy hook existed, leaking the instance across editor reloads. Paired `destroy_singleton()` (idempotent, null-guarded) with the existing `GaussianSplattingPerformanceMonitors` teardown.

## Commits

- `a7626ca280` short-circuit on cull/sort stage failure (the original FAILED-only guard)
- `3d11867e51` destroy diagnostics singleton on module unload
- `4518cc5ff5` widen short-circuit to also catch SKIPPED (review-pass follow-up)

## Test plan

- [x] Cherry-picked clean onto current master (`b153169114`)
- [x] No file overlap with #326's "harden streaming and diagnostics pipeline" beyond `register_types.cpp`'s teardown block where the pairing slot is unambiguous
- [ ] `scons platform=windows target=editor dev_build=yes tests=yes module_gaussian_splatting_enabled=yes -j4` — CI will exercise this
- [ ] `python tests/ci/run_module_tests.py --guard-only` — CI will exercise this
- [ ] Existing `[Gaussian Diagnostics]` test cases pass + new `destroy_singleton` test case from `test_diagnostics.h:38-54`

## Notes

Originally part of closed PR #330 (`gaussian_splatting: GPU harness, compositor hazard fix, settings audit`). That PR's merge base predated #308, #310, and #326 on master, so it carried ~100 conflict files. Splitting by concern; remaining pieces land as follow-up PRs (compositor R/W-hazard fix, GPU test harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)