### PR TITLE
ci: align gpu-tests and gpu-harness scons args (#336)

### DIFF
--- a/.github/workflows/baseline_qa.yml
+++ b/.github/workflows/baseline_qa.yml
@@ -104,7 +104,15 @@ jobs:
 
     - name: Build module-enabled Godot editor
       run: |
-        python -m SCons platform=windows target=editor dev_build=yes tests=yes gs_native_arch=no cache_path=C:/godotgs-scons-cache cache_limit=50 -j12
+        # Pass `module_gaussian_splatting_enabled=yes` explicitly to match the
+        # gpu-harness job's scons args byte-for-byte. The module already
+        # defaults to on via `modules/gaussian_splatting/config.py:can_build()`,
+        # so the practical effect on CPPDEFINES is zero — but keeping the arg
+        # string aligned across both jobs eliminates any scons env-hash drift
+        # in the shared `C:/godotgs-scons-cache` and removes a misleading
+        # signal in build logs that the two jobs are building different
+        # configurations.
+        python -m SCons platform=windows target=editor dev_build=yes tests=yes module_gaussian_splatting_enabled=yes gs_native_arch=no cache_path=C:/godotgs-scons-cache cache_limit=50 -j12
 
     - name: Resolve Godot binary
       id: godot_binary
@@ -441,9 +449,15 @@ jobs:
       - name: Build module-enabled Godot editor (tests=yes)
         if: steps.path_filter.outputs.run_harness == 'true'
         run: |
-          # Mirror gpu-tests's scons args (gs_native_arch=no) so both jobs
-          # produce identical .obj cache entries and the shared C:/godotgs-
-          # scons-cache doesn't thrash between them.
+          # Mirror gpu-tests's scons args byte-for-byte so the two jobs share
+          # `C:/godotgs-scons-cache` cleanly. The module defaults to on (see
+          # modules/gaussian_splatting/config.py:can_build), so passing
+          # `module_gaussian_splatting_enabled=yes` doesn't change CPPDEFINES —
+          # it just keeps the arg string aligned and removes any scons
+          # env-hash drift between the two jobs. (Note: the dominant rebuild
+          # cost between jobs is `actions/checkout` blowing away .sconsign
+          # between runs, not cache fragmentation; eliminating that needs
+          # artifact handoff from gpu-tests, tracked separately.)
           python -m SCons platform=windows target=editor dev_build=yes tests=yes `
             module_gaussian_splatting_enabled=yes gs_native_arch=no `
             cache_path=C:/godotgs-scons-cache cache_limit=50 -j12


### PR DESCRIPTION
## Summary

Pass `module_gaussian_splatting_enabled=yes` explicitly in the `gpu-tests` job so its scons invocation matches `gpu-harness` byte-for-byte. The original bot finding (#336) framed this as cache fragmentation, but the module already defaults to on via `config.py:can_build()` — so this is cosmetic alignment, not a CPPDEFINES fix.

Updated the `gpu-harness` comment to drop the misleading "cache fragmentation" claim and point at the actual wall-time cost: `actions/checkout` discarding `.sconsign` per job, which forces a full dependency re-scan even on cache hits. That real cost can only be eliminated by artifact-handoff between the two jobs, which is a separate larger redesign (will file as a follow-up issue if pursued).

## Why this is still worth shipping

- Eliminates scons env-hash drift between the two cache writers sharing `C:/godotgs-scons-cache`.
- Stops build logs from suggesting the two jobs are building different configurations.
- Future-proofs against a `config.py:can_build()` change flipping the default to off — the explicit `=yes` protects both lanes.

## Test plan

- [x] YAML parses (`python -c "import yaml; yaml.safe_load(...)"`)
- [ ] First post-merge run on the self-hosted Windows runner will pay a one-time cold-cache miss on whichever TU side wasn't represented before. Bounded, single-run cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)