### PR TITLE
tests: raise RID-leak threshold to 4 MiB + flip gate (#335)

### DIFF
--- a/modules/gaussian_splatting/tests/gs_gpu_test_runner.cpp
+++ b/modules/gaussian_splatting/tests/gs_gpu_test_runner.cpp
@@ -220,16 +220,31 @@ struct GsGpuRidLeakListener : public doctest::IReporter {
 			return;
 		}
 #if defined(RD_ENABLED)
+		// 4 MiB threshold: empirically the compositor hazard test reliably
+		// reports ~2.25 MiB of post-teardown delta (Godot's RD allocator
+		// pools memory; 256×256 RGBA8 + D32 textures + a compositor scratch
+		// don't immediately return to the OS). 4 MiB gives a 1.78x margin
+		// above that observed noise floor on NVIDIA/Vulkan/release; any
+		// genuine leak (a missed rd->free for geometry/framebuffer state)
+		// dwarfs 4 MiB and trips the signal cleanly. Driver variance for
+		// AMD/Intel allocator pools is unknown — if a future runner trips
+		// this on the canonical hazard test, retune empirically or move
+		// to per-batch thresholds via the supervisor's BatchSpec. The
+		// listener emits per test_case, so cross-test accumulation is
+		// not a concern. See #335 for follow-up to switch to a
+		// release-build-friendly handle-count signal once available.
+		constexpr uint64_t LEAK_BYTES_THRESHOLD = 4ull << 20;
 		if (RenderingDevice *rd = RenderingDevice::get_singleton()) {
 			const uint64_t end_memory = rd->get_memory_usage(RenderingDevice::MEMORY_TOTAL);
 			if (end_memory > case_start_memory) {
 				const uint64_t delta = end_memory - case_start_memory;
-				if (delta > (1ull << 20)) {
+				if (delta > LEAK_BYTES_THRESHOLD) {
 					// Format: `[GS-GPU][RID-LEAK?] bytes=N test=<name>`
-					// The supervisor (tests/ci/run_gpu_harness.py) scrapes this
-					// pattern to fold leaks into the gate decision — listener
-					// reporters can't call CHECK_MESSAGE, so we surface the
-					// signal via stdout and let the supervisor escalate.
+					// The supervisor (tests/ci/run_gpu_harness.py) scrapes
+					// this pattern and folds leaks into gate_failed —
+					// listener reporters can't call CHECK_MESSAGE, so we
+					// surface the signal via stdout and let the supervisor
+					// escalate.
 					print_line(vformat("[GS-GPU][RID-LEAK?] bytes=%s test=advisory",
 							String::num_uint64(delta)));
 				}

--- a/tests/ci/run_gpu_harness.py
+++ b/tests/ci/run_gpu_harness.py
@@ -515,13 +515,12 @@ def main() -> int:
                     flush=True,
                 )
     # Per-batch RID-leak totals scraped from the listener's stdout marker.
-    # Surfaced for visibility in the JSON report and the DONE line so post-
-    # mortem can spot growth across runs. NOT folded into gate_failed today:
-    # the listener's current 1 MiB threshold (gs_gpu_test_runner.cpp) catches
-    # Godot's RD allocator overhead as well as actual leaks, and the hazard
-    # test's intentional 4 textures + compositor reliably trip it at ~2.25 MiB.
-    # Tightening the threshold or distinguishing allocator overhead from real
-    # leaks is a follow-up — for now, advisory only.
+    # The listener's threshold was raised to 4 MiB in #335 (above the ~2.25 MiB
+    # of allocator-pool overhead observed on the hazard test on NVIDIA/Vulkan/
+    # release), so any non-zero value here is a real leak signal — fold into
+    # gate_failed below. If a future driver/runner's allocator pool trips the
+    # listener on the canonical hazard test, retune the threshold in
+    # gs_gpu_test_runner.cpp rather than the supervisor side.
     total_rid_leak_bytes = sum(r.rid_leak_bytes for r in results)
 
     # Batches where the doctest summary regex failed to match. Locale shifts,
@@ -541,6 +540,7 @@ def main() -> int:
         or (parsed_failures > 0)
         or bool(empty_required_batches)
         or bool(summary_parse_failures)
+        or (total_rid_leak_bytes > 0)
     )
     # Preserve the worst batch's exit code as the supervisor exit when a batch
     # itself failed (the module header promises "returns max(batch_rc)"). The


### PR DESCRIPTION
## Summary

Make the GPU harness's RID-leak signal **actionable** by tuning the threshold above observed allocator-pool noise, then flipping the supervisor's `gate_failed` to fail on any non-zero leak.

## Empirical basis

Ran the hazard test 4× on the canonical CI runner (NVIDIA RTX 3090, Vulkan, release build):

| Run | `rid_leak_bytes` |
|---|---|
| 1 | 2,359,296 (2.25 MiB) |
| 2 | 2,359,296 |
| 3 | 2,359,296 |
| 4 | 2,359,296 |

Perfectly deterministic — this is Godot's `RenderingDevice` allocator pool holding 4×(256×256 RGBA8) + D32 textures + compositor scratch RT after the test's `rd->free(...)` calls. NOT a real leak; the test correctly frees every resource it allocates.

**4 MiB threshold (`4ull << 20`)** gives 1.78x margin above this noise floor. Any genuine leak (missed `rd->free` for non-trivial framebuffer/geometry state) dwarfs 4 MiB and trips the signal cleanly.

## Changes

- `modules/gaussian_splatting/tests/gs_gpu_test_runner.cpp`: bump listener threshold from 1 MiB → `constexpr uint64_t LEAK_BYTES_THRESHOLD = 4ull << 20`. Added a comment block documenting the empirical basis and driver-variance caveat.
- `tests/ci/run_gpu_harness.py`: add `(total_rid_leak_bytes > 0)` to the `gate_failed` disjunction. Updated the comment block above `total_rid_leak_bytes` to reflect the new "real signal, gate-failing" semantics.

## What about handle-count tracking (Option B)?

Rejected for now. The underlying APIs (`RenderingDevice::get_driver_allocation_count`, `get_device_allocation_count`, per-object-type counters) are gated on `VK_TRACK_DRIVER_MEMORY` / `VK_TRACK_DEVICE_MEMORY` which are only defined under `DEBUG_ENABLED || DEV_ENABLED` (see `drivers/vulkan/rendering_context_driver_vulkan.h:37-40`). The CI harness binary is a release build, so the counters return 0 unconditionally. Switching to handle-count needs a build-mode change tracked separately.

## Risks

- **Driver variance**: AMD/Intel allocator pools are unknown. If a future runner trips this on the canonical hazard test, retune empirically or move to per-batch thresholds via the supervisor's `BatchSpec.timeout_seconds`-style override.
- **Future heavy tests**: when `TileRenderer`/`GpuSorting` batches populate, individual tests creating many large RTs could trip 4 MiB. Rerun the supervisor when those batches have real tests and revise.

## Test plan

- [x] Hazard test now silent: `rid_leak_bytes=0` in report, supervisor exits 0.
- [x] Regex scraping still works when threshold IS exceeded (verified via monkey-patched stdout in the supervisor's `RID_LEAK_RE`).
- [ ] Watch first post-merge CI run for any unexpected listener fires on the other 6 (currently empty) batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)