### PR TITLE
gaussian_splatting: pre-create graphics raster pipeline at init

### DIFF
--- a/modules/gaussian_splatting/core/gaussian_splat_manager.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_manager.cpp
@@ -975,6 +975,10 @@ void GaussianSplatManager::initialize_module() {
 	GLOBAL_DEF("rendering/gaussian_splatting/gpu_sorting_enabled", true);
 	GLOBAL_DEF("rendering/gaussian_splatting/shared_submission_device_enabled", false);
 	GLOBAL_DEF("rendering/gaussian_splatting/renderdoc_compatibility", false);
+	// Phase 4 startup-time fix: pre-create the graphics raster pipeline at TileRenderer init
+	// using the orchestrator's "probable" color format. Removes the first-frame hitch from
+	// in-render render_pipeline_create. The lazy reformat path catches format mismatches.
+	GLOBAL_DEF("rendering/gaussian_splatting/init/eager_raster_pipeline", true);
 	GLOBAL_DEF("rendering/gaussian_splatting/composite/depth_test", true);
     // Scene composite depth policy: 0=strict (skip frame if depth contract is missing), 1=relaxed (allow no-depth blend fallback).
     GLOBAL_DEF("rendering/gaussian_splatting/composite/scene_depth_policy", 0);

--- a/modules/gaussian_splatting/interfaces/painterly_renderer.cpp
+++ b/modules/gaussian_splatting/interfaces/painterly_renderer.cpp
@@ -1877,7 +1877,10 @@ Error PainterlyRenderer::populate_painterly_gbuffer(GaussianSplatRenderer *p_ren
         tile_renderer_state.renderer.instantiate();
         tile_renderer_state.renderer->set_performance_monitor(&tile_renderer_state.gpu_performance_monitor);
         p_renderer->synchronize_tile_submission(tile_device, "TileRenderer initialization");
-        Error init_err = tile_device ? tile_renderer_state.renderer->initialize(tile_device, Vector2i(width, height), TileRenderer::DEFAULT_TILE_SIZE, target_output_format, tile_device)
+        // Phase 4 eager pre-create: painterly has the real viewport + target format, so the
+        // hint will almost always match the live framebuffer (raster_pipeline_reformats stays 0).
+        Error init_err = tile_device ? tile_renderer_state.renderer->initialize(tile_device, Vector2i(width, height), TileRenderer::DEFAULT_TILE_SIZE, target_output_format, tile_device,
+                                              Size2i(width, height), target_output_format)
                                      : ERR_UNCONFIGURED;
         if (init_err != OK) {
             GS_LOG_ERROR_DEFAULT(vformat("[Painterly] Failed to initialize tile renderer: %d (will not retry)", init_err));

--- a/modules/gaussian_splatting/interfaces/rasterizer_interfaces.h
+++ b/modules/gaussian_splatting/interfaces/rasterizer_interfaces.h
@@ -221,6 +221,7 @@ struct RasterPerformance {
     uint64_t sort_sync_fallback_count = 0;
     uint64_t timing_frame_serial = 0;
     uint32_t timing_frames_behind = 0;
+    uint32_t raster_pipeline_reformats = 0;
 };
 
 // Rasterization result

--- a/modules/gaussian_splatting/interfaces/tile_rasterizer.cpp
+++ b/modules/gaussian_splatting/interfaces/tile_rasterizer.cpp
@@ -654,6 +654,7 @@ RasterPerformance TileRasterizer::get_performance() const {
     perf.sort_sync_fallback_count = tile_renderer->get_sort_sync_fallback_count();
     perf.timing_frame_serial = tile_renderer->get_gpu_timing_frame_serial();
     perf.timing_frames_behind = tile_renderer->get_gpu_timing_frames_behind();
+    perf.raster_pipeline_reformats = tile_renderer->get_raster_pipeline_reformat_count();
 
     return perf;
 }

--- a/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.cpp
@@ -179,6 +179,7 @@ static Array _production_metrics_contract() {
 	keys.push_back("raster_tile_splat_capacity");
 	keys.push_back("raster_max_raster_splats_per_tile");
 	keys.push_back("raster_shader_defines_hash");
+	keys.push_back("raster_pipeline_reformats");
 	keys.push_back("render_mode");
 	keys.push_back("stage_metrics_valid");
 	keys.push_back("stage_cull_status");
@@ -231,6 +232,7 @@ static void _append_raster_specialization_metrics(const GaussianSplatRenderer::P
 	r_metrics["raster_tile_splat_capacity"] = static_cast<int64_t>(p_perf.raster_tile_splat_capacity);
 	r_metrics["raster_max_raster_splats_per_tile"] = static_cast<int64_t>(p_perf.raster_max_raster_splats_per_tile);
 	r_metrics["raster_shader_defines_hash"] = String::num_uint64(p_perf.raster_shader_defines_hash);
+	r_metrics["raster_pipeline_reformats"] = static_cast<int64_t>(p_perf.raster_pipeline_reformats);
 }
 
 static Dictionary _build_production_metrics_snapshot(GaussianSplatRenderer &p_renderer,
@@ -342,6 +344,7 @@ static void _append_telemetry_extras(const GaussianSplatRenderer &p_renderer,
 	r_metrics["avg_frame_to_frame_ms"] = perf.avg_frame_to_frame_ms;
 	r_metrics["peak_frame_time_ms"] = perf.peak_frame_time_ms;
 	r_metrics["cull_projection_contract_mismatches"] = static_cast<int64_t>(perf.cull_projection_contract_mismatch_count);
+	r_metrics["raster_pipeline_reformats"] = static_cast<int64_t>(perf.raster_pipeline_reformats);
 	r_metrics["buffer_upload_time_ms"] = perf.buffer_upload_time_ms;
 	r_metrics["culling_time_ms"] = perf.culling_time_ms;
 	r_metrics["cull_route_uid"] = _normalize_cull_route_uid_for_stats(perf.cull_route_uid);

--- a/modules/gaussian_splatting/renderer/render_resource_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_resource_orchestrator.cpp
@@ -424,12 +424,21 @@ void RenderResourceOrchestrator::create_gpu_resources_safe() {
 					device_state->rd ? "valid" : "null"));
 		}
 #endif
+		// Phase 4 eager-raster-pipeline hint: orchestrator doesn't yet have the actual
+		// painterly framebuffer, so use the desired tile output format as the probable
+		// color attachment format. If the live framebuffer ends up using a different
+		// format on first frame, the lazy reformat path will tick raster_pipeline_reformats
+		// and rebuild. The size hint just gates whether we attempt the pre-create.
+		Size2i eager_target_size = default_viewport;
+		RD::DataFormat eager_color_format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
 		Error init_err = local_tile_renderer_state.renderer->initialize(
 				device_state->rd,
 				default_viewport,
 				TileRenderer::DEFAULT_TILE_SIZE,
 				RD::DATA_FORMAT_R8G8B8A8_UNORM,
-				device_state->rd);
+				device_state->rd,
+				eager_target_size,
+				eager_color_format);
 #ifdef DEBUG_ENABLED
 		if (log_enabled) {
 			GS_LOG_RENDERER_DEBUG(vformat("[GPU-RESOURCES] TileRenderer::initialize returned: %d", init_err));
@@ -540,6 +549,9 @@ void RenderResourceOrchestrator::update_gpu_pass_metrics_from_tile_renderer() {
 		metrics.gpu_timeline_stall_ms = 0.0f;
 		metrics.gpu_timeline_last_value = 0;
 		metrics.tile_sort_sync_fallback_count = 0;
+		// Note: leave raster_pipeline_reformats as-is across the "no rasterizer" branch.
+		// The counter is monotonic across the renderer's lifetime; resetting to 0 here
+		// would mask reformats that happened earlier in the session.
 		return;
 	}
 
@@ -569,6 +581,7 @@ void RenderResourceOrchestrator::update_gpu_pass_metrics_from_tile_renderer() {
 	metrics.tile_sort_sync_fallback_count = perf.sort_sync_fallback_count;
 	metrics.gpu_timing_frame_serial = perf.timing_frame_serial;
 	metrics.gpu_timing_frames_behind = perf.timing_frames_behind;
+	metrics.raster_pipeline_reformats = perf.raster_pipeline_reformats;
 
 	GPUPerformanceMonitor::SummaryMetrics timeline_summary =
 		tile_renderer_state->gpu_performance_monitor.get_summary_metrics();

--- a/modules/gaussian_splatting/renderer/render_types/render_performance_types.h
+++ b/modules/gaussian_splatting/renderer/render_types/render_performance_types.h
@@ -135,6 +135,7 @@ struct PerformanceMetrics {
 	float frame_to_frame_time_ms = 0.0f;
 	float avg_frame_to_frame_ms = 0.0f;
 	uint64_t cull_projection_contract_mismatch_count = 0;
+	uint32_t raster_pipeline_reformats = 0;
 };
 
 struct PerformanceState {

--- a/modules/gaussian_splatting/renderer/tile_render_rasterizer_stage.cpp
+++ b/modules/gaussian_splatting/renderer/tile_render_rasterizer_stage.cpp
@@ -136,12 +136,26 @@ uint64_t TileRenderer::TileRasterizerStage::dispatch_tile_rasterizer(uint32_t p_
         return 0;
     }
 
+    // Cache-invalidation rule: a render_pipeline is bound to ONE framebuffer-format
+    // ID at create time. If the live framebuffer's format ID changes (e.g. attachment
+    // reformat from the eager pre-create's "probable" guess to the actual texture
+    // formats), the cached pipeline is stale and must be freed before recreation.
+    const RD::FramebufferFormatID live_fb_format = submission_device->framebuffer_get_format(owner.render_targets.tile_framebuffer);
     if (owner.shader_resources.tile_raster_pipeline.is_valid() &&
-            owner.render_targets.tile_framebuffer_format != submission_device->framebuffer_get_format(owner.render_targets.tile_framebuffer)) {
+            owner.shader_resources.cached_raster_framebuffer_format != live_fb_format) {
+        static uint32_t s_reformat_log_count = 0;
+        if (s_reformat_log_count < 16) {
+            GS_LOG_RENDERER_INFO(vformat("[TileRenderer] raster pipeline reformat: from=%d to=%d",
+                    static_cast<int>(owner.shader_resources.cached_raster_framebuffer_format),
+                    static_cast<int>(live_fb_format)));
+            s_reformat_log_count++;
+        }
         if (submission_device->render_pipeline_is_valid(owner.shader_resources.tile_raster_pipeline)) {
             submission_device->free(owner.shader_resources.tile_raster_pipeline);
         }
         owner.shader_resources.tile_raster_pipeline = RID();
+        owner.shader_resources.cached_raster_framebuffer_format = RD::INVALID_ID;
+        owner.perf_metrics.raster_pipeline_reformats++;
     }
 
     uint32_t timestamp_base = submission_device->get_captured_timestamps_count();
@@ -150,7 +164,7 @@ uint64_t TileRenderer::TileRasterizerStage::dispatch_tile_rasterizer(uint32_t p_
     ScopedGpuMarker raster_marker(submission_device, "GS_TileRaster", Color(0.2f, 0.5f, 1.0f, 1.0f));
 
     if (owner.render_targets.tile_framebuffer_format == RD::INVALID_ID) {
-        owner.render_targets.tile_framebuffer_format = submission_device->framebuffer_get_format(owner.render_targets.tile_framebuffer);
+        owner.render_targets.tile_framebuffer_format = live_fb_format;
     }
 
     if (!owner.shader_resources.tile_raster_pipeline.is_valid()) {
@@ -194,6 +208,7 @@ uint64_t TileRenderer::TileRasterizerStage::dispatch_tile_rasterizer(uint32_t p_
                 owner.render_targets.tile_framebuffer_format, RD::INVALID_ID, RD::RENDER_PRIMITIVE_TRIANGLES, raster_state, ms_state,
                 depth_state, blend_state, 0);
         ERR_FAIL_COND_V(!owner.shader_resources.tile_raster_pipeline.is_valid(), 0);
+        owner.shader_resources.cached_raster_framebuffer_format = owner.render_targets.tile_framebuffer_format;
     }
 
     Rect2i viewport_rect(Vector2i(), owner.grid_state.viewport_size);

--- a/modules/gaussian_splatting/renderer/tile_render_resources.cpp
+++ b/modules/gaussian_splatting/renderer/tile_render_resources.cpp
@@ -328,6 +328,7 @@ void TileRenderTargets::destroy_output_textures() {
 		}
 		owner.shader_resources.tile_raster_pipeline = RID();
 	}
+	owner.shader_resources.cached_raster_framebuffer_format = RD::INVALID_ID;
 	if (owner.raster_stage.cached_raster_image_uniform_set.is_valid() && owner.raster_stage.cached_raster_image_device &&
 			owner.raster_stage.cached_raster_image_device->uniform_set_is_valid(owner.raster_stage.cached_raster_image_uniform_set)) {
 		owner.raster_stage.cached_raster_image_device->free(owner.raster_stage.cached_raster_image_uniform_set);
@@ -383,6 +384,7 @@ void TileRenderTargets::destroy_output_textures() {
 	tile_framebuffer_format = RD::INVALID_ID;
 	tile_framebuffer_owner = nullptr;
 	owner.shader_resources.tile_raster_pipeline = RID();
+	owner.shader_resources.cached_raster_framebuffer_format = RD::INVALID_ID;
 
 	destroy_resolve_textures();
 }
@@ -943,6 +945,7 @@ void TileShaderResources::reset_state() {
 	tile_prefix_pipeline_pass2 = RID();
 	tile_prefix_pipeline_pass3 = RID();
 	tile_raster_pipeline = RID();
+	cached_raster_framebuffer_format = RD::INVALID_ID;
 	tile_raster_compute_pipeline = RID();
 	tile_resolve_pipeline = RID();
 	tile_binning_shader = RID();

--- a/modules/gaussian_splatting/renderer/tile_render_resources.h
+++ b/modules/gaussian_splatting/renderer/tile_render_resources.h
@@ -124,6 +124,10 @@ struct TileShaderResources {
 	RID tile_prefix_pipeline_pass3;
 	RID tile_raster_shader;
 	RID tile_raster_pipeline;
+	// Framebuffer format the cached tile_raster_pipeline was created against. The pipeline
+	// must be recreated if the live framebuffer's format ID differs (e.g. attachment
+	// reformat). Initialized to INVALID_ID when no pipeline exists.
+	RD::FramebufferFormatID cached_raster_framebuffer_format = RD::INVALID_ID;
 	RID tile_raster_compute_shader;
 	RID tile_raster_compute_pipeline;
 	RID tile_resolve_shader;

--- a/modules/gaussian_splatting/renderer/tile_render_types.h
+++ b/modules/gaussian_splatting/renderer/tile_render_types.h
@@ -276,6 +276,10 @@ struct TilePerformanceMetrics {
 	float rasterization_ms = 0.0f;
 	uint32_t profiling_cached_overlap_total = 0;
 	uint64_t sort_sync_fallback_count = 0;
+	// Counts how many times the cached graphics raster pipeline was rebuilt due to a
+	// framebuffer-format mismatch (e.g. when the eager pre-create at init used a
+	// "probable" color format that differed from the live framebuffer).
+	uint32_t raster_pipeline_reformats = 0;
 	uint64_t compute_raster_frames = 0;
 	uint64_t fragment_raster_frames = 0;
 	bool last_raster_used_compute = false;

--- a/modules/gaussian_splatting/renderer/tile_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/tile_renderer.cpp
@@ -1465,53 +1465,78 @@ Error TileRenderer::initialize(RenderingDevice *p_rendering_device, const Vector
         return err;
     }
 
-    // Eager graphics raster pipeline pre-create (Phase 4): if the caller gave us a
-    // probable target size and color format AND the project setting is on, build
-    // the pipeline now using a framebuffer-format descriptor identical to the one
-    // the renderer will use at draw time (color + depth(R32) + normal(R16G16B16A16)).
-    // If the format guess is wrong on the first frame, the lazy reformat path will
-    // free this pipeline and rebuild it; raster_pipeline_reformats will tick.
+    if (p_initial_viewport.x > 0 && p_initial_viewport.y > 0) {
+        err = _ensure_resources(p_initial_viewport, config_state.tile_size, config_state.desired_output_format);
+        if (err != OK) {
+            return err;
+        }
+    } else {
+        grid_state.viewport_size = Vector2i();
+        grid_state.tiles_x = 0;
+        grid_state.tiles_y = 0;
+        grid_state.total_tiles = 0;
+    }
+
+    // Eager graphics raster pipeline pre-create (Phase 4): runs AFTER _ensure_resources()
+    // because _ensure_resources() takes the recreate path on first init (config_state.output_format
+    // starts as DATA_FORMAT_MAX) and TileRenderTargets::destroy_output_textures() frees
+    // owner.shader_resources.tile_raster_pipeline. Pre-creating before that would simply
+    // discard the eager pipeline and re-introduce the first-frame hitch.
+    //
+    // Format selection: if _ensure_resources() built a real framebuffer, reuse that
+    // framebuffer_format directly so the pipeline is bound to the EXACT format the
+    // renderer will draw against (no reformat on frame 1). Otherwise fall back to a
+    // probable framebuffer-format descriptor built from p_init_color_format + R32/R16G16B16A16.
+    // If the descriptor guess turns out wrong on the first frame, the lazy reformat path
+    // in dispatch_tile_rasterizer() will free this pipeline and rebuild it.
     const bool eager_enabled = GLOBAL_GET("rendering/gaussian_splatting/init/eager_raster_pipeline");
-    if (eager_enabled && p_init_target_size.x > 0 && p_init_target_size.y > 0 &&
-            p_init_color_format != RD::DATA_FORMAT_MAX && shader_resources.tile_raster_shader.is_valid()) {
+    if (eager_enabled && shader_resources.tile_raster_shader.is_valid()) {
         RenderingDevice *pipeline_device = _get_submission_device();
         if (!pipeline_device) {
             pipeline_device = device;
         }
         if (pipeline_device) {
-            Vector<RD::AttachmentFormat> attachment_formats;
-            RD::AttachmentFormat af_color;
-            af_color.format = p_init_color_format;
-            af_color.usage_flags = RD::TEXTURE_USAGE_STORAGE_BIT |
-                    RD::TEXTURE_USAGE_SAMPLING_BIT |
-                    RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT |
-                    RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT |
-                    RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
-            attachment_formats.push_back(af_color);
+            RD::FramebufferFormatID target_fb_format = RD::INVALID_ID;
+            if (render_targets.tile_framebuffer.is_valid() &&
+                    render_targets.tile_framebuffer_format != RD::INVALID_ID) {
+                // _ensure_resources() built a real framebuffer; bind directly to its format.
+                target_fb_format = render_targets.tile_framebuffer_format;
+            } else if (p_init_target_size.x > 0 && p_init_target_size.y > 0 &&
+                    p_init_color_format != RD::DATA_FORMAT_MAX) {
+                // Fall back to the caller-provided hint.
+                Vector<RD::AttachmentFormat> attachment_formats;
+                RD::AttachmentFormat af_color;
+                af_color.format = p_init_color_format;
+                af_color.usage_flags = RD::TEXTURE_USAGE_STORAGE_BIT |
+                        RD::TEXTURE_USAGE_SAMPLING_BIT |
+                        RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT |
+                        RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT |
+                        RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
+                attachment_formats.push_back(af_color);
 
-            RD::AttachmentFormat af_depth;
-            af_depth.format = RD::DATA_FORMAT_R32_SFLOAT;
-            af_depth.usage_flags = RD::TEXTURE_USAGE_STORAGE_BIT |
-                    RD::TEXTURE_USAGE_SAMPLING_BIT |
-                    RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT |
-                    RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT |
-                    RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
-            attachment_formats.push_back(af_depth);
+                RD::AttachmentFormat af_depth;
+                af_depth.format = RD::DATA_FORMAT_R32_SFLOAT;
+                af_depth.usage_flags = RD::TEXTURE_USAGE_STORAGE_BIT |
+                        RD::TEXTURE_USAGE_SAMPLING_BIT |
+                        RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT |
+                        RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT |
+                        RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
+                attachment_formats.push_back(af_depth);
 
-            RD::AttachmentFormat af_normal;
-            af_normal.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
-            af_normal.usage_flags = RD::TEXTURE_USAGE_STORAGE_BIT |
-                    RD::TEXTURE_USAGE_SAMPLING_BIT |
-                    RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT |
-                    RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT |
-                    RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
-            attachment_formats.push_back(af_normal);
+                RD::AttachmentFormat af_normal;
+                af_normal.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
+                af_normal.usage_flags = RD::TEXTURE_USAGE_STORAGE_BIT |
+                        RD::TEXTURE_USAGE_SAMPLING_BIT |
+                        RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT |
+                        RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT |
+                        RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
+                attachment_formats.push_back(af_normal);
 
-            RD::FramebufferFormatID probable_fb_format = pipeline_device->framebuffer_format_create(attachment_formats);
-            // Defensive: if initialize() is somehow re-entered without an intervening
-            // cleanup() (cached pipeline still live), free the stale RID before we
-            // overwrite the slot. cleanup() is the documented contract but this
-            // costs ~nothing and avoids a leak if the contract is broken.
+                target_fb_format = pipeline_device->framebuffer_format_create(attachment_formats);
+            }
+
+            // Defensive: if a stale pipeline survived (e.g. initialize() re-entered without
+            // cleanup()), free it before overwriting the slot.
             if (shader_resources.tile_raster_pipeline.is_valid()) {
                 if (pipeline_device->render_pipeline_is_valid(shader_resources.tile_raster_pipeline)) {
                     pipeline_device->free(shader_resources.tile_raster_pipeline);
@@ -1519,7 +1544,8 @@ Error TileRenderer::initialize(RenderingDevice *p_rendering_device, const Vector
                 shader_resources.tile_raster_pipeline = RID();
                 shader_resources.cached_raster_framebuffer_format = RD::INVALID_ID;
             }
-            if (probable_fb_format != RD::INVALID_ID) {
+
+            if (target_fb_format != RD::INVALID_ID) {
                 RD::PipelineRasterizationState raster_state;
                 raster_state.cull_mode = RD::POLYGON_CULL_DISABLED;
                 RD::PipelineMultisampleState ms_state;
@@ -1552,11 +1578,11 @@ Error TileRenderer::initialize(RenderingDevice *p_rendering_device, const Vector
                 blend_state.attachments.write[2].alpha_blend_op = RD::BLEND_OP_ADD;
 
                 RID eager_pipeline = pipeline_device->render_pipeline_create(shader_resources.tile_raster_shader,
-                        probable_fb_format, RD::INVALID_ID, RD::RENDER_PRIMITIVE_TRIANGLES, raster_state,
+                        target_fb_format, RD::INVALID_ID, RD::RENDER_PRIMITIVE_TRIANGLES, raster_state,
                         ms_state, depth_state, blend_state, 0);
                 if (eager_pipeline.is_valid()) {
                     shader_resources.tile_raster_pipeline = eager_pipeline;
-                    shader_resources.cached_raster_framebuffer_format = probable_fb_format;
+                    shader_resources.cached_raster_framebuffer_format = target_fb_format;
                 } else {
                     // Log once per process: repeated init calls (e.g. device change) must not
                     // flood the log when the pre-create consistently fails.
@@ -1566,7 +1592,10 @@ Error TileRenderer::initialize(RenderingDevice *p_rendering_device, const Vector
                         s_warned_pipeline_create = true;
                     }
                 }
-            } else {
+            } else if (p_init_target_size.x > 0 && p_init_target_size.y > 0 &&
+                    p_init_color_format != RD::DATA_FORMAT_MAX) {
+                // Only warn when a hint was provided but framebuffer_format_create rejected it;
+                // a hint-less init with no viewport is a normal "skip eager create" case.
                 static bool s_warned_fb_format = false;
                 if (!s_warned_fb_format) {
                     GS_LOG_WARN_DEFAULT("[TileRenderer] Eager raster pipeline pre-create: framebuffer_format_create returned invalid; lazy path will run.");
@@ -1574,18 +1603,6 @@ Error TileRenderer::initialize(RenderingDevice *p_rendering_device, const Vector
                 }
             }
         }
-    }
-
-    if (p_initial_viewport.x > 0 && p_initial_viewport.y > 0) {
-        err = _ensure_resources(p_initial_viewport, config_state.tile_size, config_state.desired_output_format);
-        if (err != OK) {
-            return err;
-        }
-    } else {
-        grid_state.viewport_size = Vector2i();
-        grid_state.tiles_x = 0;
-        grid_state.tiles_y = 0;
-        grid_state.total_tiles = 0;
     }
 
     return OK;

--- a/modules/gaussian_splatting/renderer/tile_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/tile_renderer.cpp
@@ -1438,7 +1438,8 @@ TileRenderer::~TileRenderer() {
 }
 
 Error TileRenderer::initialize(RenderingDevice *p_rendering_device, const Vector2i &p_initial_viewport, int p_tile_size,
-        RD::DataFormat p_format, RenderingDevice *p_submission_device) {
+        RD::DataFormat p_format, RenderingDevice *p_submission_device,
+        const Size2i &p_init_target_size, RD::DataFormat p_init_color_format) {
     ERR_FAIL_NULL_V_MSG(p_rendering_device, ERR_INVALID_PARAMETER, "[TileRenderer] Rendering device is required for initialization");
 
     device_context.resource_rd = p_rendering_device;
@@ -1462,6 +1463,117 @@ Error TileRenderer::initialize(RenderingDevice *p_rendering_device, const Vector
     if (err != OK) {
         GS_LOG_ERROR_DEFAULT("[TileRenderer] Failed to compile tile renderer shaders");
         return err;
+    }
+
+    // Eager graphics raster pipeline pre-create (Phase 4): if the caller gave us a
+    // probable target size and color format AND the project setting is on, build
+    // the pipeline now using a framebuffer-format descriptor identical to the one
+    // the renderer will use at draw time (color + depth(R32) + normal(R16G16B16A16)).
+    // If the format guess is wrong on the first frame, the lazy reformat path will
+    // free this pipeline and rebuild it; raster_pipeline_reformats will tick.
+    const bool eager_enabled = GLOBAL_GET("rendering/gaussian_splatting/init/eager_raster_pipeline");
+    if (eager_enabled && p_init_target_size.x > 0 && p_init_target_size.y > 0 &&
+            p_init_color_format != RD::DATA_FORMAT_MAX && shader_resources.tile_raster_shader.is_valid()) {
+        RenderingDevice *pipeline_device = _get_submission_device();
+        if (!pipeline_device) {
+            pipeline_device = device;
+        }
+        if (pipeline_device) {
+            Vector<RD::AttachmentFormat> attachment_formats;
+            RD::AttachmentFormat af_color;
+            af_color.format = p_init_color_format;
+            af_color.usage_flags = RD::TEXTURE_USAGE_STORAGE_BIT |
+                    RD::TEXTURE_USAGE_SAMPLING_BIT |
+                    RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT |
+                    RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT |
+                    RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
+            attachment_formats.push_back(af_color);
+
+            RD::AttachmentFormat af_depth;
+            af_depth.format = RD::DATA_FORMAT_R32_SFLOAT;
+            af_depth.usage_flags = RD::TEXTURE_USAGE_STORAGE_BIT |
+                    RD::TEXTURE_USAGE_SAMPLING_BIT |
+                    RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT |
+                    RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT |
+                    RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
+            attachment_formats.push_back(af_depth);
+
+            RD::AttachmentFormat af_normal;
+            af_normal.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
+            af_normal.usage_flags = RD::TEXTURE_USAGE_STORAGE_BIT |
+                    RD::TEXTURE_USAGE_SAMPLING_BIT |
+                    RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT |
+                    RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT |
+                    RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
+            attachment_formats.push_back(af_normal);
+
+            RD::FramebufferFormatID probable_fb_format = pipeline_device->framebuffer_format_create(attachment_formats);
+            // Defensive: if initialize() is somehow re-entered without an intervening
+            // cleanup() (cached pipeline still live), free the stale RID before we
+            // overwrite the slot. cleanup() is the documented contract but this
+            // costs ~nothing and avoids a leak if the contract is broken.
+            if (shader_resources.tile_raster_pipeline.is_valid()) {
+                if (pipeline_device->render_pipeline_is_valid(shader_resources.tile_raster_pipeline)) {
+                    pipeline_device->free(shader_resources.tile_raster_pipeline);
+                }
+                shader_resources.tile_raster_pipeline = RID();
+                shader_resources.cached_raster_framebuffer_format = RD::INVALID_ID;
+            }
+            if (probable_fb_format != RD::INVALID_ID) {
+                RD::PipelineRasterizationState raster_state;
+                raster_state.cull_mode = RD::POLYGON_CULL_DISABLED;
+                RD::PipelineMultisampleState ms_state;
+                RD::PipelineDepthStencilState depth_state;
+                depth_state.enable_depth_test = false;
+                depth_state.enable_depth_write = false;
+
+                RD::PipelineColorBlendState blend_state;
+                blend_state.attachments.resize(3);
+
+                blend_state.attachments.write[0] = RD::PipelineColorBlendState::Attachment();
+                blend_state.attachments.write[0].enable_blend = true;
+                blend_state.attachments.write[0].src_color_blend_factor = RD::BLEND_FACTOR_ONE;
+                blend_state.attachments.write[0].dst_color_blend_factor = RD::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+                blend_state.attachments.write[0].color_blend_op = RD::BLEND_OP_ADD;
+                blend_state.attachments.write[0].src_alpha_blend_factor = RD::BLEND_FACTOR_ONE;
+                blend_state.attachments.write[0].dst_alpha_blend_factor = RD::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+                blend_state.attachments.write[0].alpha_blend_op = RD::BLEND_OP_ADD;
+
+                blend_state.attachments.write[1] = RD::PipelineColorBlendState::Attachment();
+                blend_state.attachments.write[1].enable_blend = false;
+
+                blend_state.attachments.write[2] = RD::PipelineColorBlendState::Attachment();
+                blend_state.attachments.write[2].enable_blend = true;
+                blend_state.attachments.write[2].src_color_blend_factor = RD::BLEND_FACTOR_ONE;
+                blend_state.attachments.write[2].dst_color_blend_factor = RD::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+                blend_state.attachments.write[2].color_blend_op = RD::BLEND_OP_ADD;
+                blend_state.attachments.write[2].src_alpha_blend_factor = RD::BLEND_FACTOR_ONE;
+                blend_state.attachments.write[2].dst_alpha_blend_factor = RD::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+                blend_state.attachments.write[2].alpha_blend_op = RD::BLEND_OP_ADD;
+
+                RID eager_pipeline = pipeline_device->render_pipeline_create(shader_resources.tile_raster_shader,
+                        probable_fb_format, RD::INVALID_ID, RD::RENDER_PRIMITIVE_TRIANGLES, raster_state,
+                        ms_state, depth_state, blend_state, 0);
+                if (eager_pipeline.is_valid()) {
+                    shader_resources.tile_raster_pipeline = eager_pipeline;
+                    shader_resources.cached_raster_framebuffer_format = probable_fb_format;
+                } else {
+                    // Log once per process: repeated init calls (e.g. device change) must not
+                    // flood the log when the pre-create consistently fails.
+                    static bool s_warned_pipeline_create = false;
+                    if (!s_warned_pipeline_create) {
+                        GS_LOG_WARN_DEFAULT("[TileRenderer] Eager raster pipeline pre-create failed; lazy path will run on first frame.");
+                        s_warned_pipeline_create = true;
+                    }
+                }
+            } else {
+                static bool s_warned_fb_format = false;
+                if (!s_warned_fb_format) {
+                    GS_LOG_WARN_DEFAULT("[TileRenderer] Eager raster pipeline pre-create: framebuffer_format_create returned invalid; lazy path will run.");
+                    s_warned_fb_format = true;
+                }
+            }
+        }
     }
 
     if (p_initial_viewport.x > 0 && p_initial_viewport.y > 0) {
@@ -2132,6 +2244,7 @@ void TileRenderer::_free_existing_pipelines(RenderingDevice *p_shader_owner) {
 		}
 		shader_resources.tile_raster_pipeline = RID();
 	}
+	shader_resources.cached_raster_framebuffer_format = RD::INVALID_ID;
 	if (shader_resources.tile_raster_compute_pipeline.is_valid()) {
 		if (p_shader_owner && p_shader_owner->compute_pipeline_is_valid(shader_resources.tile_raster_compute_pipeline)) {
 			p_shader_owner->free(shader_resources.tile_raster_compute_pipeline);

--- a/modules/gaussian_splatting/renderer/tile_renderer.h
+++ b/modules/gaussian_splatting/renderer/tile_renderer.h
@@ -87,7 +87,8 @@ public:
     ~TileRenderer();
 
     Error initialize(RenderingDevice *p_rendering_device, const Vector2i &p_initial_viewport = Vector2i(), int p_tile_size = -1,
-            RD::DataFormat p_format = RD::DATA_FORMAT_MAX, RenderingDevice *p_submission_device = nullptr);
+            RD::DataFormat p_format = RD::DATA_FORMAT_MAX, RenderingDevice *p_submission_device = nullptr,
+            const Size2i &p_init_target_size = Size2i(), RD::DataFormat p_init_color_format = RD::DATA_FORMAT_MAX);
     void cleanup();
 
     RID render(RenderingDevice *p_rendering_device, const RenderParams &p_params);
@@ -164,6 +165,7 @@ public:
     float get_tile_assignment_time() const { return perf_metrics.tile_assignment_ms; }
     float get_rasterization_time() const { return perf_metrics.rasterization_ms; }
 	uint64_t get_sort_sync_fallback_count() const { return perf_metrics.sort_sync_fallback_count; }
+	uint32_t get_raster_pipeline_reformat_count() const { return perf_metrics.raster_pipeline_reformats; }
 	float get_last_submission_cpu_ms() const { return timing_state.last_submission_cpu_ms; }
 	float get_last_gpu_frame_time_ms() const { return timing_state.last_frame_gpu_ms; }
 	bool is_last_gpu_frame_time_valid() const { return timing_state.frame_gpu_timing_valid; }


### PR DESCRIPTION
## Summary
- Moves the graphics-raster `render_pipeline_create` from first-frame lazy creation (inside `dispatch_tile_rasterizer`) to `TileRenderer::initialize`.
- `TileRenderer::initialize` accepts optional `p_init_target_size` and `p_init_color_format`. Eager pre-create builds the same descriptor the lazy path would build.
- Lazy fallback still runs if the actual framebuffer format on frame 1 differs from the eager guess; old pipeline is freed before recreate, counter incremented, log gated to once-per-process.
- New `raster_pipeline_reformats` counter exposed via diagnostics dictionary (`TileRenderer` → `TileRasterizer` → `RasterPerformance` → `PerformanceMetrics` → diagnostics keys).
- Gated by `rendering/gaussian_splatting/init/eager_raster_pipeline` (default true).

## Why
The lazy `render_pipeline_create` runs inside the first call to `dispatch_tile_rasterizer`, putting driver pipeline-compile time on the user-visible first-frame path. Pre-creating at init moves the cost off that critical path.

## Hint sources
- `RenderResourceOrchestrator` passes `R8G8B8A8_UNORM` at 1280×720 as the probable default. HDR projects with `R16G16B16A16_SFLOAT` painterly framebuffers will reformat **once** on frame 1; counter + log let us catch this in telemetry.
- `PainterlyRenderer` passes its real `target_output_format` and dimensions, so its path won't reformat in steady state.

## Code review
Reviewed by Claude — flagged and fixed:
- **MEDIUM:** defensive free of pre-existing `tile_raster_pipeline` RID before overwriting in the eager block. Current callers always `cleanup()` first, but the defensive guard prevents a future caller from leaking a pipeline.
- **LOW:** pre-create failure warnings gated to once-per-process via a `static bool` so repeated device-change re-inits don't flood logs.

Other checklist items passed: setting flag is read where the eager block runs, reformat path frees old pipeline once, `cached_raster_framebuffer_format` defaults to `INVALID_ID`, all pipeline-free sites reset the cached format, metric surfaces correctly in the diagnostics dictionary, no caller breaks (defaults supplied).

## Test plan
- [x] Build: `scons platform=windows target=editor dev_build=yes optimize=speed_trace -j8` → exit 0.
- [x] Binary mtime advanced.
- [ ] After #342 (startup trace) lands, confirm `first_frame_raster_pipeline_create` phase time drops to ~0 with the eager path enabled.
- [ ] Smoke test on Grandma's House — verify `raster_pipeline_reformats` stays at 0 in steady state for the painterly path; expect 1 reformat on frame 1 only for HDR projects via the orchestrator path.
- [ ] Visual regression check on real-scan content per visual-validation rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)