### PR TITLE
gaussian_splatting: arm startup trace at set_splat_asset convergence

### DIFF
--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -649,6 +649,16 @@ void GaussianSplatNode3D::set_splat_asset(const Ref<GaussianSplatAsset> &p_asset
         return;
     }
 
+    // Arm the startup trace only when this assignment will drive a render
+    // pipeline. Out-of-tree assignment (e.g. tests, programmatic builders that
+    // configure the node before adding to a scene) and the three existing arm
+    // sites (_load_asset, _set ply_file_path migration, drop handler) already
+    // fire their own begin_asset_open() before this point - the asset_loading
+    // flag guards against double-arming on the reload path.
+    if (p_asset.is_valid() && is_inside_tree() && is_inside_world() && !asset_loading) {
+        GSStartupTrace::get_singleton()->begin_asset_open();
+    }
+
     if (splat_asset.is_valid() && splat_asset->is_connected("changed", callable_mp(this, &GaussianSplatNode3D::_on_asset_changed))) {
         splat_asset->disconnect("changed", callable_mp(this, &GaussianSplatNode3D::_on_asset_changed));
     }


### PR DESCRIPTION
## Summary
- The shipped Phase 0 trace (PR #342) only fired on three node paths: `_load_asset`, `ply_file_path` migration, drag-drop.
- Real game scenes assign `node.splat_asset = X` programmatically (ExtResource in a .tscn, container merge, editor reimport, hot-reload) and never hit any of those three paths. The trace never fired on Grandma's House, so the per-phase startup breakdown was never observable.
- Add the arm inside `set_splat_asset` (the convergence point), gated by \`is_inside_tree() && is_inside_world() && !asset_loading\` so the three existing arms don't double-arm and non-render-context callers (tests, ResourceFormatLoader, importer preview) don't queue pending traces that won't drain.

## Why
This is the prerequisite for measuring where the 12s startup on real content actually goes. Without it, we cannot validate any further optimization (per the project's \"measure before recommending\" rule).

## Validation done
- Call-site grep confirmed:
  - \`_load_asset\` sets \`asset_loading=true\` before \`set_splat_asset\` at line 1777, cleared at 1783 → \`!asset_loading\` guard blocks.
  - Migration in \`_set()\` fires during scene deserialization → node not yet in tree → \`is_inside_tree()\` blocks.
  - Drop handler arms before \`add_child\` → blocks.
- New render-context paths unlocked: \`GaussianSplatContainer::apply_to_node\`, \`GaussianEditorPlugin::_complete_reimport\`, \`GaussianEditorPlugin::_apply_hot_reload_asset_to_nodes\`, and the .tscn ExtResource property restore.
- All 18 test call sites in \`tests/test_gaussian_splat_node.h\` assign \`set_splat_asset\` before \`add_child\` → gate blocks them.
- Build verified: \`bin/godot.windows.editor.dev.x86_64.exe\` relinked (mtime advanced, 153 MB).

## Followup
The trace fires on real scenes after this. The actual per-phase data should be captured on Grandma's House to validate the Phase B work that follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)