### PR TITLE
gaussian_splatting: add per-phase startup-time trace

### DIFF
--- a/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
@@ -11,6 +11,7 @@
 #include "core/os/os.h"
 #include "core/os/thread.h"
 #include "../logger/gs_logger.h"
+#include "../logger/startup_trace.h"
 #include "scene/resources/image_texture.h"
 
 namespace {
@@ -1094,6 +1095,8 @@ Error GaussianSplatAsset::load_from_file(const String &p_path) {
         return ERR_FILE_NOT_FOUND;
     }
 
+    GSStartupTrace::get_singleton()->begin_asset_open();
+
 	uint64_t total_start_usec = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : 0;
 	uint64_t source_start_usec = total_start_usec;
 
@@ -1240,6 +1243,7 @@ Ref<::GaussianData> GaussianSplatAsset::get_gaussian_data() const {
 }
 
 bool GaussianSplatAsset::populate_gaussian_data(Ref<::GaussianData> &r_data) const {
+    GS_STARTUP_SCOPE("asset_populate_gaussian_data");
     if (splat_count == 0) {
         return false;
     }

--- a/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
@@ -1095,7 +1095,10 @@ Error GaussianSplatAsset::load_from_file(const String &p_path) {
         return ERR_FILE_NOT_FOUND;
     }
 
-    GSStartupTrace::get_singleton()->begin_asset_open();
+    // GSStartupTrace is armed by render-context callers (the
+    // GaussianSplatNode3D load sites) so importers, tests, and other
+    // headless flows that call load_from_file directly do not queue
+    // pending traces that will never be drained.
 
 	uint64_t total_start_usec = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : 0;
 	uint64_t source_start_usec = total_start_usec;

--- a/modules/gaussian_splatting/core/gaussian_splat_manager.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_manager.cpp
@@ -12,6 +12,7 @@
 #include "../renderer/sorting_settings_utils.h"
 #include "../nodes/gaussian_splat_node_3d.h"
 #include "../logger/gs_logger.h"
+#include "../logger/startup_trace.h"
 #include "../interfaces/sync_policy.h"
 #include "servers/rendering/rendering_device.h"
 #include "servers/rendering_server.h"
@@ -215,6 +216,7 @@ void GaussianSplatManager::ScopedSubmissionLock::_release() {
 }
 
 GaussianSplatManager::GaussianSplatManager() {
+    GS_STARTUP_SCOPE("manager_construct");
     ERR_FAIL_COND_MSG(singleton != nullptr, "GaussianSplatManager singleton already exists.");
     singleton = this;
 
@@ -249,8 +251,14 @@ GaussianSplatManager::GaussianSplatManager() {
         // Create a local device for primary operations
         RenderingServer *rs = RenderingServer::get_singleton();
         if (rs) {
-            _request_primary_local_device();
-            _request_shared_local_device();
+            {
+                GS_STARTUP_SCOPE("device_request_primary");
+                _request_primary_local_device();
+            }
+            {
+                GS_STARTUP_SCOPE("device_request_shared");
+                _request_shared_local_device();
+            }
             primary_device_render_thread_bound = false;
             shared_device_render_thread_bound = false;
         } else {

--- a/modules/gaussian_splatting/core/gaussian_streaming.cpp
+++ b/modules/gaussian_splatting/core/gaussian_streaming.cpp
@@ -16,6 +16,7 @@
 #include "../renderer/gpu_debug_utils.h"
 #include "../renderer/quantization_config.h"
 #include "../logger/gs_logger.h"
+#include "../logger/startup_trace.h"
 #include "../interfaces/sync_policy.h"
 #include "../lod/lod_config.h"
 #include <cfloat>  // For FLT_MAX
@@ -901,6 +902,7 @@ void GaussianStreamingSystem::initialize(Ref<::GaussianData> p_data) {
     }
 
     if (rd) {
+        GS_STARTUP_SCOPE("streaming_persistent_buffer_alloc");
         const uint64_t persistent_bytes64 = uint64_t(effective_max_chunks) * _streaming_chunk_slot_bytes();
         if (persistent_bytes64 == 0 || persistent_bytes64 > uint64_t(UINT32_MAX)) {
             ERR_PRINT(vformat("[Streaming] Initialization failed: persistent buffer size overflow (%s bytes, max=%u).",
@@ -943,8 +945,14 @@ void GaussianStreamingSystem::initialize(Ref<::GaussianData> p_data) {
                 quantization_scales_enabled ? vformat("%d bits scale", quantization_scale_bits) : "scale unquantized"));
     }
 
-    global_atlas_registry.build_cpu_state(*this);
-    global_atlas_registry.sync_to_gpu(*this, rd);
+    {
+        GS_STARTUP_SCOPE("streaming_atlas_build_cpu");
+        global_atlas_registry.build_cpu_state(*this);
+    }
+    {
+        GS_STARTUP_SCOPE("streaming_atlas_sync_gpu");
+        global_atlas_registry.sync_to_gpu(*this, rd);
+    }
 
     GS_LOG_STREAMING_INFO(vformat("[Streaming] Initialized with %d chunks for %d splats (VRAM budget: %d MB, max chunks: %d)",
             chunks.size(), total_splat_count,

--- a/modules/gaussian_splatting/io/gaussian_data_loader.cpp
+++ b/modules/gaussian_splatting/io/gaussian_data_loader.cpp
@@ -1,13 +1,16 @@
 #include "gaussian_data_loader.h"
 
 #include "../logger/gs_logger.h"
-#include "../logger/startup_trace.h"
 #include "ply_loader.h"
 #include "spz_loader.h"
 
 Error load_gaussian_data_from_file(const String &p_path, GaussianDataLoadResult &r_result) {
     r_result = GaussianDataLoadResult();
-    GSStartupTrace::get_singleton()->begin_asset_open();
+    // Do not arm GSStartupTrace here. This entry point is reached from
+    // headless tests, importers, and CLI tools where no renderer ever drains
+    // the pending-flush queue, so each call would leak a sealed_traces entry
+    // until process exit. The render-path entry point (GaussianSplatAsset::
+    // load_from_file) arms its own trace and routes around this loader.
 
     const String extension = p_path.get_extension().to_lower();
     if (extension == "spz") {

--- a/modules/gaussian_splatting/io/gaussian_data_loader.cpp
+++ b/modules/gaussian_splatting/io/gaussian_data_loader.cpp
@@ -1,11 +1,13 @@
 #include "gaussian_data_loader.h"
 
 #include "../logger/gs_logger.h"
+#include "../logger/startup_trace.h"
 #include "ply_loader.h"
 #include "spz_loader.h"
 
 Error load_gaussian_data_from_file(const String &p_path, GaussianDataLoadResult &r_result) {
     r_result = GaussianDataLoadResult();
+    GSStartupTrace::get_singleton()->begin_asset_open();
 
     const String extension = p_path.get_extension().to_lower();
     if (extension == "spz") {

--- a/modules/gaussian_splatting/io/ply_loader.cpp
+++ b/modules/gaussian_splatting/io/ply_loader.cpp
@@ -7,6 +7,7 @@
 #include "io_settings_utils.h"
 #include "../core/gaussian_splat_world.h"
 #include "../logger/gs_logger.h"
+#include "../logger/startup_trace.h"
 
 #include <climits>
 
@@ -78,6 +79,8 @@ Error PLYLoader::load_file(const String &p_path) {
         return ERR_FILE_NOT_FOUND;
     }
 
+    GSStartupTrace::get_singleton()->begin_asset_open();
+
     last_cache_hit = false;
     last_header_time_us = 0;
     last_parse_time_us = 0;
@@ -106,6 +109,10 @@ Error PLYLoader::load_file(const String &p_path) {
             last_cache_time_us = OS::get_singleton()->get_ticks_usec() - cache_start;
             last_cache_hit = true;
             last_load_time_us = OS::get_singleton()->get_ticks_usec() - start_time;
+            if (GSStartupTrace *trace = GSStartupTrace::get_singleton(); trace && trace->is_enabled()) {
+                trace->record_subphase("ply_header_parse", last_header_time_us);
+                trace->record_subphase("ply_cache_lookup", last_cache_time_us);
+            }
             GS_LOG_STREAMING_INFO(vformat("PLY cache hit: %d splats in %.2f ms",
                     header.vertex_count, last_load_time_us / 1000.0));
             return OK;
@@ -115,12 +122,19 @@ Error PLYLoader::load_file(const String &p_path) {
 
     // Parse data based on format
     uint64_t parse_start = OS::get_singleton()->get_ticks_usec();
-    if (header.is_binary) {
-        err = parse_binary_data(file);
-    } else {
-        err = parse_ascii_data(file);
+    {
+        GS_STARTUP_SCOPE("ply_payload_parse");
+        if (header.is_binary) {
+            err = parse_binary_data(file);
+        } else {
+            err = parse_ascii_data(file);
+        }
     }
     last_parse_time_us = OS::get_singleton()->get_ticks_usec() - parse_start;
+    if (GSStartupTrace *trace = GSStartupTrace::get_singleton(); trace && trace->is_enabled()) {
+        trace->record_subphase("ply_header_parse", last_header_time_us);
+        trace->record_subphase("ply_cache_lookup", last_cache_time_us);
+    }
 
     if (err != OK) {
         GS_LOG_ERROR_DEFAULT("Failed to parse PLY data");

--- a/modules/gaussian_splatting/io/ply_loader.cpp
+++ b/modules/gaussian_splatting/io/ply_loader.cpp
@@ -79,7 +79,10 @@ Error PLYLoader::load_file(const String &p_path) {
         return ERR_FILE_NOT_FOUND;
     }
 
-    GSStartupTrace::get_singleton()->begin_asset_open();
+    // Higher-level entry points (GaussianSplatAsset::load_from_file,
+    // load_gaussian_data_from_file) own the begin_asset_open() call; nesting
+    // one here would double-arm the pending-flush counter and split a single
+    // asset load across multiple [StartupTrace] lines.
 
     last_cache_hit = false;
     last_header_time_us = 0;

--- a/modules/gaussian_splatting/io/spz_loader.cpp
+++ b/modules/gaussian_splatting/io/spz_loader.cpp
@@ -1,4 +1,5 @@
 #include "spz_loader.h"
+#include "../logger/startup_trace.h"
 #include "core/os/os.h"
 #include "../logger/gs_logger.h"
 
@@ -119,6 +120,8 @@ Error SPZLoader::load_file(const String &p_path) {
         GS_LOG_ERROR_DEFAULT("Failed to open SPZ file: " + p_path);
         return ERR_FILE_NOT_FOUND;
     }
+
+    GSStartupTrace::get_singleton()->begin_asset_open();
 
     int64_t file_size = file->get_length();
     GS_LOG_STREAMING_INFO(vformat("[SPZ-LOAD] File opened, size=%d MB", (int)(file_size / 1024 / 1024)));

--- a/modules/gaussian_splatting/io/spz_loader.cpp
+++ b/modules/gaussian_splatting/io/spz_loader.cpp
@@ -1,5 +1,4 @@
 #include "spz_loader.h"
-#include "../logger/startup_trace.h"
 #include "core/os/os.h"
 #include "../logger/gs_logger.h"
 
@@ -121,7 +120,9 @@ Error SPZLoader::load_file(const String &p_path) {
         return ERR_FILE_NOT_FOUND;
     }
 
-    GSStartupTrace::get_singleton()->begin_asset_open();
+    // Higher-level loaders own begin_asset_open(); nesting it here would
+    // double-arm the trace counter and split a single asset open across
+    // multiple [StartupTrace] lines.
 
     int64_t file_size = file->get_length();
     GS_LOG_STREAMING_INFO(vformat("[SPZ-LOAD] File opened, size=%d MB", (int)(file_size / 1024 / 1024)));

--- a/modules/gaussian_splatting/logger/startup_trace.cpp
+++ b/modules/gaussian_splatting/logger/startup_trace.cpp
@@ -45,6 +45,7 @@ void GSStartupTrace::begin_asset_open() {
 		totals_usec.clear();
 		insertion_order.clear();
 		pending_flush_count.store(0, std::memory_order_relaxed);
+		active_begin_usec = 0;
 		return;
 	}
 
@@ -56,6 +57,7 @@ void GSStartupTrace::begin_asset_open() {
 		GSStartupTraceSnapshot snapshot;
 		snapshot.totals_usec = totals_usec;
 		snapshot.insertion_order = insertion_order;
+		snapshot.begin_usec = active_begin_usec;
 		sealed_traces.push_back(snapshot);
 		totals_usec.clear();
 		insertion_order.clear();
@@ -63,6 +65,9 @@ void GSStartupTrace::begin_asset_open() {
 	// First call (pending_flush_count == 0) preserves any pre-open module-init
 	// phases already recorded in the active accumulator so the first
 	// [StartupTrace] line includes them.
+
+	OS *os = OS::get_singleton();
+	active_begin_usec = os ? os->get_ticks_usec() : 0;
 
 	pending_flush_count.fetch_add(1, std::memory_order_acq_rel);
 }
@@ -73,6 +78,7 @@ void GSStartupTrace::reset() {
 	totals_usec.clear();
 	insertion_order.clear();
 	pending_flush_count.store(0, std::memory_order_relaxed);
+	active_begin_usec = 0;
 }
 
 bool GSStartupTrace::consume_pending_flush() {
@@ -126,7 +132,7 @@ void GSStartupTrace::record_subphase(const char *p_phase, uint64_t p_duration_us
 	record_subphase(StringName(p_phase), p_duration_usec);
 }
 
-void GSStartupTrace::flush(double p_total_ms) {
+void GSStartupTrace::flush() {
 	String line;
 	{
 		MutexLock lock(state_mutex);
@@ -140,18 +146,30 @@ void GSStartupTrace::flush(double p_total_ms) {
 		// it so the next open starts fresh.
 		const HashMap<StringName, uint64_t> *emit_totals = nullptr;
 		const LocalVector<StringName> *emit_order = nullptr;
+		uint64_t emit_begin_usec = 0;
 		GSStartupTraceSnapshot popped;
 		if (!sealed_traces.is_empty()) {
 			popped = sealed_traces[0];
 			sealed_traces.remove_at(0);
 			emit_totals = &popped.totals_usec;
 			emit_order = &popped.insertion_order;
+			emit_begin_usec = popped.begin_usec;
 		} else if (!insertion_order.is_empty()) {
 			emit_totals = &totals_usec;
 			emit_order = &insertion_order;
+			emit_begin_usec = active_begin_usec;
 		} else {
 			return;
 		}
+
+		// total= measures from begin_asset_open() to now so it reflects the
+		// end-to-end startup duration the user actually sees, not the
+		// frame-entry slice the caller happens to be inside.
+		OS *os = OS::get_singleton();
+		const uint64_t now_usec = os ? os->get_ticks_usec() : 0;
+		const double total_ms = (emit_begin_usec > 0 && now_usec >= emit_begin_usec)
+				? double(now_usec - emit_begin_usec) / 1000.0
+				: 0.0;
 
 		line = "[StartupTrace]";
 		for (const StringName &phase : *emit_order) {
@@ -166,7 +184,7 @@ void GSStartupTrace::flush(double p_total_ms) {
 			line += "ms";
 		}
 		line += " total=";
-		line += String::num(p_total_ms, 2);
+		line += String::num(total_ms, 2);
 		line += "ms";
 
 		// Only clear the active accumulator after we have actually emitted
@@ -175,6 +193,7 @@ void GSStartupTrace::flush(double p_total_ms) {
 		if (emit_totals == &totals_usec) {
 			totals_usec.clear();
 			insertion_order.clear();
+			active_begin_usec = 0;
 		}
 	}
 

--- a/modules/gaussian_splatting/logger/startup_trace.cpp
+++ b/modules/gaussian_splatting/logger/startup_trace.cpp
@@ -81,18 +81,12 @@ void GSStartupTrace::reset() {
 	active_begin_usec = 0;
 }
 
-bool GSStartupTrace::consume_pending_flush() {
-	// Atomic decrement-if-positive: CAS loop guards against two consumers
-	// racing to drain the same begin_asset_open() event.
-	uint32_t expected = pending_flush_count.load(std::memory_order_acquire);
-	while (expected > 0) {
-		if (pending_flush_count.compare_exchange_weak(expected, expected - 1,
-					std::memory_order_acq_rel, std::memory_order_acquire)) {
-			return true;
-		}
-	}
-	return false;
-}
+// flush() and consume_pending_flush() used to be separate operations, but
+// decrementing pending_flush_count outside the state_mutex creates a window in
+// which a concurrent begin_asset_open() observes count==0 and skips sealing
+// the previous open's accumulator. flush_one_pending() now performs the
+// decrement, snapshot pop, and emission all under the same mutex so begin's
+// seal check is consistent with the live count.
 
 void GSStartupTrace::begin_scope(const StringName & /*p_phase*/) {
 	// Scope start is captured by the RAII object itself; this hook is kept for
@@ -132,12 +126,21 @@ void GSStartupTrace::record_subphase(const char *p_phase, uint64_t p_duration_us
 	record_subphase(StringName(p_phase), p_duration_usec);
 }
 
-void GSStartupTrace::flush() {
+bool GSStartupTrace::flush_one_pending() {
 	String line;
+	bool emitted = false;
+	bool consumed = false;
 	{
 		MutexLock lock(state_mutex);
+		if (pending_flush_count.load(std::memory_order_relaxed) == 0) {
+			return false;
+		}
+
+		// If the trace was disabled between begin_asset_open() and now, drain
+		// the count so it can't leak indefinitely, but don't emit.
 		if (!is_enabled_fast()) {
-			return;
+			pending_flush_count.fetch_sub(1, std::memory_order_acq_rel);
+			return true;
 		}
 
 		// Drain the oldest sealed snapshot first so multiple back-to-back
@@ -158,8 +161,19 @@ void GSStartupTrace::flush() {
 			emit_totals = &totals_usec;
 			emit_order = &insertion_order;
 			emit_begin_usec = active_begin_usec;
-		} else {
-			return;
+		}
+
+		// Decrement under the lock so a concurrent begin_asset_open() either
+		// sees count>0 (and seals the previous accumulator correctly) or
+		// sees the post-emit state where active has already been cleared.
+		pending_flush_count.fetch_sub(1, std::memory_order_acq_rel);
+		consumed = true;
+
+		if (emit_totals == nullptr) {
+			// Pending event with no content to emit (begin_asset_open() fired
+			// before any scope recorded a phase). Decrement the count so the
+			// caller's drain loop can move on; nothing else to do.
+			return true;
 		}
 
 		// total= measures from begin_asset_open() to now so it reflects the
@@ -195,9 +209,13 @@ void GSStartupTrace::flush() {
 			insertion_order.clear();
 			active_begin_usec = 0;
 		}
+		emitted = true;
 	}
 
-	GS_LOG_RENDERER_INFO(line);
+	if (emitted) {
+		GS_LOG_RENDERER_INFO(line);
+	}
+	return consumed;
 }
 
 GSStartupTraceScope::GSStartupTraceScope(const char *p_phase) {

--- a/modules/gaussian_splatting/logger/startup_trace.cpp
+++ b/modules/gaussian_splatting/logger/startup_trace.cpp
@@ -136,11 +136,18 @@ bool GSStartupTrace::flush_one_pending() {
 			return false;
 		}
 
-		// If the trace was disabled between begin_asset_open() and now, drain
-		// the count so it can't leak indefinitely, but don't emit.
+		// If the trace was disabled between begin_asset_open() and now, fully
+		// reset accumulator state so a later re-enable does not merge stale
+		// phases from this disabled window into a new asset-open line.
+		// Zeroing the count here makes the caller's drain loop exit on the
+		// next iteration; subsequent toggles start from a clean slate.
 		if (!is_enabled_fast()) {
-			pending_flush_count.fetch_sub(1, std::memory_order_acq_rel);
-			return true;
+			sealed_traces.clear();
+			totals_usec.clear();
+			insertion_order.clear();
+			active_begin_usec = 0;
+			pending_flush_count.store(0, std::memory_order_release);
+			return false;
 		}
 
 		// Drain the oldest sealed snapshot first so multiple back-to-back

--- a/modules/gaussian_splatting/logger/startup_trace.cpp
+++ b/modules/gaussian_splatting/logger/startup_trace.cpp
@@ -46,25 +46,34 @@ void GSStartupTrace::begin_asset_open() {
 		insertion_order.clear();
 		pending_flush_count.store(0, std::memory_order_relaxed);
 		active_begin_usec = 0;
+		ever_flushed = false;
 		return;
 	}
 
-	// If a prior begin_asset_open() has not yet been drained by the renderer,
-	// seal the active accumulator as that prior open's snapshot before
-	// starting the new one. This keeps each open's timings in its own line
-	// instead of merging multiple opens into one.
-	if (pending_flush_count.load(std::memory_order_relaxed) > 0 && !insertion_order.is_empty()) {
-		GSStartupTraceSnapshot snapshot;
-		snapshot.totals_usec = totals_usec;
-		snapshot.insertion_order = insertion_order;
-		snapshot.begin_usec = active_begin_usec;
-		sealed_traces.push_back(snapshot);
-		totals_usec.clear();
-		insertion_order.clear();
+	if (!insertion_order.is_empty()) {
+		if (pending_flush_count.load(std::memory_order_relaxed) > 0) {
+			// A prior begin_asset_open() has not yet been drained. Seal the
+			// active accumulator as that prior open's snapshot so this new
+			// open starts with a clean slate instead of merging.
+			GSStartupTraceSnapshot snapshot;
+			snapshot.totals_usec = totals_usec;
+			snapshot.insertion_order = insertion_order;
+			snapshot.begin_usec = active_begin_usec;
+			sealed_traces.push_back(snapshot);
+			totals_usec.clear();
+			insertion_order.clear();
+		} else if (ever_flushed) {
+			// count==0 means the prior open already flushed; any phases that
+			// have accumulated since (for example a GS_STARTUP_SCOPE that
+			// fired outside an asset-open boundary) are stale and would
+			// otherwise be attributed to this new open. Drop them.
+			totals_usec.clear();
+			insertion_order.clear();
+		}
+		// else (count==0 && !ever_flushed): first-ever begin with pre-open
+		// module-init phases in active. Preserve so the first
+		// [StartupTrace] line includes them.
 	}
-	// First call (pending_flush_count == 0) preserves any pre-open module-init
-	// phases already recorded in the active accumulator so the first
-	// [StartupTrace] line includes them.
 
 	OS *os = OS::get_singleton();
 	active_begin_usec = os ? os->get_ticks_usec() : 0;
@@ -79,6 +88,7 @@ void GSStartupTrace::reset() {
 	insertion_order.clear();
 	pending_flush_count.store(0, std::memory_order_relaxed);
 	active_begin_usec = 0;
+	ever_flushed = false;
 }
 
 // flush() and consume_pending_flush() used to be separate operations, but
@@ -146,6 +156,7 @@ bool GSStartupTrace::flush_one_pending() {
 			totals_usec.clear();
 			insertion_order.clear();
 			active_begin_usec = 0;
+			ever_flushed = false;
 			pending_flush_count.store(0, std::memory_order_release);
 			return false;
 		}
@@ -217,6 +228,7 @@ bool GSStartupTrace::flush_one_pending() {
 			active_begin_usec = 0;
 		}
 		emitted = true;
+		ever_flushed = true;
 	}
 
 	if (emitted) {

--- a/modules/gaussian_splatting/logger/startup_trace.cpp
+++ b/modules/gaussian_splatting/logger/startup_trace.cpp
@@ -41,34 +41,51 @@ void GSStartupTrace::begin_asset_open() {
 
 	MutexLock lock(state_mutex);
 	if (!is_enabled_fast()) {
+		sealed_traces.clear();
 		totals_usec.clear();
 		insertion_order.clear();
-		flushed = false;
-		pending_flush.store(false, std::memory_order_relaxed);
+		pending_flush_count.store(0, std::memory_order_relaxed);
 		return;
 	}
 
-	// Preserve any pre-open module-init phases recorded for the first asset
-	// open. For subsequent asset opens (or after a flush), clear the
-	// accumulator so each open emits its own trace line.
-	if (flushed || insertion_order.is_empty()) {
+	// If a prior begin_asset_open() has not yet been drained by the renderer,
+	// seal the active accumulator as that prior open's snapshot before
+	// starting the new one. This keeps each open's timings in its own line
+	// instead of merging multiple opens into one.
+	if (pending_flush_count.load(std::memory_order_relaxed) > 0 && !insertion_order.is_empty()) {
+		GSStartupTraceSnapshot snapshot;
+		snapshot.totals_usec = totals_usec;
+		snapshot.insertion_order = insertion_order;
+		sealed_traces.push_back(snapshot);
 		totals_usec.clear();
 		insertion_order.clear();
-		flushed = false;
 	}
-	pending_flush.store(true, std::memory_order_release);
+	// First call (pending_flush_count == 0) preserves any pre-open module-init
+	// phases already recorded in the active accumulator so the first
+	// [StartupTrace] line includes them.
+
+	pending_flush_count.fetch_add(1, std::memory_order_acq_rel);
 }
 
 void GSStartupTrace::reset() {
 	MutexLock lock(state_mutex);
+	sealed_traces.clear();
 	totals_usec.clear();
 	insertion_order.clear();
-	flushed = false;
-	pending_flush.store(false, std::memory_order_relaxed);
+	pending_flush_count.store(0, std::memory_order_relaxed);
 }
 
 bool GSStartupTrace::consume_pending_flush() {
-	return pending_flush.exchange(false, std::memory_order_acq_rel);
+	// Atomic decrement-if-positive: CAS loop guards against two consumers
+	// racing to drain the same begin_asset_open() event.
+	uint32_t expected = pending_flush_count.load(std::memory_order_acquire);
+	while (expected > 0) {
+		if (pending_flush_count.compare_exchange_weak(expected, expected - 1,
+					std::memory_order_acq_rel, std::memory_order_acquire)) {
+			return true;
+		}
+	}
+	return false;
 }
 
 void GSStartupTrace::begin_scope(const StringName & /*p_phase*/) {
@@ -92,9 +109,6 @@ void GSStartupTrace::record_subphase(const StringName &p_phase, uint64_t p_durat
 	}
 
 	MutexLock lock(state_mutex);
-	if (flushed) {
-		return;
-	}
 
 	HashMap<StringName, uint64_t>::Iterator it = totals_usec.find(p_phase);
 	if (it == totals_usec.end()) {
@@ -116,18 +130,33 @@ void GSStartupTrace::flush(double p_total_ms) {
 	String line;
 	{
 		MutexLock lock(state_mutex);
-		if (flushed) {
+		if (!is_enabled_fast()) {
 			return;
 		}
-		flushed = true;
-		if (!is_enabled_fast() || insertion_order.is_empty()) {
+
+		// Drain the oldest sealed snapshot first so multiple back-to-back
+		// asset opens each emit their own line in arrival order. When no
+		// sealed snapshot is queued, emit the active accumulator and clear
+		// it so the next open starts fresh.
+		const HashMap<StringName, uint64_t> *emit_totals = nullptr;
+		const LocalVector<StringName> *emit_order = nullptr;
+		GSStartupTraceSnapshot popped;
+		if (!sealed_traces.is_empty()) {
+			popped = sealed_traces[0];
+			sealed_traces.remove_at(0);
+			emit_totals = &popped.totals_usec;
+			emit_order = &popped.insertion_order;
+		} else if (!insertion_order.is_empty()) {
+			emit_totals = &totals_usec;
+			emit_order = &insertion_order;
+		} else {
 			return;
 		}
 
 		line = "[StartupTrace]";
-		for (const StringName &phase : insertion_order) {
-			HashMap<StringName, uint64_t>::ConstIterator it = totals_usec.find(phase);
-			if (it == totals_usec.end()) {
+		for (const StringName &phase : *emit_order) {
+			HashMap<StringName, uint64_t>::ConstIterator it = emit_totals->find(phase);
+			if (it == emit_totals->end()) {
 				continue;
 			}
 			line += " ";
@@ -139,6 +168,14 @@ void GSStartupTrace::flush(double p_total_ms) {
 		line += " total=";
 		line += String::num(p_total_ms, 2);
 		line += "ms";
+
+		// Only clear the active accumulator after we have actually emitted
+		// from it (snapshots own their copy). This keeps active empty for
+		// the next open's phases.
+		if (emit_totals == &totals_usec) {
+			totals_usec.clear();
+			insertion_order.clear();
+		}
 	}
 
 	GS_LOG_RENDERER_INFO(line);

--- a/modules/gaussian_splatting/logger/startup_trace.cpp
+++ b/modules/gaussian_splatting/logger/startup_trace.cpp
@@ -1,0 +1,169 @@
+#include "startup_trace.h"
+
+#include "../core/gs_project_settings.h"
+#include "gs_logger.h"
+
+#include "core/config/project_settings.h"
+#include "core/os/mutex.h"
+#include "core/os/os.h"
+#include "core/string/ustring.h"
+
+namespace {
+static constexpr int STARTUP_TRACE_RESERVE = 32;
+static constexpr const char *STARTUP_TRACE_SETTING_PATH =
+		"rendering/gaussian_splatting/diagnostics/startup_trace";
+} // namespace
+
+std::atomic<bool> GSStartupTrace::enabled{ false };
+
+GSStartupTrace *GSStartupTrace::get_singleton() {
+	static GSStartupTrace instance;
+	return &instance;
+}
+
+GSStartupTrace::GSStartupTrace() {
+	totals_usec.reserve(STARTUP_TRACE_RESERVE);
+	insertion_order.reserve(STARTUP_TRACE_RESERVE);
+}
+
+bool GSStartupTrace::is_enabled_fast() {
+	return enabled.load(std::memory_order_relaxed);
+}
+
+void GSStartupTrace::refresh_enabled() {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	const bool value = gs::settings::get_bool(ps, StringName(STARTUP_TRACE_SETTING_PATH), true);
+	enabled.store(value, std::memory_order_relaxed);
+}
+
+void GSStartupTrace::begin_asset_open() {
+	refresh_enabled();
+
+	MutexLock lock(state_mutex);
+	if (!is_enabled_fast()) {
+		totals_usec.clear();
+		insertion_order.clear();
+		flushed = false;
+		return;
+	}
+
+	if (!flushed && !insertion_order.is_empty()) {
+		return;
+	}
+
+	totals_usec.clear();
+	insertion_order.clear();
+	flushed = false;
+}
+
+void GSStartupTrace::reset() {
+	MutexLock lock(state_mutex);
+	totals_usec.clear();
+	insertion_order.clear();
+	flushed = false;
+}
+
+void GSStartupTrace::begin_scope(const StringName & /*p_phase*/) {
+	// Scope start is captured by the RAII object itself; this hook is kept for
+	// symmetry and future per-scope bookkeeping.
+}
+
+void GSStartupTrace::end_scope(const StringName &p_phase, uint64_t p_start_usec) {
+	OS *os = OS::get_singleton();
+	if (!os) {
+		return;
+	}
+	const uint64_t now = os->get_ticks_usec();
+	const uint64_t duration = now >= p_start_usec ? now - p_start_usec : 0;
+	record_subphase(p_phase, duration);
+}
+
+void GSStartupTrace::record_subphase(const StringName &p_phase, uint64_t p_duration_usec) {
+	if (!is_enabled_fast()) {
+		return;
+	}
+
+	MutexLock lock(state_mutex);
+	if (flushed) {
+		return;
+	}
+
+	HashMap<StringName, uint64_t>::Iterator it = totals_usec.find(p_phase);
+	if (it == totals_usec.end()) {
+		totals_usec.insert(p_phase, p_duration_usec);
+		insertion_order.push_back(p_phase);
+	} else {
+		it->value += p_duration_usec;
+	}
+}
+
+void GSStartupTrace::record_subphase(const char *p_phase, uint64_t p_duration_usec) {
+	if (!p_phase || !is_enabled_fast()) {
+		return;
+	}
+	record_subphase(StringName(p_phase), p_duration_usec);
+}
+
+void GSStartupTrace::flush(double p_total_ms) {
+	String line;
+	{
+		MutexLock lock(state_mutex);
+		if (flushed) {
+			return;
+		}
+		flushed = true;
+		if (!is_enabled_fast() || insertion_order.is_empty()) {
+			return;
+		}
+
+		line = "[StartupTrace]";
+		for (const StringName &phase : insertion_order) {
+			HashMap<StringName, uint64_t>::ConstIterator it = totals_usec.find(phase);
+			if (it == totals_usec.end()) {
+				continue;
+			}
+			line += " ";
+			line += String(phase);
+			line += "=";
+			line += String::num(double(it->value) / 1000.0, 2);
+			line += "ms";
+		}
+		line += " total=";
+		line += String::num(p_total_ms, 2);
+		line += "ms";
+	}
+
+	GS_LOG_RENDERER_INFO(line);
+}
+
+GSStartupTraceScope::GSStartupTraceScope(const char *p_phase) {
+	if (!p_phase || !GSStartupTrace::is_enabled_fast()) {
+		return;
+	}
+
+	GSStartupTrace *trace = GSStartupTrace::get_singleton();
+	if (!trace) {
+		return;
+	}
+
+	OS *os = OS::get_singleton();
+	if (!os) {
+		return;
+	}
+
+	phase = StringName(p_phase);
+	start_usec = os->get_ticks_usec();
+	active = true;
+	trace->begin_scope(phase);
+}
+
+GSStartupTraceScope::~GSStartupTraceScope() {
+	if (!active) {
+		return;
+	}
+	GSStartupTrace *trace = GSStartupTrace::get_singleton();
+	if (!trace) {
+		return;
+	}
+	trace->end_scope(phase, start_usec);
+}

--- a/modules/gaussian_splatting/logger/startup_trace.cpp
+++ b/modules/gaussian_splatting/logger/startup_trace.cpp
@@ -44,16 +44,19 @@ void GSStartupTrace::begin_asset_open() {
 		totals_usec.clear();
 		insertion_order.clear();
 		flushed = false;
+		pending_flush.store(false, std::memory_order_relaxed);
 		return;
 	}
 
-	if (!flushed && !insertion_order.is_empty()) {
-		return;
+	// Preserve any pre-open module-init phases recorded for the first asset
+	// open. For subsequent asset opens (or after a flush), clear the
+	// accumulator so each open emits its own trace line.
+	if (flushed || insertion_order.is_empty()) {
+		totals_usec.clear();
+		insertion_order.clear();
+		flushed = false;
 	}
-
-	totals_usec.clear();
-	insertion_order.clear();
-	flushed = false;
+	pending_flush.store(true, std::memory_order_release);
 }
 
 void GSStartupTrace::reset() {
@@ -61,6 +64,11 @@ void GSStartupTrace::reset() {
 	totals_usec.clear();
 	insertion_order.clear();
 	flushed = false;
+	pending_flush.store(false, std::memory_order_relaxed);
+}
+
+bool GSStartupTrace::consume_pending_flush() {
+	return pending_flush.exchange(false, std::memory_order_acq_rel);
 }
 
 void GSStartupTrace::begin_scope(const StringName & /*p_phase*/) {

--- a/modules/gaussian_splatting/logger/startup_trace.h
+++ b/modules/gaussian_splatting/logger/startup_trace.h
@@ -47,16 +47,15 @@ public:
 	void record_subphase(const StringName &p_phase, uint64_t p_duration_usec);
 	void record_subphase(const char *p_phase, uint64_t p_duration_usec);
 
-	// Emits one [StartupTrace] line for the oldest pending open (or the
-	// active accumulator if no opens are sealed). total= is the elapsed time
-	// from that open's begin_asset_open() to now, not the frame-entry slice
-	// the caller is currently inside.
-	void flush();
-
-	// Atomically decrements the pending-flush counter if positive. Returns true
-	// exactly once per begin_asset_open() call so multiple opens that happen
-	// before the renderer drains them each get their own [StartupTrace] line.
-	bool consume_pending_flush();
+	// Drains one pending begin_asset_open() event: decrement pending count,
+	// pop the oldest sealed snapshot (or take the active accumulator), and
+	// emit one [StartupTrace] line. Returns true if a pending event was
+	// consumed (caller should keep looping to drain all pending). The
+	// decrement and emission happen under the same lock as begin_asset_open()
+	// so a concurrent begin cannot observe a count==0 window and skip
+	// sealing the previous open's accumulator. total= is computed from the
+	// drained snapshot's own begin_asset_open() timestamp.
+	bool flush_one_pending();
 
 private:
 	GSStartupTrace();

--- a/modules/gaussian_splatting/logger/startup_trace.h
+++ b/modules/gaussian_splatting/logger/startup_trace.h
@@ -74,6 +74,11 @@ private:
 	HashMap<StringName, uint64_t> totals_usec;
 	LocalVector<StringName> insertion_order;
 	uint64_t active_begin_usec = 0;
+	// True once any flush has emitted. Used by begin_asset_open() to decide
+	// whether non-empty active represents the special first-open case
+	// (preserve pre-module-init phases) or stale phases recorded outside
+	// any in-flight open (drop them so they do not leak into the next line).
+	bool ever_flushed = false;
 };
 
 class GSStartupTraceScope {

--- a/modules/gaussian_splatting/logger/startup_trace.h
+++ b/modules/gaussian_splatting/logger/startup_trace.h
@@ -24,7 +24,8 @@ public:
 
 	// Starts a new asset-open trace after the previous one has flushed. If the
 	// module has already recorded pre-open startup phases for the first asset,
-	// they are preserved until that first flush.
+	// they are preserved until that first flush. Arms a pending flush so the
+	// next rendered frame emits the accumulated [StartupTrace] line.
 	void begin_asset_open();
 
 	void reset();
@@ -37,6 +38,11 @@ public:
 
 	void flush(double p_total_ms);
 
+	// Atomically consumes the pending-flush flag set by begin_asset_open().
+	// Returns true exactly once per begin_asset_open() call so the renderer can
+	// emit one [StartupTrace] line on the first frame after each asset open.
+	bool consume_pending_flush();
+
 private:
 	GSStartupTrace();
 
@@ -44,6 +50,7 @@ private:
 
 	mutable Mutex state_mutex;
 	bool flushed = false;
+	std::atomic<bool> pending_flush{ false };
 	HashMap<StringName, uint64_t> totals_usec;
 	LocalVector<StringName> insertion_order;
 };

--- a/modules/gaussian_splatting/logger/startup_trace.h
+++ b/modules/gaussian_splatting/logger/startup_trace.h
@@ -90,9 +90,14 @@ private:
 
 #define GS_STARTUP_SCOPE_CONCAT_INNER(a, b) a##b
 #define GS_STARTUP_SCOPE_CONCAT(a, b) GS_STARTUP_SCOPE_CONCAT_INNER(a, b)
+// The macro always constructs a GSStartupTraceScope so the RAII timer lives
+// for the enclosing block, not just the macro line. When the trace is
+// disabled, nullptr is passed and the constructor short-circuits cheaply.
+// The previous `if (...) {} else GSStartupTraceScope X(name)` form put the
+// variable inside the else branch, so its destructor fired immediately after
+// the macro statement and the scope measured nothing.
 #define GS_STARTUP_SCOPE(name) \
-	if (!GSStartupTrace::is_enabled_fast()) { \
-	} else \
-		GSStartupTraceScope GS_STARTUP_SCOPE_CONCAT(_gs_startup_scope_, __LINE__)(name)
+	GSStartupTraceScope GS_STARTUP_SCOPE_CONCAT(_gs_startup_scope_, __LINE__)( \
+			GSStartupTrace::is_enabled_fast() ? (name) : nullptr)
 
 #endif // GS_STARTUP_TRACE_H

--- a/modules/gaussian_splatting/logger/startup_trace.h
+++ b/modules/gaussian_splatting/logger/startup_trace.h
@@ -11,9 +11,13 @@
 
 // Per-asset-open snapshot of accumulated phases, sealed when a subsequent
 // begin_asset_open() arrives before the renderer has consumed the prior open.
+// begin_usec captures the OS::get_ticks_usec() value at begin_asset_open()
+// time so flush() can report end-to-end duration from open boundary to first
+// rendered frame, not just frame-entry time.
 struct GSStartupTraceSnapshot {
 	HashMap<StringName, uint64_t> totals_usec;
 	LocalVector<StringName> insertion_order;
+	uint64_t begin_usec = 0;
 };
 
 // Startup-time instrumentation that carries module-init phases into the first
@@ -43,7 +47,11 @@ public:
 	void record_subphase(const StringName &p_phase, uint64_t p_duration_usec);
 	void record_subphase(const char *p_phase, uint64_t p_duration_usec);
 
-	void flush(double p_total_ms);
+	// Emits one [StartupTrace] line for the oldest pending open (or the
+	// active accumulator if no opens are sealed). total= is the elapsed time
+	// from that open's begin_asset_open() to now, not the frame-entry slice
+	// the caller is currently inside.
+	void flush();
 
 	// Atomically decrements the pending-flush counter if positive. Returns true
 	// exactly once per begin_asset_open() call so multiple opens that happen
@@ -66,6 +74,7 @@ private:
 	// phases when no asset open has happened yet).
 	HashMap<StringName, uint64_t> totals_usec;
 	LocalVector<StringName> insertion_order;
+	uint64_t active_begin_usec = 0;
 };
 
 class GSStartupTraceScope {

--- a/modules/gaussian_splatting/logger/startup_trace.h
+++ b/modules/gaussian_splatting/logger/startup_trace.h
@@ -1,0 +1,69 @@
+#ifndef GS_STARTUP_TRACE_H
+#define GS_STARTUP_TRACE_H
+
+#include "core/os/mutex.h"
+#include "core/string/string_name.h"
+#include "core/templates/hash_map.h"
+#include "core/templates/local_vector.h"
+
+#include <atomic>
+#include <cstdint>
+
+// Startup-time instrumentation that carries module-init phases into the first
+// asset-open, then resets on later asset-open begins after a flush.
+class GSStartupTrace {
+public:
+	static GSStartupTrace *get_singleton();
+
+	static bool is_enabled_fast();
+
+	// Project-setting gate. Refreshed explicitly during module init and at
+	// asset-open boundaries so the macro can stay cheap.
+	bool is_enabled() const { return is_enabled_fast(); }
+	void refresh_enabled();
+
+	// Starts a new asset-open trace after the previous one has flushed. If the
+	// module has already recorded pre-open startup phases for the first asset,
+	// they are preserved until that first flush.
+	void begin_asset_open();
+
+	void reset();
+
+	void begin_scope(const StringName &p_phase);
+	void end_scope(const StringName &p_phase, uint64_t p_start_usec);
+
+	void record_subphase(const StringName &p_phase, uint64_t p_duration_usec);
+	void record_subphase(const char *p_phase, uint64_t p_duration_usec);
+
+	void flush(double p_total_ms);
+
+private:
+	GSStartupTrace();
+
+	static std::atomic<bool> enabled;
+
+	mutable Mutex state_mutex;
+	bool flushed = false;
+	HashMap<StringName, uint64_t> totals_usec;
+	LocalVector<StringName> insertion_order;
+};
+
+class GSStartupTraceScope {
+public:
+	GSStartupTraceScope(const char *p_phase);
+	~GSStartupTraceScope();
+
+private:
+	StringName phase;
+	uint64_t start_usec = 0;
+	bool active = false;
+};
+
+#define GS_STARTUP_SCOPE_CONCAT_INNER(a, b) a##b
+#define GS_STARTUP_SCOPE_CONCAT(a, b) GS_STARTUP_SCOPE_CONCAT_INNER(a, b)
+#define GS_STARTUP_SCOPE(name) \
+	if (!GSStartupTrace::is_enabled_fast()) { \
+	} else \
+		GSStartupTraceScope GS_STARTUP_SCOPE_CONCAT(_gs_startup_scope_, __LINE__)(name)
+
+#endif // GS_STARTUP_TRACE_H

--- a/modules/gaussian_splatting/logger/startup_trace.h
+++ b/modules/gaussian_splatting/logger/startup_trace.h
@@ -9,6 +9,13 @@
 #include <atomic>
 #include <cstdint>
 
+// Per-asset-open snapshot of accumulated phases, sealed when a subsequent
+// begin_asset_open() arrives before the renderer has consumed the prior open.
+struct GSStartupTraceSnapshot {
+	HashMap<StringName, uint64_t> totals_usec;
+	LocalVector<StringName> insertion_order;
+};
+
 // Startup-time instrumentation that carries module-init phases into the first
 // asset-open, then resets on later asset-open begins after a flush.
 class GSStartupTrace {
@@ -38,9 +45,9 @@ public:
 
 	void flush(double p_total_ms);
 
-	// Atomically consumes the pending-flush flag set by begin_asset_open().
-	// Returns true exactly once per begin_asset_open() call so the renderer can
-	// emit one [StartupTrace] line on the first frame after each asset open.
+	// Atomically decrements the pending-flush counter if positive. Returns true
+	// exactly once per begin_asset_open() call so multiple opens that happen
+	// before the renderer drains them each get their own [StartupTrace] line.
 	bool consume_pending_flush();
 
 private:
@@ -49,8 +56,14 @@ private:
 	static std::atomic<bool> enabled;
 
 	mutable Mutex state_mutex;
-	bool flushed = false;
-	std::atomic<bool> pending_flush{ false };
+	// Counts begin_asset_open() calls that have not yet been flushed. A
+	// boolean here would collapse multiple back-to-back opens into one line.
+	std::atomic<uint32_t> pending_flush_count{ 0 };
+	// Sealed snapshots of prior asset-opens that arrived before the renderer
+	// drained them. Oldest-first; flush() pops index 0.
+	LocalVector<GSStartupTraceSnapshot> sealed_traces;
+	// Active accumulator for the currently-open asset (or pre-open module-init
+	// phases when no asset open has happened yet).
 	HashMap<StringName, uint64_t> totals_usec;
 	LocalVector<StringName> insertion_order;
 };

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -1721,6 +1721,13 @@ void GaussianSplatNode3D::_load_asset() {
 
     asset_loading = true;
 
+    // Arm the startup trace once at the function entry so both code paths
+    // (ResourceLoader::load -> ResourceFormatLoaderGaussianSplat::load ->
+    // asset->load_from_file, AND the direct asset->load_from_file fallback)
+    // are covered. Arming inside only the fallback would miss the common
+    // successful ResourceLoader path.
+    GSStartupTrace::get_singleton()->begin_asset_open();
+
     Ref<GaussianSplatAsset> reloaded_asset;
     String load_error_message;
 
@@ -1754,7 +1761,6 @@ void GaussianSplatNode3D::_load_asset() {
 
     if (reloaded_asset.is_null() && !asset_source_path.is_empty()) {
         reloaded_asset.instantiate();
-        GSStartupTrace::get_singleton()->begin_asset_open();
         const Error load_error = reloaded_asset->load_from_file(asset_source_path);
         if (load_error != OK || reloaded_asset->get_splat_count() == 0) {
             load_error_message = vformat("Failed to reload GaussianSplatAsset source: %s (Error %d)",
@@ -2621,10 +2627,14 @@ void GaussianSplatNode3D::_drop_data_fw(const Point2 &p_point, const Variant &p_
         const String file_lower = files[0].to_lower();
         if (file_lower.ends_with(".ply") || file_lower.ends_with(".spz")) {
             const String file_path = files[0];
+            // Arm the trace before ResourceLoader::load so the common
+            // successful path (which routes through
+            // ResourceFormatLoaderGaussianSplat::load and ultimately calls
+            // asset->load_from_file) is covered alongside the fallback.
+            GSStartupTrace::get_singleton()->begin_asset_open();
             Ref<GaussianSplatAsset> dropped_asset = ResourceLoader::load(file_path, "GaussianSplatAsset");
             if (dropped_asset.is_null()) {
                 dropped_asset.instantiate();
-                GSStartupTrace::get_singleton()->begin_asset_open();
                 if (dropped_asset->load_from_file(file_path) != OK) {
                     ERR_PRINT(vformat("Failed to load dropped Gaussian splat asset: %s", file_path));
                     return;

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -32,6 +32,7 @@
 #include <cstdint>
 
 #include "../logger/gs_logger.h"
+#include "../logger/startup_trace.h"
 
 // Project settings helpers provided by gs_project_settings.h (gs::settings namespace).
 namespace {
@@ -564,6 +565,7 @@ bool GaussianSplatNode3D::_set(const StringName &p_name, const Variant &p_value)
                 path));
         Ref<GaussianSplatAsset> migrated_asset;
         migrated_asset.instantiate();
+        GSStartupTrace::get_singleton()->begin_asset_open();
         const Error err = migrated_asset->load_from_file(path);
         if (err != OK || migrated_asset->get_splat_count() == 0) {
             ERR_PRINT(vformat(
@@ -1752,6 +1754,7 @@ void GaussianSplatNode3D::_load_asset() {
 
     if (reloaded_asset.is_null() && !asset_source_path.is_empty()) {
         reloaded_asset.instantiate();
+        GSStartupTrace::get_singleton()->begin_asset_open();
         const Error load_error = reloaded_asset->load_from_file(asset_source_path);
         if (load_error != OK || reloaded_asset->get_splat_count() == 0) {
             load_error_message = vformat("Failed to reload GaussianSplatAsset source: %s (Error %d)",
@@ -2621,6 +2624,7 @@ void GaussianSplatNode3D::_drop_data_fw(const Point2 &p_point, const Variant &p_
             Ref<GaussianSplatAsset> dropped_asset = ResourceLoader::load(file_path, "GaussianSplatAsset");
             if (dropped_asset.is_null()) {
                 dropped_asset.instantiate();
+                GSStartupTrace::get_singleton()->begin_asset_open();
                 if (dropped_asset->load_from_file(file_path) != OK) {
                     ERR_PRINT(vformat("Failed to load dropped Gaussian splat asset: %s", file_path));
                     return;

--- a/modules/gaussian_splatting/register_types.cpp
+++ b/modules/gaussian_splatting/register_types.cpp
@@ -1,5 +1,8 @@
 #include "register_types.h"
 
+#include "core/config/project_settings.h"
+#include "logger/startup_trace.h"
+
 #include "core/gaussian_data.h"
 #include "core/gaussian_splat_asset.h"
 #include "core/gaussian_splat_world.h"
@@ -63,6 +66,14 @@ static Ref<ResourceImporterGSplatWorld> gsplatworld_importer;
 #endif
 
 void initialize_gaussian_splatting_module(ModuleInitializationLevel p_level) {
+    // Register diagnostics setting before any GS code reads it; the trace
+    // singleton refreshes its cached enable flag after registration.
+    if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+        GLOBAL_DEF("rendering/gaussian_splatting/diagnostics/startup_trace", true);
+        GSStartupTrace::get_singleton()->refresh_enabled();
+        GSStartupTrace::get_singleton()->reset();
+    }
+    GS_STARTUP_SCOPE("module_register");
     switch (p_level) {
         case MODULE_INITIALIZATION_LEVEL_SCENE: {
             // Initialize configuration systems ahead of renderer setup.

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
@@ -19,6 +19,7 @@
 #include "pipeline_io_contracts.h"
 #include "resident_instance_contract_publisher.h"
 #include "../logger/gs_debug_trace.h"
+#include "../logger/startup_trace.h"
 #include "core/object/callable_method_pointer.h"
 
 using GaussianSplatting::ScopedGpuMarker;
@@ -794,6 +795,7 @@ void GaussianSplatRenderer::_notify_render_thread_dispatch_completed(uint64_t p_
 }
 
 GaussianSplatRenderer::GaussianSplatRenderer(RenderingDevice *p_device) {
+    GS_STARTUP_SCOPE("renderer_construct");
     // State buckets: frame_context_manager (view + frame metrics), device state (orchestrator-owned),
     // resource orchestrator state, streaming state (data orchestrator), debug_state_orchestrator, diagnostics_orchestrator.
     RenderingDevice *device = p_device;

--- a/modules/gaussian_splatting/renderer/gpu_sorter.cpp
+++ b/modules/gaussian_splatting/renderer/gpu_sorter.cpp
@@ -68,6 +68,7 @@
 
 #include "../core/gaussian_splat_manager.h"
 #include "../logger/gs_logger.h"
+#include "../logger/startup_trace.h"
 #include "../interfaces/sync_policy.h"
 
 using GaussianSplatting::PassColors;
@@ -1474,6 +1475,7 @@ uint64_t RadixSort::_sort_async_internal(RID keys_buffer, RID values_buffer, uin
 }
 
 Error RadixSort::create_variant(RenderingDevice *device, uint32_t radix_bits) {
+    GS_STARTUP_SCOPE("sorter_create_variant");
     if (!device) {
         return ERR_CANT_CREATE;
     }

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -826,14 +826,15 @@ void RenderPipelineStages::execute_frame_entry(const RenderFrameContext &p_frame
 	// drained snapshot computes its own total= from its own begin_asset_open()
 	// timestamp, so deferring a snapshot to a later frame would inflate that
 	// open's total= relative to the time the user actually waited.
+	// flush_one_pending() performs the decrement and emission atomically so
+	// a concurrent begin_asset_open() cannot race the consume window.
 	struct StartupTraceFlushGuard {
 		~StartupTraceFlushGuard() {
 			GSStartupTrace *trace = GSStartupTrace::get_singleton();
 			if (!trace) {
 				return;
 			}
-			while (trace->consume_pending_flush()) {
-				trace->flush();
+			while (trace->flush_one_pending()) {
 			}
 		}
 	} startup_trace_flush_guard;

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -823,10 +823,14 @@ void RenderPipelineStages::execute_frame_entry(const RenderFrameContext &p_frame
 	const bool startup_trace_enabled = GSStartupTrace::is_enabled_fast();
 	const uint64_t startup_trace_frame_start_usec =
 			startup_trace_enabled && OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : 0;
-	const bool startup_trace_is_first_frame =
+	// Consume the per-asset-open pending-flush flag set by
+	// GSStartupTrace::begin_asset_open(). This decouples the flush from
+	// frame_counter==0 so each asset open (not only the very first) emits one
+	// [StartupTrace] line on its first rendered frame.
+	const bool startup_trace_should_flush =
 			startup_trace_enabled &&
-			p_frame_context.deps.frame_state &&
-			p_frame_context.deps.frame_state->frame_counter == 0;
+			GSStartupTrace::get_singleton() &&
+			GSStartupTrace::get_singleton()->consume_pending_flush();
 	struct StartupTraceFlushGuard {
 		bool active;
 		uint64_t start_usec;
@@ -841,7 +845,7 @@ void RenderPipelineStages::execute_frame_entry(const RenderFrameContext &p_frame
 			const uint64_t now = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : start_usec;
 			trace->flush(double(now - start_usec) / 1000.0);
 		}
-	} startup_trace_flush_guard{startup_trace_is_first_frame, startup_trace_frame_start_usec};
+	} startup_trace_flush_guard{startup_trace_should_flush, startup_trace_frame_start_usec};
 
 	// Copy frame context first, then build frame_plan and update deps.
 	// The provider must be constructed AFTER this so it sees the updated deps.

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -24,6 +24,7 @@
 #include "../interfaces/painterly_renderer.h"
 #include "../logger/gs_debug_trace.h"
 #include "../logger/gs_logger.h"
+#include "../logger/startup_trace.h"
 #include "../resources/color_grading_resource.h"
 #include "../core/gaussian_splat_scene_director.h"
 #include "gpu_sorting_config.h"
@@ -818,6 +819,29 @@ void RenderPipelineStages::execute_frame_entry(const RenderFrameContext &p_frame
 		bool p_set_skip_metrics, bool p_clear_cull_state_on_skip) {
 	ERR_FAIL_NULL(renderer);
 	ERR_FAIL_COND(!p_frame_context.deps.validate());
+
+	const bool startup_trace_enabled = GSStartupTrace::is_enabled_fast();
+	const uint64_t startup_trace_frame_start_usec =
+			startup_trace_enabled && OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : 0;
+	const bool startup_trace_is_first_frame =
+			startup_trace_enabled &&
+			p_frame_context.deps.frame_state &&
+			p_frame_context.deps.frame_state->frame_counter == 0;
+	struct StartupTraceFlushGuard {
+		bool active;
+		uint64_t start_usec;
+		~StartupTraceFlushGuard() {
+			if (!active) {
+				return;
+			}
+			GSStartupTrace *trace = GSStartupTrace::get_singleton();
+			if (!trace) {
+				return;
+			}
+			const uint64_t now = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : start_usec;
+			trace->flush(double(now - start_usec) / 1000.0);
+		}
+	} startup_trace_flush_guard{startup_trace_is_first_frame, startup_trace_frame_start_usec};
 
 	// Copy frame context first, then build frame_plan and update deps.
 	// The provider must be constructed AFTER this so it sees the updated deps.

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -820,20 +820,18 @@ void RenderPipelineStages::execute_frame_entry(const RenderFrameContext &p_frame
 	ERR_FAIL_NULL(renderer);
 	ERR_FAIL_COND(!p_frame_context.deps.validate());
 
-	const bool startup_trace_enabled = GSStartupTrace::is_enabled_fast();
-	const uint64_t startup_trace_frame_start_usec =
-			startup_trace_enabled && OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : 0;
-	// Consume the per-asset-open pending-flush flag set by
+	// Consume the per-asset-open pending-flush counter set by
 	// GSStartupTrace::begin_asset_open(). This decouples the flush from
 	// frame_counter==0 so each asset open (not only the very first) emits one
-	// [StartupTrace] line on its first rendered frame.
+	// [StartupTrace] line on its first rendered frame. flush() reads the
+	// open's begin timestamp itself, so total= measures from
+	// begin_asset_open() to here, not from the start of this function.
 	const bool startup_trace_should_flush =
-			startup_trace_enabled &&
+			GSStartupTrace::is_enabled_fast() &&
 			GSStartupTrace::get_singleton() &&
 			GSStartupTrace::get_singleton()->consume_pending_flush();
 	struct StartupTraceFlushGuard {
 		bool active;
-		uint64_t start_usec;
 		~StartupTraceFlushGuard() {
 			if (!active) {
 				return;
@@ -842,10 +840,9 @@ void RenderPipelineStages::execute_frame_entry(const RenderFrameContext &p_frame
 			if (!trace) {
 				return;
 			}
-			const uint64_t now = OS::get_singleton() ? OS::get_singleton()->get_ticks_usec() : start_usec;
-			trace->flush(double(now - start_usec) / 1000.0);
+			trace->flush();
 		}
-	} startup_trace_flush_guard{startup_trace_should_flush, startup_trace_frame_start_usec};
+	} startup_trace_flush_guard{startup_trace_should_flush};
 
 	// Copy frame context first, then build frame_plan and update deps.
 	// The provider must be constructed AFTER this so it sees the updated deps.

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -820,29 +820,23 @@ void RenderPipelineStages::execute_frame_entry(const RenderFrameContext &p_frame
 	ERR_FAIL_NULL(renderer);
 	ERR_FAIL_COND(!p_frame_context.deps.validate());
 
-	// Consume the per-asset-open pending-flush counter set by
-	// GSStartupTrace::begin_asset_open(). This decouples the flush from
-	// frame_counter==0 so each asset open (not only the very first) emits one
-	// [StartupTrace] line on its first rendered frame. flush() reads the
-	// open's begin timestamp itself, so total= measures from
-	// begin_asset_open() to here, not from the start of this function.
-	const bool startup_trace_should_flush =
-			GSStartupTrace::is_enabled_fast() &&
-			GSStartupTrace::get_singleton() &&
-			GSStartupTrace::get_singleton()->consume_pending_flush();
+	// Drain every pending begin_asset_open() that arrived before this frame so
+	// multi-asset scene loads emit their full set of [StartupTrace] lines on
+	// the first rendered frame instead of trickling out one per frame. Each
+	// drained snapshot computes its own total= from its own begin_asset_open()
+	// timestamp, so deferring a snapshot to a later frame would inflate that
+	// open's total= relative to the time the user actually waited.
 	struct StartupTraceFlushGuard {
-		bool active;
 		~StartupTraceFlushGuard() {
-			if (!active) {
-				return;
-			}
 			GSStartupTrace *trace = GSStartupTrace::get_singleton();
 			if (!trace) {
 				return;
 			}
-			trace->flush();
+			while (trace->consume_pending_flush()) {
+				trace->flush();
+			}
 		}
-	} startup_trace_flush_guard{startup_trace_should_flush};
+	} startup_trace_flush_guard;
 
 	// Copy frame context first, then build frame_plan and update deps.
 	// The provider must be constructed AFTER this so it sees the updated deps.

--- a/modules/gaussian_splatting/renderer/render_resource_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_resource_orchestrator.cpp
@@ -8,6 +8,7 @@
 #include "gpu_sorting_config.h"
 #include "../interfaces/interactive_state_manager.h"
 #include "../logger/gs_logger.h"
+#include "../logger/startup_trace.h"
 #include "../shaders/gaussian_splat.glsl.gen.h"
 #include <cstring>
 
@@ -161,6 +162,7 @@ void RenderResourceOrchestrator::create_gpu_resources_safe() {
 
 	// Initialize GPU buffer manager
 	if (resource_state.buffer_manager.is_valid() && (!resource_state.buffer_manager_initialized || needs_buffer_resize)) {
+		GS_STARTUP_SCOPE("gpu_buffer_manager_init");
 		int max_splats_for_buffer = local_performance_settings.max_splats;
 		Error err = resource_state.buffer_manager->initialize(
 				device_state->rd, max_splats_for_buffer);

--- a/modules/gaussian_splatting/renderer/shader_compilation_helper.cpp
+++ b/modules/gaussian_splatting/renderer/shader_compilation_helper.cpp
@@ -3,6 +3,7 @@
 #include "core/error/error_macros.h"
 #include "core/string/string_builder.h"
 #include "../logger/gs_logger.h"
+#include "../logger/startup_trace.h"
 #include "quantization_config.h"
 #include "tile_prefix_scan_utils.h"
 #include "tile_renderer.h"
@@ -342,6 +343,7 @@ Error ShaderCompilationManager::compile_all_shaders(RenderingDevice *p_device_hi
 }
 
 Error ShaderCompilationManager::compile_binning_shaders(RenderingDevice *p_device) {
+	GS_STARTUP_SCOPE("shader_compile_binning");
 	const int variant_index = TileShaderCompilation::DEFAULT_VARIANT_INDEX;
 	ERR_FAIL_NULL_V(owner.shader_resources.tile_binning_shader_source.get(), ERR_UNCONFIGURED);
 
@@ -380,6 +382,7 @@ Error ShaderCompilationManager::compile_binning_shaders(RenderingDevice *p_devic
 }
 
 Error ShaderCompilationManager::compile_prefix_shaders(RenderingDevice *p_device) {
+	GS_STARTUP_SCOPE("shader_compile_prefix");
 	const int variant_index = TileShaderCompilation::DEFAULT_VARIANT_INDEX;
 	ERR_FAIL_NULL_V(owner.shader_resources.tile_prefix_shader_source.get(), ERR_UNCONFIGURED);
 
@@ -432,6 +435,7 @@ Error ShaderCompilationManager::compile_prefix_shaders(RenderingDevice *p_device
 }
 
 Error ShaderCompilationManager::compile_raster_shaders(RenderingDevice *p_device, bool p_want_compute_raster) {
+	GS_STARTUP_SCOPE("shader_compile_raster");
 	const int variant_index = TileShaderCompilation::DEFAULT_VARIANT_INDEX;
 	ERR_FAIL_NULL_V(owner.shader_resources.tile_raster_shader_source.get(), ERR_UNCONFIGURED);
 	ERR_FAIL_NULL_V(owner.shader_resources.tile_raster_compute_shader_source.get(), ERR_UNCONFIGURED);

--- a/modules/gaussian_splatting/renderer/tile_render_rasterizer_stage.cpp
+++ b/modules/gaussian_splatting/renderer/tile_render_rasterizer_stage.cpp
@@ -32,6 +32,7 @@
 #include "quantization_config.h"
 #include "resource_owner_mismatch_contract.h"
 #include "../logger/gs_logger.h"
+#include "../logger/startup_trace.h"
 #include "gaussian_gpu_layout.h"
 #include "pipeline_io_contracts.h"
 #include "shader_compilation_helper.h"
@@ -154,6 +155,7 @@ uint64_t TileRenderer::TileRasterizerStage::dispatch_tile_rasterizer(uint32_t p_
     }
 
     if (!owner.shader_resources.tile_raster_pipeline.is_valid()) {
+        GS_STARTUP_SCOPE("first_frame_raster_pipeline_create");
         RD::PipelineRasterizationState raster_state;
         raster_state.cull_mode = RD::POLYGON_CULL_DISABLED;
         RD::PipelineMultisampleState ms_state;


### PR DESCRIPTION
## Summary
- Adds `GSStartupTrace` RAII scope timer instrumenting ~16 init-path call sites across registration, manager construction, GPU resource creation, shader compile, sorter variant build, streaming buffer alloc, atlas sync, PLY/SPZ payload parse, and first-frame raster pipeline create.
- Emits one `[StartupTrace]` line per asset-open on the first rendered frame, broken down by phase.
- Disabled-path zero-overhead via static atomic short-circuit. Gated by `rendering/gaussian_splatting/diagnostics/startup_trace` (default `true`).
- Phase 0 of the startup-time fix plan — measurement only, no behavior change. Required baseline for Phases 1, 3, 4 to be evaluated against.

## Why
Cold-launch is 30–60s for small scenes. Until per-phase timings exist, every optimization is a guess. This PR makes startup observable so subsequent phases can demonstrate concrete wins.

## Code review
Reviewed by Codex (gpt-5.4) — flagged and fixed:
- HIGH: mutex on accumulator state (thread safety across rendering + worker threads).
- HIGH: `begin_asset_open()` preserves pre-open module-init phases into the first asset open.
- HIGH: flush idempotence via atomic exchange.
- MEDIUM: zero-overhead disabled path; `StringName` only constructed when enabled.
- MEDIUM: PLY cache-hit subphase recording (was lost on the early-return path).
- LOW: removed constructor-time setting read (raced with `GLOBAL_DEF`).

## Test plan
- [x] Build: `scons platform=windows target=editor dev_build=yes optimize=speed_trace -j8` → exit 0.
- [x] Binary mtime advanced (linker actually ran, not just scons exit=0).
- [ ] Smoke test on Grandma's House — capture the `[StartupTrace]` line for both cold and warm (cache-hit) opens. This is the baseline that Phases 1/3/4 PRs will be measured against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)