### PR TITLE
Draft: Add #350/#360 renderer release gates foundation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -30,6 +30,20 @@ GitHub's Actions tab can also show historical workflow names from past runs, dis
 | `release_builds.yml` | `release_name` | optional string |
 | `release_builds.yml` | `keep_nightlies` | integer string |
 
+## Renderer Release Gate Contract
+
+The renderer/public-alpha evidence policy is maintained in
+`docs/reference/renderer_release_gate_manifest.json` and validated with:
+
+```bash
+python tests/ci/check_renderer_release_gates.py --mode contract
+```
+
+The contract check is deterministic and GPU-free. Public-alpha candidate mode
+adds the evidence bundle and live issue-label snapshot so P0, release-blocker,
+and alpha-relevant P1 issues cannot be bypassed by release notes or manual
+workflow choices.
+
 ## Scheduled Triggers
 
 | Workflow | Schedule (UTC) | Behavior |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -40,9 +40,12 @@ python tests/ci/check_renderer_release_gates.py --mode contract
 ```
 
 The contract check is deterministic and GPU-free. Public-alpha candidate mode
-adds the evidence bundle and live issue-label snapshot so P0, release-blocker,
-and alpha-relevant P1 issues cannot be bypassed by release notes or manual
-workflow choices.
+requires the evidence bundle, a public-alpha channel/tag selector, and a live
+issue-label snapshot so P0, release-blocker, and alpha-relevant P1 issues cannot
+be bypassed by release notes or manual workflow choices. The workflow-policy
+portion of the checker validates required workflow files and job markers only;
+the stronger no-downgrade workflow rules remain documented review policy until
+the checker grows a real GitHub Actions behavior parser.
 
 ## Scheduled Triggers
 

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -13,6 +13,7 @@ Find build, test, architecture, and contributor workflow references.
 | Test environment setup | [Testing setup guide](../testing/setup-guide.md) |
 | Versioned docs site build and deploy | [Docs site maintenance guide](docs-site.md) |
 | Screenshot capture process | [Screenshot capture spec](screenshot-capture-spec.md) |
+| Public alpha accepted limitations | [Known public alpha limitations](known-public-alpha-limitations.md) |
 | Contribution policy | [Contribution guide](../../CONTRIBUTING.md) |
 | Module architecture overview | [Module README](../../modules/gaussian_splatting/README.md) |
 | Documentation style policy | [Documentation style guide](../style/documentation-style-guide.md) |

--- a/docs/development/known-public-alpha-limitations.md
+++ b/docs/development/known-public-alpha-limitations.md
@@ -1,0 +1,17 @@
+# Known Public Alpha Limitations
+
+This page is intentionally required by the renderer release-gate manifest. A
+public-alpha candidate may carry an accepted limitation only when the candidate
+evidence bundle points to a section here with:
+
+- the issue URL;
+- user-facing impact;
+- affected platform or workflow;
+- mitigation or unsupported-path statement;
+- evidence proving the limitation does not hide renderer correctness failures.
+
+## Current Status
+
+No accepted public-alpha limitations are recorded yet. Open P0, release-blocker,
+and alpha-relevant P1 issues remain blockers unless a future PR adds an explicit
+manifest classification and a matching entry on this page.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -80,6 +80,7 @@ Use this section when you need exact names, settings, compatibility evidence, or
 - [Timing metrics reference](../timing_metrics_reference.md)
 - [Engine patch report](engine-patch.md)
 - [Build / Test / CI reference](build-test-ci.md)
+- [Renderer release gates](renderer-release-gates.md)
 - [Recurring issues](../troubleshooting/recurring-issues.md)
 
 </div>

--- a/docs/reference/renderer-release-gates.md
+++ b/docs/reference/renderer-release-gates.md
@@ -8,12 +8,15 @@ the checker is `tests/ci/check_renderer_release_gates.py`.
 ## Predicate
 
 A public alpha is not satisfied by a nightly, a manual workflow choice, a green
-advisory report, or a path-filtered subset of renderer checks. A candidate must
-declare `release_channel=public-alpha` or match a `v*-alpha*` release tag, then
-pass the manifest predicate:
+advisory report, or a path-filtered subset of renderer checks. Candidate mode
+machine-enforces that a candidate declares `release_channel=public-alpha` or
+matches a `v*-alpha*` release tag, then passes the manifest predicate:
 
+- an issue snapshot is required, either through `--issues-json` or an embedded
+  candidate evidence `issue_snapshot`;
 - open `priority:P0`, `release blocker`, and alpha-relevant `priority:P1` issues
-  must be classified as `blocking`, `accepted_alpha_limitation`, or `post_alpha`;
+  in that snapshot must be classified as `blocking`,
+  `accepted_alpha_limitation`, or `post_alpha`;
 - any `accepted_alpha_limitation` must have a user-facing entry in
   `docs/development/known-public-alpha-limitations.md`;
 - Linux and Windows artifacts, runtime validation, GPU harness output,
@@ -21,6 +24,15 @@ pass the manifest predicate:
   acceptance, and open-world proof must all be present;
 - missing GPU runner availability, manual inputs, path filters, or advisory
   open-world proof cannot downgrade a public-alpha candidate to pass.
+
+## Workflow Policy Scope
+
+The contract checker currently validates that required workflow files exist and
+contain the required job markers. It does not yet parse GitHub Actions YAML
+deeply enough to prove manual-input bypasses, path-filter bypasses, Linux-only
+publishing, unmatched release-file allowances, or open-world advisory-only
+behavior. Those no-downgrade rules remain documented review policy in the
+manifest until a workflow-behavior parser is added.
 
 ## Renderer Evidence
 
@@ -64,7 +76,8 @@ Run the contract check locally or in CI:
 python3 tests/ci/check_renderer_release_gates.py --mode contract
 ```
 
-Candidate release validation accepts an evidence bundle and optional issue JSON:
+Candidate release validation requires an evidence bundle and an issue snapshot
+unless the evidence bundle embeds `issue_snapshot`:
 
 ```bash
 python3 tests/ci/check_renderer_release_gates.py \

--- a/docs/reference/renderer-release-gates.md
+++ b/docs/reference/renderer-release-gates.md
@@ -1,0 +1,78 @@
+# Renderer Release Gates
+
+This page defines the release evidence contract for renderer evidence and the
+public-alpha gate. The source of truth is
+[`renderer_release_gate_manifest.json`](renderer_release_gate_manifest.json);
+the checker is `tests/ci/check_renderer_release_gates.py`.
+
+## Predicate
+
+A public alpha is not satisfied by a nightly, a manual workflow choice, a green
+advisory report, or a path-filtered subset of renderer checks. A candidate must
+declare `release_channel=public-alpha` or match a `v*-alpha*` release tag, then
+pass the manifest predicate:
+
+- open `priority:P0`, `release blocker`, and alpha-relevant `priority:P1` issues
+  must be classified as `blocking`, `accepted_alpha_limitation`, or `post_alpha`;
+- any `accepted_alpha_limitation` must have a user-facing entry in
+  `docs/development/known-public-alpha-limitations.md`;
+- Linux and Windows artifacts, runtime validation, GPU harness output,
+  production evidence, benchmark reports, compatibility sources, docs release
+  acceptance, and open-world proof must all be present;
+- missing GPU runner availability, manual inputs, path filters, or advisory
+  open-world proof cannot downgrade a public-alpha candidate to pass.
+
+## Renderer Evidence
+
+The current foundation profile requires the compositor hazard visual gate and
+tracks every `[RequiresGPU]` doctest by a checked snapshot. The snapshot is
+deliberately strict: adding, renaming, or deleting a GPU test without updating
+the manifest fails contract validation.
+
+`[SceneTree][RequiresGPU]` and `[Importer][RequiresGPU]` tests remain deferred
+because the current offscreen GPU harness does not bootstrap those integration
+paths. They are still release blockers. Public-alpha signoff and closure of
+#350/#360 require either zero deferred tests or explicit waivers in the manifest
+with owner, date, issue URL, product risk, mitigation, and a known-limitations
+docs path.
+
+## Visual And Benchmark Rules
+
+Visual and benchmark evidence is machine-checkable before it becomes release
+evidence:
+
+- required GPU batches must match at least one test, parse doctest summaries,
+  avoid timeouts, avoid skips unless explicitly allowed, and report zero RID
+  leak bytes;
+- blocking visual lanes need committed reference PNGs, nonzero captures, all
+  expected references matched, and non-null SSIM/PSNR fields;
+- benchmark rows used for public alpha need hardware, driver, OS, binary,
+  route/stage, fallback, queue-pressure, timing, and proof metadata;
+- timeout-written reports fail;
+- `gpu_time_frame_ms` can be positive evidence only when GPU timing is available
+  and provenance proves the source. Otherwise the row must explicitly mark GPU
+  timing as unavailable and use CPU-observed labels.
+
+The current public performance dashboard remains a non-authoritative snapshot
+until a complete candidate evidence bundle exists.
+
+## CI Hook
+
+Run the contract check locally or in CI:
+
+```bash
+python3 tests/ci/check_renderer_release_gates.py --mode contract
+```
+
+Candidate release validation accepts an evidence bundle and optional issue JSON:
+
+```bash
+python3 tests/ci/check_renderer_release_gates.py \
+  --mode candidate \
+  --candidate-evidence artifacts/public-alpha/evidence_bundle.json \
+  --issues-json artifacts/public-alpha/open_issues.json
+```
+
+The issue JSON is intended to come from `gh issue list` or the GitHub API with
+labels included. This PR does not require live network access for the
+deterministic contract check.

--- a/docs/reference/renderer_release_gate_manifest.json
+++ b/docs/reference/renderer_release_gate_manifest.json
@@ -49,36 +49,35 @@
     ]
   },
   "workflow_policy": {
+    "machine_enforcement_scope": "workflow-presence-and-required-job-markers",
+    "documented_non_enforced_rules": [
+      "manual workflow inputs must not bypass public-alpha readiness",
+      "path filters must not downgrade public-alpha readiness",
+      "public-alpha release publication must not be Linux-only",
+      "public-alpha release publication must not allow unmatched release files",
+      "open-world proof must be blocking rather than advisory"
+    ],
     "required_workflows": [
       {
         "file": ".github/workflows/gaussian_production_gates.yml",
         "required_for_public_alpha": true,
-        "required_jobs": ["guards", "module-validation"],
-        "must_enforce_readiness": true,
-        "manual_input_may_disable": false,
-        "path_filter_may_disable": false
+        "required_jobs": ["guards", "module-validation"]
       },
       {
         "file": ".github/workflows/baseline_qa.yml",
         "required_for_public_alpha": true,
-        "required_jobs": ["Run GPU harness"],
-        "manual_input_may_disable": false,
-        "path_filter_may_disable": false
+        "required_jobs": ["Run GPU harness"]
       },
       {
         "file": ".github/workflows/release_builds.yml",
         "required_for_public_alpha": true,
-        "required_jobs": ["build_linux", "build_windows", "publish_release"],
-        "manual_input_may_disable": false,
-        "path_filter_may_disable": false,
-        "linux_only_release_allowed": false,
-        "unmatched_release_files_allowed": false
+        "required_jobs": ["build_linux", "build_windows", "publish_release"]
       }
     ],
     "open_world_proof": {
-      "required_for_public_alpha": true,
-      "advisory_only_allowed": false,
-      "required_artifact_group": "open_world_proof"
+      "required_for_public_alpha_candidate_artifacts": true,
+      "required_artifact_group": "open_world_proof",
+      "workflow_blocking_behavior_machine_enforced": false
     }
   },
   "visual_acceptance": {

--- a/docs/reference/renderer_release_gate_manifest.json
+++ b/docs/reference/renderer_release_gate_manifest.json
@@ -1,0 +1,154 @@
+{
+  "schema_version": 1,
+  "policy_id": "renderer-public-alpha-release-gates",
+  "status": "foundation",
+  "owner_issues": [350, 360],
+  "public_alpha_predicate": {
+    "channel": "public-alpha",
+    "accepted_tag_patterns": ["v*-alpha*"],
+    "not_satisfied_by": ["nightly", "stable", "manual workflow intent", "advisory evidence"],
+    "candidate_manifest_field": "release_channel=public-alpha",
+    "disallow_path_filter_downgrade": true,
+    "disallow_manual_downgrade": true,
+    "disallow_missing_gpu_runner_downgrade": true,
+    "disallow_open_world_advisory_only": true,
+    "required_issue_query": {
+      "blocking_labels_any": ["priority:P0", "release blocker"],
+      "alpha_relevant_p1_labels_all": ["priority:P1", "alpha-relevant"],
+      "allowed_classifications": ["blocking", "accepted_alpha_limitation", "post_alpha"],
+      "accepted_limitation_requires_docs_path": true
+    }
+  },
+  "known_limitations_page": "docs/development/known-public-alpha-limitations.md",
+  "requires_gpu_test_snapshot": {
+    "source_glob": "modules/gaussian_splatting/tests/**/*.{h,cpp}",
+    "test_count": 93,
+    "sha256": "704a15f3989517fe04c16d9c6cae847f97d65db3c26324b851cf58eb2d6b04d0",
+    "deferred_tags_any": ["SceneTree", "Importer"],
+    "deferred_count": 29,
+    "new_or_missing_test_policy": "fail-contract-check",
+    "closure_policy": "deferred RequiresGPU coverage blocks #350/#360 closure unless each remaining test has an explicit waiver below"
+  },
+  "deferred_requires_gpu_waivers": [],
+  "gpu_harness_policy": {
+    "script": "tests/ci/run_gpu_harness.py",
+    "blocking_profile": "renderer-release-foundation",
+    "required_batches": [
+      {
+        "name": "CompositorHazard",
+        "minimum_test_cases": 1,
+        "allow_skips": false,
+        "allow_timeout": false,
+        "allow_rid_leaks": false,
+        "reference_artifacts": ["tests/visual_baselines/composite_hazard_256x256.png"]
+      }
+    ],
+    "follow_up_hooks": [
+      "Promote the harness to a release-renderer/core-gpu profile that requires GpuSorting, MemoryStream, Streaming, renderer route/stage diagnostics, and SceneTree/Importer batches once #329 bootstrap work lands.",
+      "Wire release-candidate CI to call run_gpu_harness.py with the blocking profile instead of relying on default advisory batches."
+    ]
+  },
+  "workflow_policy": {
+    "required_workflows": [
+      {
+        "file": ".github/workflows/gaussian_production_gates.yml",
+        "required_for_public_alpha": true,
+        "required_jobs": ["guards", "module-validation"],
+        "must_enforce_readiness": true,
+        "manual_input_may_disable": false,
+        "path_filter_may_disable": false
+      },
+      {
+        "file": ".github/workflows/baseline_qa.yml",
+        "required_for_public_alpha": true,
+        "required_jobs": ["Run GPU harness"],
+        "manual_input_may_disable": false,
+        "path_filter_may_disable": false
+      },
+      {
+        "file": ".github/workflows/release_builds.yml",
+        "required_for_public_alpha": true,
+        "required_jobs": ["build_linux", "build_windows", "publish_release"],
+        "manual_input_may_disable": false,
+        "path_filter_may_disable": false,
+        "linux_only_release_allowed": false,
+        "unmatched_release_files_allowed": false
+      }
+    ],
+    "open_world_proof": {
+      "required_for_public_alpha": true,
+      "advisory_only_allowed": false,
+      "required_artifact_group": "open_world_proof"
+    }
+  },
+  "visual_acceptance": {
+    "tracked_actual_png_allowed": false,
+    "blocking_references": [
+      {
+        "id": "compositor_hazard_256",
+        "path": "tests/visual_baselines/composite_hazard_256x256.png",
+        "required": true
+      }
+    ],
+    "candidate_rules": {
+      "capture_count_min": 1,
+      "capture_reference_match_count_must_equal_capture_count": true,
+      "capture_ssim_min_must_be_non_null": true,
+      "capture_psnr_min_must_be_non_null": true
+    }
+  },
+  "benchmark_acceptance": {
+    "authoritative_public_snapshot": false,
+    "candidate_required_lanes": [
+      "static_baseline",
+      "streaming_corridor",
+      "city_flyover",
+      "instance_storm",
+      "integrity_sentinel",
+      "parity_fidelity"
+    ],
+    "required_fields_non_null": [
+      "lane_id",
+      "commit_sha",
+      "godot_binary_commit",
+      "godot_binary_mtime_utc",
+      "gpu",
+      "driver",
+      "os_build",
+      "render_backend",
+      "avg_fps",
+      "p99_frame_ms",
+      "route_uid",
+      "stage_statuses",
+      "fallback_counters",
+      "queue_pressure",
+      "proof_status"
+    ],
+    "timeout_report_policy": "fail",
+    "gpu_timing_policy": "positive_gpu_time_only_when_gpu_timing_available_otherwise_explicitly_unavailable",
+    "fallback_route_policy": "fail unless lane explicitly allows exact fallback route"
+  },
+  "artifact_requirements": {
+    "required_groups": [
+      "linux_release_archive",
+      "windows_release_archive",
+      "runtime_validation_report",
+      "gpu_harness_report",
+      "production_evidence_summary",
+      "benchmark_suite_report",
+      "compatibility_source_snapshot",
+      "docs_release_acceptance_report",
+      "known_limitations_page",
+      "open_world_proof"
+    ],
+    "each_artifact_requires": ["path", "sha256", "godot_binary_commit", "godot_binary_mtime_utc"]
+  },
+  "references": [
+    "docs/reference/renderer-release-gates.md",
+    "docs/development/known-public-alpha-limitations.md",
+    "docs/performance/index.md",
+    "docs/assets/data/benchmark_latest.json",
+    "tests/visual_baselines/README.md",
+    "tests/runtime/runtime_scenarios.json"
+  ]
+}

--- a/tests/ci/check_renderer_release_gates.py
+++ b/tests/ci/check_renderer_release_gates.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Validate renderer evidence and public-alpha release gate contracts."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import fnmatch
+import hashlib
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = ROOT / "docs" / "reference" / "renderer_release_gate_manifest.json"
+TEST_CASE_RE = re.compile(r'TEST_CASE\("([^"]*\[RequiresGPU\][^"]*)"')
+TAG_RE = re.compile(r"\[([^\]]+)\]")
+
+
+def _load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _repo_path(root: Path, value: str) -> Path:
+    return root / value
+
+
+def _extract_requires_gpu_tests(root: Path) -> list[dict[str, Any]]:
+    tests_root = root / "modules" / "gaussian_splatting" / "tests"
+    tests: list[dict[str, Any]] = []
+    for path in sorted(tests_root.rglob("*")):
+        if path.suffix not in {".h", ".cpp"}:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for match in TEST_CASE_RE.finditer(text):
+            name = match.group(1)
+            tests.append(
+                {
+                    "path": path.relative_to(root).as_posix(),
+                    "line": text[: match.start()].count("\n") + 1,
+                    "name": name,
+                    "tags": TAG_RE.findall(name),
+                }
+            )
+    return tests
+
+
+def _requires_gpu_snapshot(tests: Iterable[dict[str, Any]]) -> tuple[int, str]:
+    rows = [f"{item['path']}\0{item['name']}" for item in tests]
+    payload = "\n".join(rows).encode("utf-8")
+    return len(rows), hashlib.sha256(payload).hexdigest()
+
+
+def _load_gpu_harness_batches(root: Path, script_rel: str) -> dict[str, tuple[str, ...]]:
+    script = _repo_path(root, script_rel)
+    spec = importlib.util.spec_from_file_location("godotgs_gpu_harness_contract", script)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to import {script_rel}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return {batch.name: tuple(batch.filters) for batch in module.BATCHES}
+
+
+def _filter_matches(filter_pattern: str, test_name: str) -> bool:
+    return fnmatch.fnmatchcase(test_name, filter_pattern)
+
+
+def _is_broad_required_filter(filter_pattern: str) -> bool:
+    compact = filter_pattern.replace("*", "").replace("?", "")
+    return compact in {"[RequiresGPU]", "][RequiresGPU]", "RequiresGPU"}
+
+
+def _tracked_actual_pngs(root: Path) -> list[str]:
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "tests/visual_baselines/**/*.actual.png"],
+            cwd=root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return [line for line in result.stdout.splitlines() if line.strip()]
+    except OSError:
+        pass
+    return [p.relative_to(root).as_posix() for p in (root / "tests" / "visual_baselines").rglob("*.actual.png")]
+
+
+def validate_contract(root: Path, manifest: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+
+    if manifest.get("schema_version") != 1:
+        failures.append("manifest schema_version must be 1")
+
+    for ref in manifest.get("references", []):
+        if not _repo_path(root, ref).exists():
+            failures.append(f"reference path missing: {ref}")
+
+    known_limitations = manifest.get("known_limitations_page")
+    if not known_limitations or not _repo_path(root, known_limitations).exists():
+        failures.append("known limitations page is missing")
+
+    predicate = manifest.get("public_alpha_predicate", {})
+    for flag in (
+        "disallow_path_filter_downgrade",
+        "disallow_manual_downgrade",
+        "disallow_missing_gpu_runner_downgrade",
+        "disallow_open_world_advisory_only",
+    ):
+        if predicate.get(flag) is not True:
+            failures.append(f"public_alpha_predicate.{flag} must be true")
+
+    tests = _extract_requires_gpu_tests(root)
+    count, digest = _requires_gpu_snapshot(tests)
+    snapshot = manifest.get("requires_gpu_test_snapshot", {})
+    if count != snapshot.get("test_count") or digest != snapshot.get("sha256"):
+        failures.append(
+            "RequiresGPU test snapshot drift: "
+            f"current count={count} sha256={digest}, "
+            f"manifest count={snapshot.get('test_count')} sha256={snapshot.get('sha256')}"
+        )
+
+    deferred_tags = set(snapshot.get("deferred_tags_any", []))
+    deferred = [item for item in tests if deferred_tags.intersection(item["tags"])]
+    if len(deferred) != snapshot.get("deferred_count"):
+        failures.append(
+            f"deferred RequiresGPU count drift: current={len(deferred)} "
+            f"manifest={snapshot.get('deferred_count')}"
+        )
+    if deferred and snapshot.get("closure_policy", "").find("blocks") < 0:
+        failures.append("deferred RequiresGPU tests must be declared closure blockers")
+
+    for waiver in manifest.get("deferred_requires_gpu_waivers", []):
+        for field in ("test_name", "issue_url", "owner", "expires_utc", "risk", "mitigation", "docs_path"):
+            if not waiver.get(field):
+                failures.append(f"deferred waiver missing {field}: {waiver!r}")
+        docs_path = waiver.get("docs_path")
+        if docs_path and not _repo_path(root, docs_path).exists():
+            failures.append(f"deferred waiver docs_path missing: {docs_path}")
+
+    gpu_policy = manifest.get("gpu_harness_policy", {})
+    try:
+        batches = _load_gpu_harness_batches(root, gpu_policy.get("script", ""))
+    except Exception as exc:
+        failures.append(f"unable to load GPU harness batches: {exc}")
+        batches = {}
+    test_names = [item["name"] for item in tests]
+    for batch in gpu_policy.get("required_batches", []):
+        name = batch.get("name")
+        filters = batches.get(name)
+        if not filters:
+            failures.append(f"required GPU batch missing from harness: {name}")
+            continue
+        for pattern in filters:
+            if _is_broad_required_filter(pattern):
+                failures.append(f"required GPU batch {name} uses broad filter: {pattern}")
+        matched = [case for case in test_names if any(_filter_matches(pattern, case) for pattern in filters)]
+        if len(matched) < int(batch.get("minimum_test_cases", 1)):
+            failures.append(f"required GPU batch {name} matches {len(matched)} tests")
+        for ref in batch.get("reference_artifacts", []):
+            if not _repo_path(root, ref).exists():
+                failures.append(f"required GPU batch {name} reference missing: {ref}")
+
+    visual = manifest.get("visual_acceptance", {})
+    if visual.get("tracked_actual_png_allowed") is False:
+        tracked_actual = _tracked_actual_pngs(root)
+        if tracked_actual:
+            failures.append(f"tracked .actual.png artifacts are forbidden: {tracked_actual}")
+    for reference in visual.get("blocking_references", []):
+        if reference.get("required") and not _repo_path(root, reference.get("path", "")).exists():
+            failures.append(f"blocking visual reference missing: {reference.get('path')}")
+
+    for workflow in manifest.get("workflow_policy", {}).get("required_workflows", []):
+        workflow_file = workflow.get("file", "")
+        text_path = _repo_path(root, workflow_file)
+        if not text_path.exists():
+            failures.append(f"required workflow missing: {workflow_file}")
+            continue
+        text = text_path.read_text(encoding="utf-8", errors="ignore")
+        for marker in workflow.get("required_jobs", []):
+            if marker not in text:
+                failures.append(f"required workflow marker {marker!r} missing from {workflow_file}")
+        if workflow.get("manual_input_may_disable") is not False:
+            failures.append(f"{workflow_file} must not allow manual public-alpha downgrade")
+        if workflow.get("path_filter_may_disable") is not False:
+            failures.append(f"{workflow_file} must not allow path-filter public-alpha downgrade")
+
+    return failures
+
+
+def _find_lane(rows: Iterable[dict[str, Any]], lane_id: str) -> dict[str, Any] | None:
+    for row in rows:
+        if row.get("lane_id") == lane_id:
+            return row
+    return None
+
+
+def _rows_from_report(report: Any) -> list[dict[str, Any]]:
+    if isinstance(report, list):
+        return [row for row in report if isinstance(row, dict)]
+    if isinstance(report, dict):
+        for key in ("lanes", "results", "rows"):
+            value = report.get(key)
+            if isinstance(value, list):
+                return [row for row in value if isinstance(row, dict)]
+    return []
+
+
+def _parse_time(value: str) -> _dt.datetime | None:
+    try:
+        return _dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, ValueError):
+        return None
+
+
+def validate_candidate(
+    root: Path,
+    manifest: dict[str, Any],
+    evidence: dict[str, Any],
+    issues: list[dict[str, Any]] | None = None,
+) -> list[str]:
+    failures = validate_contract(root, manifest)
+
+    known_limitations = manifest.get("known_limitations_page")
+    if known_limitations and not _repo_path(root, known_limitations).exists():
+        failures.append("candidate known limitations page is missing")
+
+    tests = _extract_requires_gpu_tests(root)
+    deferred_tags = set(manifest.get("requires_gpu_test_snapshot", {}).get("deferred_tags_any", []))
+    deferred = [item for item in tests if deferred_tags.intersection(item["tags"])]
+    waivers = manifest.get("deferred_requires_gpu_waivers", [])
+    if len(waivers) < len(deferred):
+        failures.append(
+            f"candidate has {len(deferred)} deferred RequiresGPU tests but only {len(waivers)} explicit waivers"
+        )
+
+    artifacts = evidence.get("artifacts", {})
+    required_groups = manifest.get("artifact_requirements", {}).get("required_groups", [])
+    required_fields = manifest.get("artifact_requirements", {}).get("each_artifact_requires", [])
+    commit = evidence.get("commit")
+    commit_time = _parse_time(evidence.get("commit_time_utc", ""))
+    for group in required_groups:
+        artifact = artifacts.get(group)
+        if not isinstance(artifact, dict):
+            failures.append(f"candidate artifact group missing: {group}")
+            continue
+        for field in required_fields:
+            if not artifact.get(field):
+                failures.append(f"candidate artifact {group} missing {field}")
+        if commit and artifact.get("godot_binary_commit") != commit:
+            failures.append(f"candidate artifact {group} built from stale commit {artifact.get('godot_binary_commit')}")
+        mtime = _parse_time(artifact.get("godot_binary_mtime_utc", ""))
+        if commit_time and mtime and mtime < commit_time:
+            failures.append(f"candidate artifact {group} binary predates commit")
+
+    gpu_report_path = evidence.get("gpu_harness_report")
+    if gpu_report_path:
+        report = _load_json(_repo_path(root, gpu_report_path))
+        batches = {batch.get("name"): batch for batch in report.get("batches", [])}
+        for required in manifest.get("gpu_harness_policy", {}).get("required_batches", []):
+            name = required.get("name")
+            batch = batches.get(name)
+            if not batch:
+                failures.append(f"candidate GPU report missing required batch: {name}")
+                continue
+            cases = batch.get("test_cases", {})
+            assertions = batch.get("assertions", {})
+            if cases.get("total", 0) < int(required.get("minimum_test_cases", 1)):
+                failures.append(f"candidate GPU batch {name} matched zero/too few tests")
+            if batch.get("timed_out"):
+                failures.append(f"candidate GPU batch {name} timed out")
+            if batch.get("summary_parse_ok") is not True:
+                failures.append(f"candidate GPU batch {name} summary did not parse")
+            if cases.get("failed", 0) or assertions.get("failed", 0) or batch.get("rc", 0) != 0:
+                failures.append(f"candidate GPU batch {name} failed")
+            if not required.get("allow_skips", False) and cases.get("skipped", 0):
+                failures.append(f"candidate GPU batch {name} skipped tests")
+            if not required.get("allow_rid_leaks", False) and batch.get("rid_leak_bytes", 0):
+                failures.append(f"candidate GPU batch {name} reported RID leaks")
+    else:
+        failures.append("candidate evidence missing gpu_harness_report")
+
+    benchmark_report_path = evidence.get("benchmark_report")
+    if benchmark_report_path:
+        rows = _rows_from_report(_load_json(_repo_path(root, benchmark_report_path)))
+        required_non_null = manifest.get("benchmark_acceptance", {}).get("required_fields_non_null", [])
+        visual_rules = manifest.get("visual_acceptance", {}).get("candidate_rules", {})
+        for lane_id in manifest.get("benchmark_acceptance", {}).get("candidate_required_lanes", []):
+            row = _find_lane(rows, lane_id)
+            if row is None:
+                failures.append(f"candidate benchmark lane missing: {lane_id}")
+                continue
+            if row.get("timed_out"):
+                failures.append(f"candidate benchmark lane timed out: {lane_id}")
+            for field in required_non_null:
+                if row.get(field) is None:
+                    failures.append(f"candidate benchmark lane {lane_id} has null/missing {field}")
+            if row.get("capture_count", 0) < visual_rules.get("capture_count_min", 1):
+                failures.append(f"candidate benchmark lane {lane_id} has no visual captures")
+            if row.get("capture_reference_match_count") != row.get("capture_count"):
+                failures.append(f"candidate benchmark lane {lane_id} did not match all references")
+            if row.get("capture_ssim_min") is None:
+                failures.append(f"candidate benchmark lane {lane_id} has null capture_ssim_min")
+            if row.get("capture_psnr_min") is None:
+                failures.append(f"candidate benchmark lane {lane_id} has null capture_psnr_min")
+            gpu_time = row.get("gpu_time_frame_ms")
+            gpu_available = row.get("gpu_timing_available")
+            if gpu_available is True and (gpu_time is None or gpu_time <= 0):
+                failures.append(f"candidate benchmark lane {lane_id} has invalid GPU time")
+            if gpu_available is not True and row.get("gpu_timing_source") != "unavailable":
+                failures.append(f"candidate benchmark lane {lane_id} lacks explicit GPU timing unavailability")
+            if row.get("cpu_fallback_route") and not row.get("fallback_route_allowed"):
+                failures.append(f"candidate benchmark lane {lane_id} used unallowed CPU/fallback route")
+    else:
+        failures.append("candidate evidence missing benchmark_report")
+
+    if issues is not None:
+        policy = manifest.get("public_alpha_predicate", {}).get("required_issue_query", {})
+        blocking_any = set(policy.get("blocking_labels_any", []))
+        alpha_p1_all = set(policy.get("alpha_relevant_p1_labels_all", []))
+        classifications = evidence.get("issue_classifications", {})
+        for issue in issues:
+            if issue.get("state", "OPEN").upper() not in {"OPEN", "open".upper()}:
+                continue
+            labels = {
+                label.get("name", label) if isinstance(label, dict) else label
+                for label in issue.get("labels", [])
+            }
+            relevant = bool(blocking_any.intersection(labels)) or alpha_p1_all.issubset(labels)
+            if not relevant:
+                continue
+            number = str(issue.get("number"))
+            classification = classifications.get(number)
+            if not classification:
+                failures.append(f"candidate issue #{number} missing alpha classification")
+                continue
+            status = classification.get("status")
+            if status == "blocking":
+                failures.append(f"candidate issue #{number} is still blocking")
+            elif status == "accepted_alpha_limitation":
+                docs_path = classification.get("docs_path")
+                if not docs_path or not _repo_path(root, docs_path).exists():
+                    failures.append(f"candidate issue #{number} accepted limitation missing docs_path")
+            elif status == "post_alpha":
+                if not classification.get("rationale"):
+                    failures.append(f"candidate issue #{number} post_alpha classification missing rationale")
+            else:
+                failures.append(f"candidate issue #{number} has invalid classification {status!r}")
+
+    return failures
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=("contract", "candidate"), default="contract")
+    parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
+    parser.add_argument("--candidate-evidence", default=None)
+    parser.add_argument("--issues-json", default=None)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    manifest_path = Path(args.manifest).resolve()
+    root = manifest_path.parents[2]
+    manifest = _load_json(manifest_path)
+
+    if args.mode == "contract":
+        failures = validate_contract(root, manifest)
+    else:
+        if not args.candidate_evidence:
+            print("--candidate-evidence is required in candidate mode", file=sys.stderr)
+            return 2
+        evidence = _load_json(Path(args.candidate_evidence))
+        issues = _load_json(Path(args.issues_json)) if args.issues_json else None
+        failures = validate_candidate(root, manifest, evidence, issues)
+
+    if failures:
+        print("Renderer release gate check failed:")
+        for failure in failures:
+            print(f" - {failure}")
+        return 1
+
+    print(f"Renderer release gate {args.mode} check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/check_renderer_release_gates.py
+++ b/tests/ci/check_renderer_release_gates.py
@@ -20,6 +20,20 @@ ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST = ROOT / "docs" / "reference" / "renderer_release_gate_manifest.json"
 TEST_CASE_RE = re.compile(r'TEST_CASE\("([^"]*\[RequiresGPU\][^"]*)"')
 TAG_RE = re.compile(r"\[([^\]]+)\]")
+PUBLIC_ALPHA_REQUIRED_FLAGS = (
+    "disallow_path_filter_downgrade",
+    "disallow_manual_downgrade",
+    "disallow_missing_gpu_runner_downgrade",
+    "disallow_open_world_advisory_only",
+)
+UNSUPPORTED_WORKFLOW_CLAIMS = (
+    "must_enforce_readiness",
+    "manual_input_may_disable",
+    "path_filter_may_disable",
+    "linux_only_release_allowed",
+    "unmatched_release_files_allowed",
+)
+EXPECTED_WORKFLOW_ENFORCEMENT_SCOPE = "workflow-presence-and-required-job-markers"
 
 
 def _load_json(path: Path) -> Any:
@@ -83,7 +97,7 @@ def _is_broad_required_filter(filter_pattern: str) -> bool:
 def _tracked_actual_pngs(root: Path) -> list[str]:
     try:
         result = subprocess.run(
-            ["git", "ls-files", "tests/visual_baselines/**/*.actual.png"],
+            ["git", "ls-files", "tests/visual_baselines/*.actual.png", "tests/visual_baselines/**/*.actual.png"],
             cwd=root,
             text=True,
             capture_output=True,
@@ -96,7 +110,15 @@ def _tracked_actual_pngs(root: Path) -> list[str]:
     return [p.relative_to(root).as_posix() for p in (root / "tests" / "visual_baselines").rglob("*.actual.png")]
 
 
-def validate_contract(root: Path, manifest: dict[str, Any]) -> list[str]:
+def _deferred_requires_gpu_tests(
+    manifest: dict[str, Any],
+    tests: Iterable[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    deferred_tags = set(manifest.get("requires_gpu_test_snapshot", {}).get("deferred_tags_any", []))
+    return [item for item in tests if deferred_tags.intersection(item["tags"])]
+
+
+def _validate_manifest_basics(root: Path, manifest: dict[str, Any]) -> list[str]:
     failures: list[str] = []
 
     if manifest.get("schema_version") != 1:
@@ -110,18 +132,25 @@ def validate_contract(root: Path, manifest: dict[str, Any]) -> list[str]:
     if not known_limitations or not _repo_path(root, known_limitations).exists():
         failures.append("known limitations page is missing")
 
+    return failures
+
+
+def _validate_public_alpha_predicate(manifest: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
     predicate = manifest.get("public_alpha_predicate", {})
-    for flag in (
-        "disallow_path_filter_downgrade",
-        "disallow_manual_downgrade",
-        "disallow_missing_gpu_runner_downgrade",
-        "disallow_open_world_advisory_only",
-    ):
+    for flag in PUBLIC_ALPHA_REQUIRED_FLAGS:
         if predicate.get(flag) is not True:
             failures.append(f"public_alpha_predicate.{flag} must be true")
+    return failures
 
-    tests = _extract_requires_gpu_tests(root)
-    count, digest = _requires_gpu_snapshot(tests)
+
+def _validate_requires_gpu_snapshot(
+    manifest: dict[str, Any],
+    tests: Iterable[dict[str, Any]],
+) -> list[str]:
+    failures: list[str] = []
+    test_list = list(tests)
+    count, digest = _requires_gpu_snapshot(test_list)
     snapshot = manifest.get("requires_gpu_test_snapshot", {})
     if count != snapshot.get("test_count") or digest != snapshot.get("sha256"):
         failures.append(
@@ -130,8 +159,7 @@ def validate_contract(root: Path, manifest: dict[str, Any]) -> list[str]:
             f"manifest count={snapshot.get('test_count')} sha256={snapshot.get('sha256')}"
         )
 
-    deferred_tags = set(snapshot.get("deferred_tags_any", []))
-    deferred = [item for item in tests if deferred_tags.intersection(item["tags"])]
+    deferred = _deferred_requires_gpu_tests(manifest, test_list)
     if len(deferred) != snapshot.get("deferred_count"):
         failures.append(
             f"deferred RequiresGPU count drift: current={len(deferred)} "
@@ -139,7 +167,11 @@ def validate_contract(root: Path, manifest: dict[str, Any]) -> list[str]:
         )
     if deferred and snapshot.get("closure_policy", "").find("blocks") < 0:
         failures.append("deferred RequiresGPU tests must be declared closure blockers")
+    return failures
 
+
+def _validate_deferred_requires_gpu_waivers(root: Path, manifest: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
     for waiver in manifest.get("deferred_requires_gpu_waivers", []):
         for field in ("test_name", "issue_url", "owner", "expires_utc", "risk", "mitigation", "docs_path"):
             if not waiver.get(field):
@@ -147,7 +179,61 @@ def validate_contract(root: Path, manifest: dict[str, Any]) -> list[str]:
         docs_path = waiver.get("docs_path")
         if docs_path and not _repo_path(root, docs_path).exists():
             failures.append(f"deferred waiver docs_path missing: {docs_path}")
+    return failures
 
+
+def _required_gpu_batch_filter_failures(name: Any, filters: tuple[str, ...]) -> list[str]:
+    failures: list[str] = []
+    for pattern in filters:
+        if _is_broad_required_filter(pattern):
+            failures.append(f"required GPU batch {name} uses broad filter: {pattern}")
+    return failures
+
+
+def _required_gpu_batch_match_failures(
+    batch: dict[str, Any],
+    name: Any,
+    filters: tuple[str, ...],
+    test_names: list[str],
+) -> list[str]:
+    matched = [case for case in test_names if any(_filter_matches(pattern, case) for pattern in filters)]
+    if len(matched) < int(batch.get("minimum_test_cases", 1)):
+        return [f"required GPU batch {name} matches {len(matched)} tests"]
+    return []
+
+
+def _required_gpu_batch_reference_failures(
+    root: Path,
+    batch: dict[str, Any],
+    name: Any,
+) -> list[str]:
+    failures: list[str] = []
+    for ref in batch.get("reference_artifacts", []):
+        if not _repo_path(root, ref).exists():
+            failures.append(f"required GPU batch {name} reference missing: {ref}")
+    return failures
+
+
+def _validate_required_gpu_batch(
+    root: Path,
+    batch: dict[str, Any],
+    name: Any,
+    filters: tuple[str, ...],
+    test_names: list[str],
+) -> list[str]:
+    failures: list[str] = []
+    failures.extend(_required_gpu_batch_filter_failures(name, filters))
+    failures.extend(_required_gpu_batch_match_failures(batch, name, filters, test_names))
+    failures.extend(_required_gpu_batch_reference_failures(root, batch, name))
+    return failures
+
+
+def _validate_gpu_harness_policy(
+    root: Path,
+    manifest: dict[str, Any],
+    tests: Iterable[dict[str, Any]],
+) -> list[str]:
+    failures: list[str] = []
     gpu_policy = manifest.get("gpu_harness_policy", {})
     try:
         batches = _load_gpu_harness_batches(root, gpu_policy.get("script", ""))
@@ -161,16 +247,12 @@ def validate_contract(root: Path, manifest: dict[str, Any]) -> list[str]:
         if not filters:
             failures.append(f"required GPU batch missing from harness: {name}")
             continue
-        for pattern in filters:
-            if _is_broad_required_filter(pattern):
-                failures.append(f"required GPU batch {name} uses broad filter: {pattern}")
-        matched = [case for case in test_names if any(_filter_matches(pattern, case) for pattern in filters)]
-        if len(matched) < int(batch.get("minimum_test_cases", 1)):
-            failures.append(f"required GPU batch {name} matches {len(matched)} tests")
-        for ref in batch.get("reference_artifacts", []):
-            if not _repo_path(root, ref).exists():
-                failures.append(f"required GPU batch {name} reference missing: {ref}")
+        failures.extend(_validate_required_gpu_batch(root, batch, name, filters, test_names))
+    return failures
 
+
+def _validate_visual_acceptance(root: Path, manifest: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
     visual = manifest.get("visual_acceptance", {})
     if visual.get("tracked_actual_png_allowed") is False:
         tracked_actual = _tracked_actual_pngs(root)
@@ -179,22 +261,53 @@ def validate_contract(root: Path, manifest: dict[str, Any]) -> list[str]:
     for reference in visual.get("blocking_references", []):
         if reference.get("required") and not _repo_path(root, reference.get("path", "")).exists():
             failures.append(f"blocking visual reference missing: {reference.get('path')}")
+    return failures
 
-    for workflow in manifest.get("workflow_policy", {}).get("required_workflows", []):
-        workflow_file = workflow.get("file", "")
-        text_path = _repo_path(root, workflow_file)
-        if not text_path.exists():
-            failures.append(f"required workflow missing: {workflow_file}")
-            continue
-        text = text_path.read_text(encoding="utf-8", errors="ignore")
-        for marker in workflow.get("required_jobs", []):
-            if marker not in text:
-                failures.append(f"required workflow marker {marker!r} missing from {workflow_file}")
-        if workflow.get("manual_input_may_disable") is not False:
-            failures.append(f"{workflow_file} must not allow manual public-alpha downgrade")
-        if workflow.get("path_filter_may_disable") is not False:
-            failures.append(f"{workflow_file} must not allow path-filter public-alpha downgrade")
 
+def _workflow_policy_scope_failures(workflow_policy: dict[str, Any]) -> list[str]:
+    if workflow_policy.get("machine_enforcement_scope") == EXPECTED_WORKFLOW_ENFORCEMENT_SCOPE:
+        return []
+    return [
+        f"workflow_policy.machine_enforcement_scope must be {EXPECTED_WORKFLOW_ENFORCEMENT_SCOPE!r}"
+    ]
+
+
+def _validate_required_workflow(root: Path, workflow: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    workflow_file = workflow.get("file", "")
+    text_path = _repo_path(root, workflow_file)
+    if not text_path.exists():
+        return [f"required workflow missing: {workflow_file}"]
+
+    text = text_path.read_text(encoding="utf-8", errors="ignore")
+    for marker in workflow.get("required_jobs", []):
+        if marker not in text:
+            failures.append(f"required workflow marker {marker!r} missing from {workflow_file}")
+    for claim in UNSUPPORTED_WORKFLOW_CLAIMS:
+        if claim in workflow:
+            failures.append(f"workflow policy claim {claim!r} is not machine-enforced for {workflow_file}")
+    return failures
+
+
+def _validate_workflow_policy(root: Path, manifest: dict[str, Any]) -> list[str]:
+    workflow_policy = manifest.get("workflow_policy", {})
+    failures = _workflow_policy_scope_failures(workflow_policy)
+    for workflow in workflow_policy.get("required_workflows", []):
+        failures.extend(_validate_required_workflow(root, workflow))
+
+    return failures
+
+
+def validate_contract(root: Path, manifest: dict[str, Any]) -> list[str]:
+    tests = _extract_requires_gpu_tests(root)
+    failures: list[str] = []
+    failures.extend(_validate_manifest_basics(root, manifest))
+    failures.extend(_validate_public_alpha_predicate(manifest))
+    failures.extend(_validate_requires_gpu_snapshot(manifest, tests))
+    failures.extend(_validate_deferred_requires_gpu_waivers(root, manifest))
+    failures.extend(_validate_gpu_harness_policy(root, manifest, tests))
+    failures.extend(_validate_visual_acceptance(root, manifest))
+    failures.extend(_validate_workflow_policy(root, manifest))
     return failures
 
 
@@ -216,6 +329,29 @@ def _rows_from_report(report: Any) -> list[dict[str, Any]]:
     return []
 
 
+def _load_candidate_json(root: Path, rel_path: Any, label: str) -> tuple[Any | None, list[str]]:
+    if not rel_path:
+        return None, [f"candidate evidence missing {label}"]
+    path = _repo_path(root, str(rel_path))
+    try:
+        return _load_json(path), []
+    except OSError as exc:
+        return None, [f"candidate {label} unreadable: {rel_path} ({exc})"]
+    except json.JSONDecodeError as exc:
+        return None, [f"candidate {label} invalid JSON: {rel_path} ({exc})"]
+
+
+def _issue_rows_from_snapshot(snapshot: Any) -> list[dict[str, Any]] | None:
+    if isinstance(snapshot, list):
+        return [row for row in snapshot if isinstance(row, dict)]
+    if isinstance(snapshot, dict):
+        for key in ("issues", "nodes", "items", "rows"):
+            value = snapshot.get(key)
+            if isinstance(value, list):
+                return [row for row in value if isinstance(row, dict)]
+    return None
+
+
 def _parse_time(value: str) -> _dt.datetime | None:
     try:
         return _dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
@@ -223,139 +359,550 @@ def _parse_time(value: str) -> _dt.datetime | None:
         return None
 
 
+def _to_utc_aware(value: _dt.datetime) -> _dt.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=_dt.timezone.utc)
+    return value.astimezone(_dt.timezone.utc)
+
+
+def _is_json_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _candidate_selector_failures(manifest: dict[str, Any], evidence: dict[str, Any]) -> list[str]:
+    predicate = manifest.get("public_alpha_predicate", {})
+    expected_channel = predicate.get("channel")
+    tag_patterns = predicate.get("accepted_tag_patterns", [])
+    release_channel = evidence.get("release_channel") or evidence.get("channel")
+    release_tag = evidence.get("release_tag") or evidence.get("tag")
+
+    if _candidate_selector_matches(expected_channel, tag_patterns, release_channel, release_tag):
+        return []
+
+    expected = _candidate_selector_expected(expected_channel, tag_patterns)
+    if release_channel or release_tag:
+        return [
+            "candidate selector is not public-alpha: "
+            f"expected {expected}, got release_channel={release_channel!r} release_tag={release_tag!r}"
+        ]
+    return [f"candidate selector missing: expected {expected}"]
+
+
+def _candidate_selector_matches(
+    expected_channel: Any,
+    tag_patterns: Iterable[Any],
+    release_channel: Any,
+    release_tag: Any,
+) -> bool:
+    if expected_channel and release_channel == expected_channel:
+        return True
+    if release_tag and any(fnmatch.fnmatchcase(str(release_tag), str(pattern)) for pattern in tag_patterns):
+        return True
+    return False
+
+
+def _candidate_selector_expected(expected_channel: Any, tag_patterns: Iterable[Any]) -> str:
+    expected = f"release_channel={expected_channel}"
+    if tag_patterns:
+        expected += f" or release_tag matching {tag_patterns}"
+    return expected
+
+
+def _validate_candidate_deferred_waivers(
+    manifest: dict[str, Any],
+    tests: Iterable[dict[str, Any]],
+) -> list[str]:
+    deferred = _deferred_requires_gpu_tests(manifest, tests)
+    deferred_names = {item["name"] for item in deferred}
+    waivers = manifest.get("deferred_requires_gpu_waivers", [])
+    waiver_counts: dict[Any, int] = {}
+    failures: list[str] = []
+    for waiver in waivers:
+        if not isinstance(waiver, dict):
+            failures.append(f"candidate deferred RequiresGPU waiver must be an object: {waiver!r}")
+            continue
+        test_name = waiver.get("test_name")
+        if not test_name:
+            failures.append(f"candidate deferred RequiresGPU waiver missing test_name: {waiver!r}")
+            continue
+        waiver_counts[test_name] = waiver_counts.get(test_name, 0) + 1
+
+    waiver_names = set(waiver_counts)
+    for name in sorted(deferred_names - waiver_names):
+        failures.append(f"candidate deferred RequiresGPU test missing waiver: {name}")
+    for name in sorted(waiver_names - deferred_names):
+        failures.append(f"candidate deferred RequiresGPU waiver does not match a deferred test: {name}")
+    for name, count in sorted(waiver_counts.items()):
+        if count > 1:
+            failures.append(f"candidate deferred RequiresGPU waiver duplicated for {name}: {count}")
+    return failures
+
+
+def _candidate_commit_metadata_failures(evidence: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    if not evidence.get("commit"):
+        failures.append("candidate evidence missing commit")
+    commit_time_value = evidence.get("commit_time_utc")
+    if not commit_time_value:
+        failures.append("candidate evidence missing commit_time_utc")
+    elif _parse_time(commit_time_value) is None:
+        failures.append(f"candidate evidence has invalid commit_time_utc: {commit_time_value!r}")
+    return failures
+
+
+def _validate_candidate_artifact_group(
+    root: Path,
+    group: Any,
+    artifact: Any,
+    required_fields: Iterable[Any],
+    commit: Any,
+    commit_time: _dt.datetime | None,
+) -> list[str]:
+    failures: list[str] = []
+    if not isinstance(artifact, dict):
+        return [f"candidate artifact group missing: {group}"]
+    failures.extend(_candidate_artifact_required_field_failures(group, artifact, required_fields))
+    failures.extend(_candidate_artifact_integrity_failures(root, group, artifact))
+    failures.extend(_candidate_artifact_commit_failures(group, artifact, commit))
+    failures.extend(_candidate_artifact_mtime_failures(group, artifact, commit_time))
+    return failures
+
+
+def _candidate_artifact_required_field_failures(
+    group: Any,
+    artifact: dict[str, Any],
+    required_fields: Iterable[Any],
+) -> list[str]:
+    failures: list[str] = []
+    for field in required_fields:
+        if not artifact.get(field):
+            failures.append(f"candidate artifact {group} missing {field}")
+    return failures
+
+
+def _candidate_artifact_integrity_failures(
+    root: Path,
+    group: Any,
+    artifact: dict[str, Any],
+) -> list[str]:
+    failures: list[str] = []
+    raw_path = artifact.get("path")
+    if not raw_path:
+        return failures
+
+    artifact_path = _candidate_artifact_path(root, raw_path)
+    if not artifact_path.exists():
+        return [f"candidate artifact {group} path missing: {raw_path}"]
+    if not artifact_path.is_file():
+        return [f"candidate artifact {group} path is not a file: {raw_path}"]
+
+    expected_sha = artifact.get("sha256")
+    if not expected_sha:
+        return failures
+    try:
+        actual_sha = hashlib.sha256(artifact_path.read_bytes()).hexdigest()
+    except OSError as exc:
+        return [f"candidate artifact {group} cannot be read for sha256: {raw_path} ({exc})"]
+    if str(expected_sha).lower() != actual_sha:
+        failures.append(
+            f"candidate artifact {group} sha256 mismatch: "
+            f"expected {expected_sha} got {actual_sha}"
+        )
+    return failures
+
+
+def _candidate_artifact_path(root: Path, raw_path: Any) -> Path:
+    path = Path(str(raw_path))
+    if path.is_absolute():
+        return path
+    return _repo_path(root, path.as_posix())
+
+
+def _candidate_artifact_commit_failures(
+    group: Any,
+    artifact: dict[str, Any],
+    commit: Any,
+) -> list[str]:
+    if commit and artifact.get("godot_binary_commit") != commit:
+        return [f"candidate artifact {group} built from stale commit {artifact.get('godot_binary_commit')}"]
+    return []
+
+
+def _candidate_artifact_mtime_failures(
+    group: Any,
+    artifact: dict[str, Any],
+    commit_time: _dt.datetime | None,
+) -> list[str]:
+    mtime = _parse_time(artifact.get("godot_binary_mtime_utc", ""))
+    if commit_time and mtime and _to_utc_aware(mtime) < _to_utc_aware(commit_time):
+        return [f"candidate artifact {group} binary predates commit"]
+    return []
+
+
+def _validate_candidate_artifacts(root: Path, manifest: dict[str, Any], evidence: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    artifacts = evidence.get("artifacts", {})
+    if not isinstance(artifacts, dict):
+        return ["candidate artifacts must be a JSON object"]
+    required_groups = manifest.get("artifact_requirements", {}).get("required_groups", [])
+    required_fields = manifest.get("artifact_requirements", {}).get("each_artifact_requires", [])
+    commit = evidence.get("commit")
+    commit_time = _parse_time(evidence.get("commit_time_utc", ""))
+
+    for group in required_groups:
+        artifact = artifacts.get(group)
+        failures.extend(_validate_candidate_artifact_group(root, group, artifact, required_fields, commit, commit_time))
+
+    return failures
+
+
+def _candidate_gpu_batch_count_failures(
+    name: Any,
+    cases: dict[str, Any],
+    required: dict[str, Any],
+) -> list[str]:
+    total = cases.get("total", 0)
+    if not _is_json_number(total):
+        return [f"candidate GPU batch {name} test_cases.total must be numeric"]
+    if total < int(required.get("minimum_test_cases", 1)):
+        return [f"candidate GPU batch {name} matched zero/too few tests"]
+    return []
+
+
+def _candidate_gpu_batch_execution_failures(
+    name: Any,
+    batch: dict[str, Any],
+    cases: dict[str, Any],
+    assertions: dict[str, Any],
+    required: dict[str, Any],
+) -> list[str]:
+    failures: list[str] = []
+    if batch.get("timed_out") and not required.get("allow_timeout", False):
+        failures.append(f"candidate GPU batch {name} timed out")
+    if batch.get("summary_parse_ok") is not True:
+        failures.append(f"candidate GPU batch {name} summary did not parse")
+
+    case_failed = cases.get("failed", 0)
+    assertion_failed = assertions.get("failed", 0)
+    rc = batch.get("rc", 0)
+    invalid_counters = False
+    if not _is_json_number(case_failed):
+        failures.append(f"candidate GPU batch {name} test_cases.failed must be numeric")
+        invalid_counters = True
+    if not _is_json_number(assertion_failed):
+        failures.append(f"candidate GPU batch {name} assertions.failed must be numeric")
+        invalid_counters = True
+    if not _is_json_number(rc):
+        failures.append(f"candidate GPU batch {name} rc must be numeric")
+        invalid_counters = True
+    if not invalid_counters and (case_failed or assertion_failed or rc != 0):
+        failures.append(f"candidate GPU batch {name} failed")
+    return failures
+
+
+def _candidate_gpu_batch_policy_failures(
+    name: Any,
+    batch: dict[str, Any],
+    cases: dict[str, Any],
+    required: dict[str, Any],
+) -> list[str]:
+    failures: list[str] = []
+    skipped = cases.get("skipped", 0)
+    if not _is_json_number(skipped):
+        failures.append(f"candidate GPU batch {name} test_cases.skipped must be numeric")
+    elif not required.get("allow_skips", False) and skipped:
+        failures.append(f"candidate GPU batch {name} skipped tests")
+    rid_leak_bytes = batch.get("rid_leak_bytes", 0)
+    if not _is_json_number(rid_leak_bytes):
+        failures.append(f"candidate GPU batch {name} rid_leak_bytes must be numeric")
+    elif not required.get("allow_rid_leaks", False) and rid_leak_bytes:
+        failures.append(f"candidate GPU batch {name} reported RID leaks")
+    return failures
+
+
+def _validate_candidate_gpu_batch(
+    name: Any,
+    batch: dict[str, Any],
+    required: dict[str, Any],
+) -> list[str]:
+    failures: list[str] = []
+    cases = batch.get("test_cases", {})
+    assertions = batch.get("assertions", {})
+    if not isinstance(cases, dict):
+        failures.append(f"candidate GPU batch {name} test_cases must be a JSON object")
+        cases = {}
+    if not isinstance(assertions, dict):
+        failures.append(f"candidate GPU batch {name} assertions must be a JSON object")
+        assertions = {}
+    failures.extend(_candidate_gpu_batch_count_failures(name, cases, required))
+    failures.extend(_candidate_gpu_batch_execution_failures(name, batch, cases, assertions, required))
+    failures.extend(_candidate_gpu_batch_policy_failures(name, batch, cases, required))
+    return failures
+
+
+def _validate_candidate_gpu_report(root: Path, manifest: dict[str, Any], evidence: dict[str, Any]) -> list[str]:
+    gpu_report_path = evidence.get("gpu_harness_report")
+    report, load_failures = _load_candidate_json(root, gpu_report_path, "gpu_harness_report")
+    if load_failures:
+        return load_failures
+    if not isinstance(report, dict):
+        return [f"candidate gpu_harness_report must be a JSON object: {gpu_report_path}"]
+
+    failures: list[str] = []
+    batch_rows = report.get("batches", [])
+    if not isinstance(batch_rows, list):
+        failures.append(f"candidate GPU report batches must be a list: {gpu_report_path}")
+        batch_rows = []
+
+    batches: dict[Any, dict[str, Any]] = {}
+    for index, batch in enumerate(batch_rows):
+        if not isinstance(batch, dict):
+            failures.append(f"candidate GPU report batch at index {index} must be a JSON object: {gpu_report_path}")
+            continue
+        batch_name = batch.get("name")
+        if not isinstance(batch_name, str):
+            failures.append(f"candidate GPU report batch at index {index} name must be a string: {gpu_report_path}")
+            continue
+        batches[batch_name] = batch
+    for required in manifest.get("gpu_harness_policy", {}).get("required_batches", []):
+        name = required.get("name")
+        batch = batches.get(name)
+        if not batch:
+            failures.append(f"candidate GPU report missing required batch: {name}")
+            continue
+        failures.extend(_validate_candidate_gpu_batch(name, batch, required))
+    return failures
+
+
+def _candidate_lane_timeout_failures(lane_id: str, row: dict[str, Any]) -> list[str]:
+    if row.get("timed_out"):
+        return [f"candidate benchmark lane timed out: {lane_id}"]
+    return []
+
+
+def _candidate_lane_required_field_failures(
+    lane_id: str,
+    row: dict[str, Any],
+    required_non_null: Iterable[str],
+) -> list[str]:
+    failures: list[str] = []
+    for field in required_non_null:
+        if row.get(field) is None:
+            failures.append(f"candidate benchmark lane {lane_id} has null/missing {field}")
+    return failures
+
+
+def _candidate_lane_visual_failures(
+    lane_id: str,
+    row: dict[str, Any],
+    visual_rules: dict[str, Any],
+) -> list[str]:
+    failures: list[str] = []
+    capture_count = row.get("capture_count", 0)
+    capture_reference_match_count = row.get("capture_reference_match_count")
+    capture_count_valid = _is_json_number(capture_count)
+    capture_match_valid = _is_json_number(capture_reference_match_count)
+    if not capture_count_valid:
+        failures.append(f"candidate benchmark lane {lane_id} capture_count must be numeric")
+    elif capture_count < visual_rules.get("capture_count_min", 1):
+        failures.append(f"candidate benchmark lane {lane_id} has no visual captures")
+    if not capture_match_valid:
+        failures.append(f"candidate benchmark lane {lane_id} capture_reference_match_count must be numeric")
+    elif capture_count_valid and capture_reference_match_count != capture_count:
+        failures.append(f"candidate benchmark lane {lane_id} did not match all references")
+    if row.get("capture_ssim_min") is None:
+        failures.append(f"candidate benchmark lane {lane_id} has null capture_ssim_min")
+    if row.get("capture_psnr_min") is None:
+        failures.append(f"candidate benchmark lane {lane_id} has null capture_psnr_min")
+    return failures
+
+
+def _candidate_lane_gpu_timing_failures(lane_id: str, row: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    gpu_time = row.get("gpu_time_frame_ms")
+    gpu_available = row.get("gpu_timing_available")
+    gpu_time_is_number = isinstance(gpu_time, (int, float)) and not isinstance(gpu_time, bool)
+    if gpu_available is True and (not gpu_time_is_number or gpu_time <= 0):
+        failures.append(f"candidate benchmark lane {lane_id} has invalid GPU time")
+    if gpu_available is not True and row.get("gpu_timing_source") != "unavailable":
+        failures.append(f"candidate benchmark lane {lane_id} lacks explicit GPU timing unavailability")
+    return failures
+
+
+def _candidate_lane_route_failures(lane_id: str, row: dict[str, Any]) -> list[str]:
+    if row.get("cpu_fallback_route") and not row.get("fallback_route_allowed"):
+        return [f"candidate benchmark lane {lane_id} used unallowed CPU/fallback route"]
+    return []
+
+
+def _validate_candidate_benchmark_lane(
+    lane_id: str,
+    row: dict[str, Any],
+    required_non_null: Iterable[str],
+    visual_rules: dict[str, Any],
+) -> list[str]:
+    failures: list[str] = []
+    failures.extend(_candidate_lane_timeout_failures(lane_id, row))
+    failures.extend(_candidate_lane_required_field_failures(lane_id, row, required_non_null))
+    failures.extend(_candidate_lane_visual_failures(lane_id, row, visual_rules))
+    failures.extend(_candidate_lane_gpu_timing_failures(lane_id, row))
+    failures.extend(_candidate_lane_route_failures(lane_id, row))
+    return failures
+
+
+def _validate_candidate_benchmark_report(root: Path, manifest: dict[str, Any], evidence: dict[str, Any]) -> list[str]:
+    benchmark_report_path = evidence.get("benchmark_report")
+    report, load_failures = _load_candidate_json(root, benchmark_report_path, "benchmark_report")
+    if load_failures:
+        return load_failures
+
+    failures: list[str] = []
+    rows = _rows_from_report(report)
+    required_non_null = manifest.get("benchmark_acceptance", {}).get("required_fields_non_null", [])
+    visual_rules = manifest.get("visual_acceptance", {}).get("candidate_rules", {})
+    for lane_id in manifest.get("benchmark_acceptance", {}).get("candidate_required_lanes", []):
+        row = _find_lane(rows, lane_id)
+        if row is None:
+            failures.append(f"candidate benchmark lane missing: {lane_id}")
+            continue
+        failures.extend(_validate_candidate_benchmark_lane(lane_id, row, required_non_null, visual_rules))
+    return failures
+
+
+def _candidate_issue_rows(evidence: dict[str, Any], issues: Any | None) -> list[dict[str, Any]] | None:
+    issue_rows = _issue_rows_from_snapshot(issues)
+    if issue_rows is not None:
+        return issue_rows
+    return _issue_rows_from_snapshot(evidence.get("issue_snapshot", evidence.get("issues", evidence.get("open_issues"))))
+
+
+def _candidate_issue_label_names(issue: dict[str, Any]) -> set[Any]:
+    return {
+        label.get("name", label) if isinstance(label, dict) else label
+        for label in issue.get("labels", [])
+    }
+
+
+def _candidate_issue_is_relevant(policy: dict[str, Any], labels: set[Any]) -> bool:
+    blocking_any = set(policy.get("blocking_labels_any", []))
+    alpha_p1_all = set(policy.get("alpha_relevant_p1_labels_all", []))
+    return bool(blocking_any.intersection(labels)) or alpha_p1_all.issubset(labels)
+
+
+def _validate_candidate_issue_classification(
+    root: Path,
+    manifest: dict[str, Any],
+    number: str,
+    classification: Any,
+) -> list[str]:
+    if not classification:
+        return [f"candidate issue #{number} missing alpha classification"]
+    if not isinstance(classification, dict):
+        return [f"candidate issue #{number} alpha classification must be a JSON object"]
+
+    status = classification.get("status")
+    handlers = {
+        "blocking": _candidate_issue_blocking_failures,
+        "accepted_alpha_limitation": _candidate_issue_accepted_limitation_failures,
+        "post_alpha": _candidate_issue_post_alpha_failures,
+    }
+    handler = handlers.get(status)
+    if handler:
+        return handler(root, manifest, number, classification)
+    return [f"candidate issue #{number} has invalid classification {status!r}"]
+
+
+def _candidate_issue_blocking_failures(
+    _root: Path,
+    _manifest: dict[str, Any],
+    number: str,
+    _classification: dict[str, Any],
+) -> list[str]:
+    return [f"candidate issue #{number} is still blocking"]
+
+
+def _candidate_issue_accepted_limitation_failures(
+    root: Path,
+    manifest: dict[str, Any],
+    number: str,
+    classification: dict[str, Any],
+) -> list[str]:
+    docs_path = classification.get("docs_path")
+    known_limitations = manifest.get("known_limitations_page")
+    if not docs_path:
+        return [f"candidate issue #{number} accepted limitation missing docs_path"]
+    if docs_path != known_limitations:
+        return [
+            f"candidate issue #{number} accepted limitation must use known_limitations_page "
+            f"{known_limitations!r}, got {docs_path!r}"
+        ]
+    if not _repo_path(root, docs_path).exists():
+        return [f"candidate issue #{number} accepted limitation missing docs_path"]
+    return []
+
+
+def _candidate_issue_post_alpha_failures(
+    _root: Path,
+    _manifest: dict[str, Any],
+    number: str,
+    classification: dict[str, Any],
+) -> list[str]:
+    if not classification.get("rationale"):
+        return [f"candidate issue #{number} post_alpha classification missing rationale"]
+    return []
+
+
+def _validate_candidate_issues(
+    root: Path,
+    manifest: dict[str, Any],
+    evidence: dict[str, Any],
+    issues: Any | None,
+) -> list[str]:
+    issue_rows = _candidate_issue_rows(evidence, issues)
+    if issue_rows is None:
+        return ["candidate issue snapshot missing: pass --issues-json or embed issue_snapshot/issues"]
+
+    failures: list[str] = []
+    policy = manifest.get("public_alpha_predicate", {}).get("required_issue_query", {})
+    classifications = evidence.get("issue_classifications", {})
+    if not isinstance(classifications, dict):
+        return ["candidate issue_classifications must be a JSON object"]
+    for issue in issue_rows:
+        if issue.get("state", "OPEN").upper() not in {"OPEN", "open".upper()}:
+            continue
+        labels = _candidate_issue_label_names(issue)
+        if not _candidate_issue_is_relevant(policy, labels):
+            continue
+        number = str(issue.get("number"))
+        classification = classifications.get(number)
+        failures.extend(_validate_candidate_issue_classification(root, manifest, number, classification))
+    return failures
+
+
 def validate_candidate(
     root: Path,
     manifest: dict[str, Any],
     evidence: dict[str, Any],
-    issues: list[dict[str, Any]] | None = None,
+    issues: Any | None = None,
 ) -> list[str]:
     failures = validate_contract(root, manifest)
+    if not isinstance(evidence, dict):
+        failures.append("candidate evidence must be a JSON object")
+        return failures
+
+    failures.extend(_candidate_selector_failures(manifest, evidence))
+    failures.extend(_candidate_commit_metadata_failures(evidence))
 
     known_limitations = manifest.get("known_limitations_page")
     if known_limitations and not _repo_path(root, known_limitations).exists():
         failures.append("candidate known limitations page is missing")
 
     tests = _extract_requires_gpu_tests(root)
-    deferred_tags = set(manifest.get("requires_gpu_test_snapshot", {}).get("deferred_tags_any", []))
-    deferred = [item for item in tests if deferred_tags.intersection(item["tags"])]
-    waivers = manifest.get("deferred_requires_gpu_waivers", [])
-    if len(waivers) < len(deferred):
-        failures.append(
-            f"candidate has {len(deferred)} deferred RequiresGPU tests but only {len(waivers)} explicit waivers"
-        )
-
-    artifacts = evidence.get("artifacts", {})
-    required_groups = manifest.get("artifact_requirements", {}).get("required_groups", [])
-    required_fields = manifest.get("artifact_requirements", {}).get("each_artifact_requires", [])
-    commit = evidence.get("commit")
-    commit_time = _parse_time(evidence.get("commit_time_utc", ""))
-    for group in required_groups:
-        artifact = artifacts.get(group)
-        if not isinstance(artifact, dict):
-            failures.append(f"candidate artifact group missing: {group}")
-            continue
-        for field in required_fields:
-            if not artifact.get(field):
-                failures.append(f"candidate artifact {group} missing {field}")
-        if commit and artifact.get("godot_binary_commit") != commit:
-            failures.append(f"candidate artifact {group} built from stale commit {artifact.get('godot_binary_commit')}")
-        mtime = _parse_time(artifact.get("godot_binary_mtime_utc", ""))
-        if commit_time and mtime and mtime < commit_time:
-            failures.append(f"candidate artifact {group} binary predates commit")
-
-    gpu_report_path = evidence.get("gpu_harness_report")
-    if gpu_report_path:
-        report = _load_json(_repo_path(root, gpu_report_path))
-        batches = {batch.get("name"): batch for batch in report.get("batches", [])}
-        for required in manifest.get("gpu_harness_policy", {}).get("required_batches", []):
-            name = required.get("name")
-            batch = batches.get(name)
-            if not batch:
-                failures.append(f"candidate GPU report missing required batch: {name}")
-                continue
-            cases = batch.get("test_cases", {})
-            assertions = batch.get("assertions", {})
-            if cases.get("total", 0) < int(required.get("minimum_test_cases", 1)):
-                failures.append(f"candidate GPU batch {name} matched zero/too few tests")
-            if batch.get("timed_out"):
-                failures.append(f"candidate GPU batch {name} timed out")
-            if batch.get("summary_parse_ok") is not True:
-                failures.append(f"candidate GPU batch {name} summary did not parse")
-            if cases.get("failed", 0) or assertions.get("failed", 0) or batch.get("rc", 0) != 0:
-                failures.append(f"candidate GPU batch {name} failed")
-            if not required.get("allow_skips", False) and cases.get("skipped", 0):
-                failures.append(f"candidate GPU batch {name} skipped tests")
-            if not required.get("allow_rid_leaks", False) and batch.get("rid_leak_bytes", 0):
-                failures.append(f"candidate GPU batch {name} reported RID leaks")
-    else:
-        failures.append("candidate evidence missing gpu_harness_report")
-
-    benchmark_report_path = evidence.get("benchmark_report")
-    if benchmark_report_path:
-        rows = _rows_from_report(_load_json(_repo_path(root, benchmark_report_path)))
-        required_non_null = manifest.get("benchmark_acceptance", {}).get("required_fields_non_null", [])
-        visual_rules = manifest.get("visual_acceptance", {}).get("candidate_rules", {})
-        for lane_id in manifest.get("benchmark_acceptance", {}).get("candidate_required_lanes", []):
-            row = _find_lane(rows, lane_id)
-            if row is None:
-                failures.append(f"candidate benchmark lane missing: {lane_id}")
-                continue
-            if row.get("timed_out"):
-                failures.append(f"candidate benchmark lane timed out: {lane_id}")
-            for field in required_non_null:
-                if row.get(field) is None:
-                    failures.append(f"candidate benchmark lane {lane_id} has null/missing {field}")
-            if row.get("capture_count", 0) < visual_rules.get("capture_count_min", 1):
-                failures.append(f"candidate benchmark lane {lane_id} has no visual captures")
-            if row.get("capture_reference_match_count") != row.get("capture_count"):
-                failures.append(f"candidate benchmark lane {lane_id} did not match all references")
-            if row.get("capture_ssim_min") is None:
-                failures.append(f"candidate benchmark lane {lane_id} has null capture_ssim_min")
-            if row.get("capture_psnr_min") is None:
-                failures.append(f"candidate benchmark lane {lane_id} has null capture_psnr_min")
-            gpu_time = row.get("gpu_time_frame_ms")
-            gpu_available = row.get("gpu_timing_available")
-            if gpu_available is True and (gpu_time is None or gpu_time <= 0):
-                failures.append(f"candidate benchmark lane {lane_id} has invalid GPU time")
-            if gpu_available is not True and row.get("gpu_timing_source") != "unavailable":
-                failures.append(f"candidate benchmark lane {lane_id} lacks explicit GPU timing unavailability")
-            if row.get("cpu_fallback_route") and not row.get("fallback_route_allowed"):
-                failures.append(f"candidate benchmark lane {lane_id} used unallowed CPU/fallback route")
-    else:
-        failures.append("candidate evidence missing benchmark_report")
-
-    if issues is not None:
-        policy = manifest.get("public_alpha_predicate", {}).get("required_issue_query", {})
-        blocking_any = set(policy.get("blocking_labels_any", []))
-        alpha_p1_all = set(policy.get("alpha_relevant_p1_labels_all", []))
-        classifications = evidence.get("issue_classifications", {})
-        for issue in issues:
-            if issue.get("state", "OPEN").upper() not in {"OPEN", "open".upper()}:
-                continue
-            labels = {
-                label.get("name", label) if isinstance(label, dict) else label
-                for label in issue.get("labels", [])
-            }
-            relevant = bool(blocking_any.intersection(labels)) or alpha_p1_all.issubset(labels)
-            if not relevant:
-                continue
-            number = str(issue.get("number"))
-            classification = classifications.get(number)
-            if not classification:
-                failures.append(f"candidate issue #{number} missing alpha classification")
-                continue
-            status = classification.get("status")
-            if status == "blocking":
-                failures.append(f"candidate issue #{number} is still blocking")
-            elif status == "accepted_alpha_limitation":
-                docs_path = classification.get("docs_path")
-                if not docs_path or not _repo_path(root, docs_path).exists():
-                    failures.append(f"candidate issue #{number} accepted limitation missing docs_path")
-            elif status == "post_alpha":
-                if not classification.get("rationale"):
-                    failures.append(f"candidate issue #{number} post_alpha classification missing rationale")
-            else:
-                failures.append(f"candidate issue #{number} has invalid classification {status!r}")
+    failures.extend(_validate_candidate_deferred_waivers(manifest, tests))
+    failures.extend(_validate_candidate_artifacts(root, manifest, evidence))
+    failures.extend(_validate_candidate_gpu_report(root, manifest, evidence))
+    failures.extend(_validate_candidate_benchmark_report(root, manifest, evidence))
+    failures.extend(_validate_candidate_issues(root, manifest, evidence, issues))
 
     return failures
 

--- a/tests/ci/test_renderer_release_gates.py
+++ b/tests/ci/test_renderer_release_gates.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Unit tests for renderer release gate checker."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "tests" / "ci" / "check_renderer_release_gates.py"
+spec = importlib.util.spec_from_file_location("check_renderer_release_gates", SCRIPT)
+assert spec and spec.loader
+checker = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(checker)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _base_manifest(root: Path) -> dict[str, Any]:
+    _write(
+        root / "modules/gaussian_splatting/tests/test_gpu.h",
+        'TEST_CASE("[GaussianSplatting][RequiresGPU][HazardRepro] Smoke") {}\n',
+    )
+    tests = checker._extract_requires_gpu_tests(root)
+    count, digest = checker._requires_gpu_snapshot(tests)
+    for rel in (
+        "docs/reference/renderer-release-gates.md",
+        "docs/development/known-public-alpha-limitations.md",
+        "docs/performance/index.md",
+        "docs/assets/data/benchmark_latest.json",
+        "tests/visual_baselines/README.md",
+        "tests/runtime/runtime_scenarios.json",
+        "tests/visual_baselines/composite_hazard_256x256.png",
+        ".github/workflows/gaussian_production_gates.yml",
+        ".github/workflows/baseline_qa.yml",
+        ".github/workflows/release_builds.yml",
+    ):
+        _write(root / rel, "guards\nmodule-validation\nRun GPU harness\nbuild_linux\nbuild_windows\npublish_release\n")
+    _write(
+        root / "tests/ci/run_gpu_harness.py",
+        "from dataclasses import dataclass\n"
+        "@dataclass(frozen=True)\n"
+        "class BatchSpec:\n"
+        "    name: str\n"
+        "    filters: tuple[str, ...]\n"
+        "BATCHES = (BatchSpec('CompositorHazard', ('*HazardRepro*',)),)\n",
+    )
+    return {
+        "schema_version": 1,
+        "public_alpha_predicate": {
+            "disallow_path_filter_downgrade": True,
+            "disallow_manual_downgrade": True,
+            "disallow_missing_gpu_runner_downgrade": True,
+            "disallow_open_world_advisory_only": True,
+            "required_issue_query": {
+                "blocking_labels_any": ["priority:P0", "release blocker"],
+                "alpha_relevant_p1_labels_all": ["priority:P1", "alpha-relevant"],
+            },
+        },
+        "known_limitations_page": "docs/development/known-public-alpha-limitations.md",
+        "references": [
+            "docs/reference/renderer-release-gates.md",
+            "docs/development/known-public-alpha-limitations.md",
+            "docs/performance/index.md",
+            "docs/assets/data/benchmark_latest.json",
+            "tests/visual_baselines/README.md",
+            "tests/runtime/runtime_scenarios.json",
+        ],
+        "requires_gpu_test_snapshot": {
+            "test_count": count,
+            "sha256": digest,
+            "deferred_tags_any": ["SceneTree", "Importer"],
+            "deferred_count": 0,
+            "closure_policy": "deferred RequiresGPU coverage blocks closure",
+        },
+        "deferred_requires_gpu_waivers": [],
+        "gpu_harness_policy": {
+            "script": "tests/ci/run_gpu_harness.py",
+            "required_batches": [
+                {
+                    "name": "CompositorHazard",
+                    "minimum_test_cases": 1,
+                    "allow_skips": False,
+                    "allow_timeout": False,
+                    "allow_rid_leaks": False,
+                    "reference_artifacts": ["tests/visual_baselines/composite_hazard_256x256.png"],
+                }
+            ],
+        },
+        "workflow_policy": {
+            "required_workflows": [
+                {
+                    "file": ".github/workflows/gaussian_production_gates.yml",
+                    "required_jobs": ["guards", "module-validation"],
+                    "manual_input_may_disable": False,
+                    "path_filter_may_disable": False,
+                },
+                {
+                    "file": ".github/workflows/baseline_qa.yml",
+                    "required_jobs": ["Run GPU harness"],
+                    "manual_input_may_disable": False,
+                    "path_filter_may_disable": False,
+                },
+                {
+                    "file": ".github/workflows/release_builds.yml",
+                    "required_jobs": ["build_linux", "build_windows", "publish_release"],
+                    "manual_input_may_disable": False,
+                    "path_filter_may_disable": False,
+                },
+            ]
+        },
+        "visual_acceptance": {
+            "tracked_actual_png_allowed": False,
+            "blocking_references": [
+                {
+                    "id": "compositor_hazard_256",
+                    "path": "tests/visual_baselines/composite_hazard_256x256.png",
+                    "required": True,
+                }
+            ],
+            "candidate_rules": {
+                "capture_count_min": 1,
+                "capture_reference_match_count_must_equal_capture_count": True,
+                "capture_ssim_min_must_be_non_null": True,
+                "capture_psnr_min_must_be_non_null": True,
+            },
+        },
+        "benchmark_acceptance": {
+            "candidate_required_lanes": ["static_baseline"],
+            "required_fields_non_null": ["lane_id", "commit_sha", "godot_binary_commit", "godot_binary_mtime_utc"],
+        },
+        "artifact_requirements": {
+            "required_groups": ["linux_release_archive", "known_limitations_page"],
+            "each_artifact_requires": ["path", "sha256", "godot_binary_commit", "godot_binary_mtime_utc"],
+        },
+    }
+
+
+class RendererReleaseGateTests(unittest.TestCase):
+    def test_repository_contract_passes(self) -> None:
+        manifest = checker._load_json(ROOT / "docs/reference/renderer_release_gate_manifest.json")
+        failures = checker.validate_contract(ROOT, manifest)
+        self.assertEqual([], failures)
+
+    def test_new_requires_gpu_test_fails_snapshot_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            _write(
+                root / "modules/gaussian_splatting/tests/test_new_gpu.h",
+                'TEST_CASE("[GaussianSplatting][RequiresGPU] New") {}\n',
+            )
+            failures = checker.validate_contract(root, manifest)
+            self.assertTrue(any("RequiresGPU test snapshot drift" in item for item in failures))
+
+    def test_missing_visual_reference_fails_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            (root / "tests/visual_baselines/composite_hazard_256x256.png").unlink()
+            failures = checker.validate_contract(root, manifest)
+            self.assertTrue(any("reference missing" in item for item in failures))
+
+    def test_missing_known_limitations_page_fails_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            (root / "docs/development/known-public-alpha-limitations.md").unlink()
+            failures = checker.validate_contract(root, manifest)
+            self.assertTrue(any("known limitations page is missing" in item for item in failures))
+
+    def test_required_batch_matching_zero_tests_fails_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            _write(
+                root / "tests/ci/run_gpu_harness.py",
+                "from dataclasses import dataclass\n"
+                "@dataclass(frozen=True)\n"
+                "class BatchSpec:\n"
+                "    name: str\n"
+                "    filters: tuple[str, ...]\n"
+                "BATCHES = (BatchSpec('CompositorHazard', ('*NoMatch*',)),)\n",
+            )
+            failures = checker.validate_contract(root, manifest)
+            self.assertTrue(any("matches 0 tests" in item for item in failures))
+
+    def test_candidate_fails_timeout_and_null_metrics(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            _write(
+                root / "gpu_report.json",
+                json.dumps(
+                    {
+                        "batches": [
+                            {
+                                "name": "CompositorHazard",
+                                "timed_out": True,
+                                "summary_parse_ok": True,
+                                "rc": 0,
+                                "test_cases": {"total": 1, "failed": 0, "skipped": 0},
+                                "assertions": {"failed": 0},
+                                "rid_leak_bytes": 0,
+                            }
+                        ]
+                    }
+                ),
+            )
+            _write(
+                root / "bench.json",
+                json.dumps([{"lane_id": "static_baseline", "commit_sha": None, "capture_count": 0}]),
+            )
+            evidence = {
+                "commit": "abc",
+                "commit_time_utc": "2026-05-19T10:00:00Z",
+                "gpu_harness_report": "gpu_report.json",
+                "benchmark_report": "bench.json",
+                "artifacts": {
+                    "linux_release_archive": {
+                        "path": "x",
+                        "sha256": "y",
+                        "godot_binary_commit": "abc",
+                        "godot_binary_mtime_utc": "2026-05-19T10:01:00Z",
+                    },
+                    "known_limitations_page": {
+                        "path": "x",
+                        "sha256": "y",
+                        "godot_binary_commit": "abc",
+                        "godot_binary_mtime_utc": "2026-05-19T10:01:00Z",
+                    },
+                },
+            }
+            failures = checker.validate_candidate(root, manifest, evidence)
+            self.assertTrue(any("timed out" in item for item in failures))
+            self.assertTrue(any("null/missing commit_sha" in item for item in failures))
+            self.assertTrue(any("has no visual captures" in item for item in failures))
+
+    def test_candidate_fails_stale_and_incomplete_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            _write(
+                root / "gpu_report.json",
+                json.dumps(
+                    {
+                        "batches": [
+                            {
+                                "name": "CompositorHazard",
+                                "timed_out": False,
+                                "summary_parse_ok": True,
+                                "rc": 0,
+                                "test_cases": {"total": 1, "failed": 0, "skipped": 0},
+                                "assertions": {"failed": 0},
+                                "rid_leak_bytes": 0,
+                            }
+                        ]
+                    }
+                ),
+            )
+            _write(
+                root / "bench.json",
+                json.dumps(
+                    [
+                        {
+                            "lane_id": "static_baseline",
+                            "commit_sha": "abc",
+                            "godot_binary_commit": "abc",
+                            "godot_binary_mtime_utc": "2026-05-19T10:01:00Z",
+                            "capture_count": 1,
+                            "capture_reference_match_count": 1,
+                            "capture_ssim_min": 0.99,
+                            "capture_psnr_min": 40.0,
+                            "gpu_timing_available": False,
+                            "gpu_timing_source": "unavailable",
+                        }
+                    ]
+                ),
+            )
+            evidence = {
+                "commit": "abc",
+                "commit_time_utc": "2026-05-19T10:00:00Z",
+                "gpu_harness_report": "gpu_report.json",
+                "benchmark_report": "bench.json",
+                "artifacts": {
+                    "linux_release_archive": {
+                        "path": "x",
+                        "sha256": "y",
+                        "godot_binary_commit": "old",
+                        "godot_binary_mtime_utc": "2026-05-19T09:00:00Z",
+                    }
+                },
+            }
+            failures = checker.validate_candidate(root, manifest, evidence)
+            self.assertTrue(any("built from stale commit" in item for item in failures))
+            self.assertTrue(any("binary predates commit" in item for item in failures))
+            self.assertTrue(any("artifact group missing: known_limitations_page" in item for item in failures))
+
+    def test_candidate_issue_classification_uses_live_labels(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = {"artifacts": {}, "issue_classifications": {"350": {"status": "blocking"}}}
+            issues = [{"number": 350, "state": "OPEN", "labels": [{"name": "release blocker"}]}]
+            failures = checker.validate_candidate(root, manifest, evidence, issues)
+            self.assertTrue(any("issue #350 is still blocking" in item for item in failures))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci/test_renderer_release_gates.py
+++ b/tests/ci/test_renderer_release_gates.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -22,6 +24,21 @@ spec.loader.exec_module(checker)
 def _write(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _artifact(root: Path, rel_path: str, content: str = "artifact\n") -> dict[str, Any]:
+    path = root / rel_path
+    _write(path, content)
+    return {
+        "path": rel_path,
+        "sha256": _sha256(path),
+        "godot_binary_commit": "abc",
+        "godot_binary_mtime_utc": "2026-05-19T10:01:00Z",
+    }
 
 
 def _base_manifest(root: Path) -> dict[str, Any]:
@@ -56,6 +73,9 @@ def _base_manifest(root: Path) -> dict[str, Any]:
     return {
         "schema_version": 1,
         "public_alpha_predicate": {
+            "channel": "public-alpha",
+            "accepted_tag_patterns": ["v*-alpha*"],
+            "candidate_manifest_field": "release_channel=public-alpha",
             "disallow_path_filter_downgrade": True,
             "disallow_manual_downgrade": True,
             "disallow_missing_gpu_runner_downgrade": True,
@@ -96,24 +116,23 @@ def _base_manifest(root: Path) -> dict[str, Any]:
             ],
         },
         "workflow_policy": {
+            "machine_enforcement_scope": "workflow-presence-and-required-job-markers",
+            "documented_non_enforced_rules": [
+                "manual workflow inputs must not bypass public-alpha readiness",
+                "path filters must not downgrade public-alpha readiness",
+            ],
             "required_workflows": [
                 {
                     "file": ".github/workflows/gaussian_production_gates.yml",
                     "required_jobs": ["guards", "module-validation"],
-                    "manual_input_may_disable": False,
-                    "path_filter_may_disable": False,
                 },
                 {
                     "file": ".github/workflows/baseline_qa.yml",
                     "required_jobs": ["Run GPU harness"],
-                    "manual_input_may_disable": False,
-                    "path_filter_may_disable": False,
                 },
                 {
                     "file": ".github/workflows/release_builds.yml",
                     "required_jobs": ["build_linux", "build_windows", "publish_release"],
-                    "manual_input_may_disable": False,
-                    "path_filter_may_disable": False,
                 },
             ]
         },
@@ -144,6 +163,62 @@ def _base_manifest(root: Path) -> dict[str, Any]:
     }
 
 
+def _valid_candidate_evidence(root: Path) -> dict[str, Any]:
+    _write(
+        root / "gpu_report.json",
+        json.dumps(
+            {
+                "batches": [
+                    {
+                        "name": "CompositorHazard",
+                        "timed_out": False,
+                        "summary_parse_ok": True,
+                        "rc": 0,
+                        "test_cases": {"total": 1, "failed": 0, "skipped": 0},
+                        "assertions": {"failed": 0},
+                        "rid_leak_bytes": 0,
+                    }
+                ]
+            }
+        ),
+    )
+    _write(
+        root / "bench.json",
+        json.dumps(
+            [
+                {
+                    "lane_id": "static_baseline",
+                    "commit_sha": "abc",
+                    "godot_binary_commit": "abc",
+                    "godot_binary_mtime_utc": "2026-05-19T10:01:00Z",
+                    "capture_count": 1,
+                    "capture_reference_match_count": 1,
+                    "capture_ssim_min": 0.99,
+                    "capture_psnr_min": 40.0,
+                    "gpu_timing_available": False,
+                    "gpu_timing_source": "unavailable",
+                }
+            ]
+        ),
+    )
+    return {
+        "release_channel": "public-alpha",
+        "commit": "abc",
+        "commit_time_utc": "2026-05-19T10:00:00Z",
+        "gpu_harness_report": "gpu_report.json",
+        "benchmark_report": "bench.json",
+        "artifacts": {
+            "linux_release_archive": _artifact(root, "artifacts/linux_release_archive.tar.xz"),
+            "known_limitations_page": {
+                "path": "docs/development/known-public-alpha-limitations.md",
+                "sha256": _sha256(root / "docs/development/known-public-alpha-limitations.md"),
+                "godot_binary_commit": "abc",
+                "godot_binary_mtime_utc": "2026-05-19T10:01:00Z",
+            },
+        },
+    }
+
+
 class RendererReleaseGateTests(unittest.TestCase):
     def test_repository_contract_passes(self) -> None:
         manifest = checker._load_json(ROOT / "docs/reference/renderer_release_gate_manifest.json")
@@ -169,6 +244,21 @@ class RendererReleaseGateTests(unittest.TestCase):
             failures = checker.validate_contract(root, manifest)
             self.assertTrue(any("reference missing" in item for item in failures))
 
+    def test_tracked_actual_pngs_detect_root_visual_baseline_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            actual = root / "tests/visual_baselines/root.actual.png"
+            _write(actual, "actual\n")
+            subprocess.run(["git", "init"], cwd=root, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.run(
+                ["git", "add", "tests/visual_baselines/root.actual.png"],
+                cwd=root,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            self.assertIn("tests/visual_baselines/root.actual.png", checker._tracked_actual_pngs(root))
+
     def test_missing_known_limitations_page_fails_contract(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -192,6 +282,101 @@ class RendererReleaseGateTests(unittest.TestCase):
             )
             failures = checker.validate_contract(root, manifest)
             self.assertTrue(any("matches 0 tests" in item for item in failures))
+
+    def test_workflow_policy_rejects_unenforced_claims(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            manifest["workflow_policy"]["required_workflows"][0]["manual_input_may_disable"] = False
+            failures = checker.validate_contract(root, manifest)
+            self.assertTrue(any("not machine-enforced" in item for item in failures))
+
+    def test_candidate_requires_issue_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            failures = checker.validate_candidate(root, manifest, evidence)
+            self.assertTrue(any("issue snapshot missing" in item for item in failures))
+
+    def test_candidate_accepts_embedded_issue_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            evidence["issue_snapshot"] = []
+            failures = checker.validate_candidate(root, manifest, evidence)
+            self.assertEqual([], failures)
+
+    def test_candidate_rejects_wrong_channel_and_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            evidence["release_channel"] = "nightly"
+            evidence["release_tag"] = "nightly-20260519"
+            failures = checker.validate_candidate(root, manifest, evidence, [])
+            self.assertTrue(any("selector is not public-alpha" in item for item in failures))
+
+    def test_candidate_accepts_alpha_tag_selector(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            evidence["release_channel"] = "nightly"
+            evidence["release_tag"] = "v1.0.0-alpha.1"
+            failures = checker.validate_candidate(root, manifest, evidence, [])
+            self.assertEqual([], failures)
+
+    def test_candidate_requires_commit_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            evidence.pop("commit")
+            evidence.pop("commit_time_utc")
+            failures = checker.validate_candidate(root, manifest, evidence, [])
+            self.assertTrue(any("candidate evidence missing commit" in item for item in failures))
+            self.assertTrue(any("candidate evidence missing commit_time_utc" in item for item in failures))
+
+    def test_candidate_rejects_invalid_commit_time_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            evidence["commit_time_utc"] = "not-a-timestamp"
+            failures = checker._candidate_commit_metadata_failures(evidence)
+            self.assertTrue(any("invalid commit_time_utc" in item for item in failures))
+
+    def test_deferred_gpu_waivers_must_match_deferred_tests(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            tests = checker._extract_requires_gpu_tests(root)
+            deferred_name = tests[0]["name"]
+            manifest["requires_gpu_test_snapshot"]["deferred_tags_any"] = ["HazardRepro"]
+            manifest["requires_gpu_test_snapshot"]["deferred_count"] = 1
+            manifest["deferred_requires_gpu_waivers"] = [{"test_name": "Unrelated deferred test"}]
+
+            failures = checker._validate_candidate_deferred_waivers(manifest, tests)
+            self.assertTrue(any(f"missing waiver: {deferred_name}" in item for item in failures))
+            self.assertTrue(any("does not match a deferred test" in item for item in failures))
+
+    def test_deferred_gpu_waivers_reject_duplicates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            tests = checker._extract_requires_gpu_tests(root)
+            deferred_name = tests[0]["name"]
+            manifest["requires_gpu_test_snapshot"]["deferred_tags_any"] = ["HazardRepro"]
+            manifest["requires_gpu_test_snapshot"]["deferred_count"] = 1
+            manifest["deferred_requires_gpu_waivers"] = [
+                {"test_name": deferred_name},
+                {"test_name": deferred_name},
+            ]
+
+            failures = checker._validate_candidate_deferred_waivers(manifest, tests)
+            self.assertTrue(any("waiver duplicated" in item for item in failures))
 
     def test_candidate_fails_timeout_and_null_metrics(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -243,6 +428,202 @@ class RendererReleaseGateTests(unittest.TestCase):
             self.assertTrue(any("timed out" in item for item in failures))
             self.assertTrue(any("null/missing commit_sha" in item for item in failures))
             self.assertTrue(any("has no visual captures" in item for item in failures))
+
+    def test_candidate_missing_gpu_report_is_structured_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            evidence["gpu_harness_report"] = "missing_gpu_report.json"
+            failures = checker._validate_candidate_gpu_report(root, manifest, evidence)
+            self.assertTrue(any("gpu_harness_report unreadable" in item for item in failures))
+
+    def test_candidate_evidence_must_be_json_object(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            failures = checker.validate_candidate(root, manifest, [])
+            self.assertTrue(any("candidate evidence must be a JSON object" in item for item in failures))
+
+    def test_candidate_gpu_report_rejects_non_object_batches(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            _write(root / "gpu_report.json", json.dumps({"batches": [1]}))
+            failures = checker._validate_candidate_gpu_report(root, manifest, evidence)
+            self.assertTrue(any("batch at index 0 must be a JSON object" in item for item in failures))
+            self.assertTrue(any("missing required batch" in item for item in failures))
+
+    def test_candidate_gpu_batch_counters_must_be_objects(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            _write(
+                root / "gpu_report.json",
+                json.dumps(
+                    {
+                        "batches": [
+                            {
+                                "name": "CompositorHazard",
+                                "timed_out": False,
+                                "summary_parse_ok": True,
+                                "rc": 0,
+                                "test_cases": [],
+                                "assertions": [],
+                                "rid_leak_bytes": 0,
+                            }
+                        ]
+                    }
+                ),
+            )
+            failures = checker._validate_candidate_gpu_report(root, manifest, evidence)
+            self.assertTrue(any("test_cases must be a JSON object" in item for item in failures))
+            self.assertTrue(any("assertions must be a JSON object" in item for item in failures))
+
+    def test_candidate_gpu_batch_name_must_be_string(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            _write(
+                root / "gpu_report.json",
+                json.dumps(
+                    {
+                        "batches": [
+                            {
+                                "name": ["CompositorHazard"],
+                                "timed_out": False,
+                                "summary_parse_ok": True,
+                                "rc": 0,
+                                "test_cases": {"total": 1, "failed": 0, "skipped": 0},
+                                "assertions": {"failed": 0},
+                                "rid_leak_bytes": 0,
+                            }
+                        ]
+                    }
+                ),
+            )
+            failures = checker._validate_candidate_gpu_report(root, manifest, evidence)
+            self.assertTrue(any("name must be a string" in item for item in failures))
+            self.assertTrue(any("missing required batch: CompositorHazard" in item for item in failures))
+
+    def test_candidate_gpu_batch_counters_must_be_numeric(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            _write(
+                root / "gpu_report.json",
+                json.dumps(
+                    {
+                        "batches": [
+                            {
+                                "name": "CompositorHazard",
+                                "timed_out": False,
+                                "summary_parse_ok": True,
+                                "rc": 0,
+                                "test_cases": {"total": "1", "failed": 0, "skipped": 0},
+                                "assertions": {"failed": 0},
+                                "rid_leak_bytes": 0,
+                            }
+                        ]
+                    }
+                ),
+            )
+            failures = checker._validate_candidate_gpu_report(root, manifest, evidence)
+            self.assertTrue(any("test_cases.total must be numeric" in item for item in failures))
+
+    def test_candidate_gpu_report_honors_allow_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            manifest["gpu_harness_policy"]["required_batches"][0]["allow_timeout"] = True
+            evidence = _valid_candidate_evidence(root)
+            _write(
+                root / "gpu_report.json",
+                json.dumps(
+                    {
+                        "batches": [
+                            {
+                                "name": "CompositorHazard",
+                                "timed_out": True,
+                                "summary_parse_ok": True,
+                                "rc": 0,
+                                "test_cases": {"total": 1, "failed": 0, "skipped": 0},
+                                "assertions": {"failed": 0},
+                                "rid_leak_bytes": 0,
+                            }
+                        ]
+                    }
+                ),
+            )
+            failures = checker._validate_candidate_gpu_report(root, manifest, evidence)
+            self.assertFalse(any("timed out" in item for item in failures))
+
+    def test_candidate_missing_benchmark_report_is_structured_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            evidence["benchmark_report"] = "missing_benchmark_report.json"
+            failures = checker._validate_candidate_benchmark_report(root, manifest, evidence)
+            self.assertTrue(any("benchmark_report unreadable" in item for item in failures))
+
+    def test_candidate_gpu_time_must_be_numeric(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            _write(
+                root / "bench.json",
+                json.dumps(
+                    [
+                        {
+                            "lane_id": "static_baseline",
+                            "commit_sha": "abc",
+                            "godot_binary_commit": "abc",
+                            "godot_binary_mtime_utc": "2026-05-19T10:01:00Z",
+                            "capture_count": 1,
+                            "capture_reference_match_count": 1,
+                            "capture_ssim_min": 0.99,
+                            "capture_psnr_min": 40.0,
+                            "gpu_timing_available": True,
+                            "gpu_time_frame_ms": "1.25",
+                        }
+                    ]
+                ),
+            )
+            failures = checker._validate_candidate_benchmark_report(root, manifest, evidence)
+            self.assertTrue(any("has invalid GPU time" in item for item in failures))
+
+    def test_candidate_visual_capture_count_must_be_numeric(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            _write(
+                root / "bench.json",
+                json.dumps(
+                    [
+                        {
+                            "lane_id": "static_baseline",
+                            "commit_sha": "abc",
+                            "godot_binary_commit": "abc",
+                            "godot_binary_mtime_utc": "2026-05-19T10:01:00Z",
+                            "capture_count": "1",
+                            "capture_reference_match_count": 1,
+                            "capture_ssim_min": 0.99,
+                            "capture_psnr_min": 40.0,
+                            "gpu_timing_available": False,
+                            "gpu_timing_source": "unavailable",
+                        }
+                    ]
+                ),
+            )
+            failures = checker._validate_candidate_benchmark_report(root, manifest, evidence)
+            self.assertTrue(any("capture_count must be numeric" in item for item in failures))
 
     def test_candidate_fails_stale_and_incomplete_artifacts(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -303,6 +684,94 @@ class RendererReleaseGateTests(unittest.TestCase):
             self.assertTrue(any("built from stale commit" in item for item in failures))
             self.assertTrue(any("binary predates commit" in item for item in failures))
             self.assertTrue(any("artifact group missing: known_limitations_page" in item for item in failures))
+
+    def test_candidate_artifact_mtime_normalizes_timezone_awareness(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            evidence["commit_time_utc"] = "2026-05-19T10:00:00Z"
+            evidence["artifacts"]["linux_release_archive"]["godot_binary_mtime_utc"] = "2026-05-19T09:00:00"
+            failures = checker._validate_candidate_artifacts(root, manifest, evidence)
+            self.assertTrue(any("binary predates commit" in item for item in failures))
+
+    def test_candidate_artifact_paths_must_exist(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            evidence["artifacts"]["linux_release_archive"]["path"] = "artifacts/missing.tar.xz"
+            failures = checker._validate_candidate_artifacts(root, manifest, evidence)
+            self.assertTrue(any("artifact linux_release_archive path missing" in item for item in failures))
+
+    def test_candidate_artifact_sha256_must_match_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            evidence["artifacts"]["linux_release_archive"]["sha256"] = "0" * 64
+            failures = checker._validate_candidate_artifacts(root, manifest, evidence)
+            self.assertTrue(any("artifact linux_release_archive sha256 mismatch" in item for item in failures))
+
+    def test_candidate_artifacts_must_be_object(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            evidence["artifacts"] = []
+            failures = checker._validate_candidate_artifacts(root, manifest, evidence)
+            self.assertTrue(any("candidate artifacts must be a JSON object" in item for item in failures))
+
+    def test_accepted_limitation_requires_canonical_limitations_page(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            _write(root / "README.md", "not the known limitations page\n")
+            evidence = {
+                "issue_classifications": {
+                    "350": {
+                        "status": "accepted_alpha_limitation",
+                        "docs_path": "README.md",
+                    }
+                }
+            }
+            issues = [{"number": 350, "state": "OPEN", "labels": [{"name": "release blocker"}]}]
+            failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
+            self.assertTrue(any("accepted limitation must use known_limitations_page" in item for item in failures))
+
+    def test_accepted_limitation_accepts_canonical_limitations_page(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = {
+                "issue_classifications": {
+                    "350": {
+                        "status": "accepted_alpha_limitation",
+                        "docs_path": "docs/development/known-public-alpha-limitations.md",
+                    }
+                }
+            }
+            issues = [{"number": 350, "state": "OPEN", "labels": [{"name": "release blocker"}]}]
+            failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
+            self.assertEqual([], failures)
+
+    def test_candidate_issue_classification_must_be_object(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = {"issue_classifications": {"350": "blocking"}}
+            issues = [{"number": 350, "state": "OPEN", "labels": [{"name": "release blocker"}]}]
+            failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
+            self.assertTrue(any("alpha classification must be a JSON object" in item for item in failures))
+
+    def test_candidate_issue_classifications_must_be_object(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = {"issue_classifications": []}
+            issues = [{"number": 350, "state": "OPEN", "labels": [{"name": "release blocker"}]}]
+            failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
+            self.assertTrue(any("candidate issue_classifications must be a JSON object" in item for item in failures))
 
     def test_candidate_issue_classification_uses_live_labels(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## What changed

- Added a machine-readable renderer/public-alpha release gate manifest at `docs/reference/renderer_release_gate_manifest.json`.
- Added `tests/ci/check_renderer_release_gates.py` with contract mode and candidate mode checks for GPU-test drift, required GPU batches, visual references, artifact completeness, benchmark metrics, timeout reports, stale binaries, deferred GPU waivers, and live issue-label classifications.
- Added deterministic unit tests for the checker and docs for the release predicate plus the required known public-alpha limitations page.
- Linked the new gate docs from the reference/development indexes and workflow README.

## Why

The current renderer evidence path can still treat important GPU, production-readiness, benchmark, and public-alpha proof as advisory or manually enforced. This PR creates the first blocking predicate and checker surface so future release-candidate CI can fail loudly instead of relying on release-note intent.

## Validation

- `python3 tests/ci/check_renderer_release_gates.py --mode contract`
- `python3 tests/ci/test_renderer_release_gates.py`
- `python3 -m py_compile tests/ci/check_renderer_release_gates.py tests/ci/test_renderer_release_gates.py`
- `git diff --cached --check`

`python3 -m ruff check ...` was attempted locally, but `ruff` is not installed in this worktree environment.

## Issue references

Refs #350.
Refs #360.

This is the foundation release-gate PR. It does not close #350 or #360 because full release-renderer GPU profile wiring, SceneTree/Importer bootstrap resolution, and a complete public-alpha evidence bundle remain follow-up work.
