### PR TITLE
tests: REQUIRE_GPU_DEVICE() owns its fallback RD (#334)

### DIFF
--- a/modules/gaussian_splatting/tests/test_macros.h
+++ b/modules/gaussian_splatting/tests/test_macros.h
@@ -60,19 +60,48 @@ public:
     }
 };
 
-// Helper macro for GPU tests that require a rendering device
-// Uses CHECK instead of REQUIRE to avoid exceptions (disabled in Godot)
+// RAII guard for the optional locally-allocated fallback RenderingDevice that
+// REQUIRE_GPU_DEVICE() may construct when RenderingDevice::get_singleton()
+// returns null. Frees the device on scope exit if-and-only-if the macro owned
+// it. `rd` is exposed as a public field so the macro can republish it under
+// that name to the surrounding test function — the call-site contract from
+// pre-refactor REQUIRE_GPU_DEVICE() is unchanged.
+class ScopedFallbackRD {
+public:
+    RenderingDevice *rd = nullptr;
+    bool owns_rd = false;
+
+    ScopedFallbackRD() {
+        rd = RenderingDevice::get_singleton();
+        if (!rd) {
+            if (RenderingServer *rs = RenderingServer::get_singleton()) {
+                rd = rs->create_local_rendering_device();
+                owns_rd = (rd != nullptr);
+            }
+        }
+    }
+    ~ScopedFallbackRD() {
+        if (owns_rd && rd) {
+            memdelete(rd);
+        }
+    }
+    ScopedFallbackRD(const ScopedFallbackRD &) = delete;
+    ScopedFallbackRD &operator=(const ScopedFallbackRD &) = delete;
+};
+
+// Helper macro for GPU tests that require a rendering device.
+// Publishes a `RenderingDevice *rd` into the calling test's scope. If the
+// engine singleton is null, a local fallback RD is created and OWNED by an
+// inline ScopedFallbackRD guard — the guard's destructor frees the device on
+// every scope exit (normal return, early return below, doctest REQUIRE
+// exception). Pre-refactor callers leaked the fallback RD because the macro
+// had no paired teardown; #334.
 #define REQUIRE_GPU_DEVICE()                                              \
-    RenderingDevice *rd = RenderingDevice::get_singleton();              \
-    if (!rd) {                                                           \
-        RenderingServer *rs = RenderingServer::get_singleton();         \
-        if (rs) {                                                        \
-            rd = rs->create_local_rendering_device();                   \
-        }                                                               \
-    }                                                                    \
-    if (rd == nullptr) {                                                 \
-        MESSAGE("Skipping test - RenderingDevice unavailable");             \
-        return;                                                          \
+    ScopedFallbackRD _gs_rd_scope;                                        \
+    RenderingDevice *rd = _gs_rd_scope.rd;                                \
+    if (rd == nullptr) {                                                  \
+        MESSAGE("Skipping test - RenderingDevice unavailable");           \
+        return;                                                           \
     }
 
 // Performance baseline checking

--- a/modules/gaussian_splatting/tests/test_output_compositor_composite_hazard.h
+++ b/modules/gaussian_splatting/tests/test_output_compositor_composite_hazard.h
@@ -65,17 +65,19 @@ static Vector<uint8_t> _build_source_premultiplied_circle_256() {
 
 } // namespace CompositeHazardRepro
 
-// Scope guard tied to this TU's hazard test: tracks textures and the optional
-// locally-allocated fallback RD that REQUIRE_GPU_DEVICE() may have created,
-// and frees them in destruction order regardless of how the test exits
-// (success, REQUIRE failure → doctest exception, or normal return). Without
-// this guard, any REQUIRE failure before the manual rd->free(...) block at
-// the end of the test would leak RIDs into the next test case, and a local
-// fallback RD (singleton path bypassed) would leak the entire device.
+// Scope guard tied to this TU's hazard test: tracks textures and the
+// compositor, and frees them in destruction order regardless of how the
+// test exits (success, REQUIRE failure → doctest exception, or normal
+// return). Without this guard, any REQUIRE failure before the manual
+// rd->free(...) block at the end of the test would leak RIDs into the
+// next test case. The RenderingDevice itself is owned by
+// REQUIRE_GPU_DEVICE()'s ScopedFallbackRD (declared first in the test
+// scope, destroyed last LIFO), so this guard intentionally does NOT free
+// the device — that would be a double-delete.
 class HazardTestScope {
 public:
-	HazardTestScope(RenderingDevice *p_rd, bool p_owns_rd) :
-			rd(p_rd), owns_rd(p_owns_rd) {}
+	explicit HazardTestScope(RenderingDevice *p_rd) :
+			rd(p_rd) {}
 
 	~HazardTestScope() {
 		if (rd) {
@@ -87,31 +89,23 @@ public:
 			if (compositor.is_valid()) {
 				compositor->shutdown();
 			}
-			if (owns_rd) {
-				memdelete(rd);
-			}
 		}
 	}
 
 	void track(RID p_texture) { textures.push_back(p_texture); }
 
 	RenderingDevice *rd = nullptr;
-	bool owns_rd = false;
 	Vector<RID> textures;
 	Ref<OutputCompositor> compositor;
 };
 
 TEST_CASE("[GaussianSplatting][RequiresGPU][HazardRepro] Compositor scratch-copy preserves destination outside source") {
-	// Track whether REQUIRE_GPU_DEVICE() allocated a local fallback RD (singleton
-	// was null) so the scope guard knows to memdelete it on test exit. Under the
-	// GPU harness path the singleton is pre-populated by `_bootstrap_rd()` and
-	// `owns_rd` stays false, but the macro is also used outside that harness
-	// (regular `--test` lane, future cross-driver swap-in lanes), where a leaked
-	// device propagates across test cases.
-	const bool _had_singleton_before = (RenderingDevice::get_singleton() != nullptr);
 	REQUIRE_GPU_DEVICE();
-	// rd was declared by REQUIRE_GPU_DEVICE; it is the singleton or a local fallback.
-	HazardTestScope _scope(rd, !_had_singleton_before && rd != RenderingDevice::get_singleton());
+	// rd was declared by REQUIRE_GPU_DEVICE and is kept alive by its inline
+	// ScopedFallbackRD guard (#334). HazardTestScope only owns the textures
+	// and compositor — the RD itself is freed by the macro's guard on scope
+	// exit, after this scope's destructor runs (LIFO destruction order).
+	HazardTestScope _scope(rd);
 
 	RD::TextureFormat source_format;
 	source_format.width = 256;


### PR DESCRIPTION
## Summary

Push the RD-ownership fix from PR #333's one-off `HazardTestScope` into the shared `REQUIRE_GPU_DEVICE()` macro so every `[RequiresGPU]` test inherits the safety automatically.

The macro can construct a local fallback `RenderingDevice` via `RenderingServer::create_local_rendering_device()` when the singleton is null, but had no paired teardown. Any test hitting the fallback path leaked a full device. Masked today by the GPU harness's `_bootstrap_rd()` pre-populating the singleton, but the macro is also used outside that harness (regular `--test` lane, future cross-driver lanes), where a leaked device would propagate across test cases.

## Design

- New `ScopedFallbackRD` RAII helper in `test_macros.h` captures the singleton or, on null, allocates and owns a local device. Frees on scope exit iff it allocated.
- The macro now instantiates one at the top of the calling test and republishes its `rd` field under the existing `rd` name — call-site contract unchanged.
- All ~14 existing callers compile unchanged. Singleton-path semantics are byte-for-byte identical (`owns_rd` stays false, destructor is a no-op).

## Hazard test cleanup

PR #333's `HazardTestScope` was tracking RD ownership defensively; with the macro now owning the RD, that path would be a double-delete. Simplified `HazardTestScope` to track only textures + compositor. LIFO destruction order keeps cleanup correct: `HazardTestScope` (textures) destructs first while `rd` is still valid, then `ScopedFallbackRD` runs and frees the device.

## Test plan

- [x] Build clean.
- [x] Hazard test through GPU harness: `cases=1/1 asserts=20/20 Status=SUCCESS`.
- [ ] Regression: full `--test` lane on Linux runner (CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)