### PR TITLE
Draft: #351 route/stage contracts foundation

### DIFF
--- a/docs/timing_metrics_reference.md
+++ b/docs/timing_metrics_reference.md
@@ -17,6 +17,19 @@ The following custom monitors are exported under the `gaussian_splatting/` prefi
 - `route_uid`: active render-route UID for the current frame diagnostics.
 - `sort_route_uid`: active sort-route UID for the current frame diagnostics.
 
+## Route and stage contracts
+
+Each rendered frame carries a `RenderRouteDecision` through `RenderFramePlan`. Stage results for cull, sort,
+raster, and composite carry the selected route UID, input/output domains, input/output counts, first failure,
+skip cause, and degradation flags.
+
+Downstream stages that did not execute because an upstream stage failed are `skipped`, not `failed`. The first
+executed failing stage keeps `failed`, and skipped stages publish `stage_skip_cause` so diagnostics can attribute
+the cascade without treating derived empty output as a second failure.
+
+Composite depth degradation is part of the stage contract. When `depth_test_honored` is false, relaxed policy
+reports a composite degradation; strict policy reports a composite contract violation/failure.
+
 ## Telemetry availability
 
 Use `telemetry_active` to distinguish unavailable monitor samples from valid runtime zeros.

--- a/modules/gaussian_splatting/interfaces/output_compositor.cpp
+++ b/modules/gaussian_splatting/interfaces/output_compositor.cpp
@@ -1383,6 +1383,9 @@ void OutputCompositor::integrate_final_output(GaussianSplatRenderer *p_renderer,
 
     final_render_texture = p_final_output;
     output_cache.has_valid_render = p_final_output.is_valid();
+    output_cache.last_depth_test_honored = true;
+    output_cache.last_copy_degraded = false;
+    output_cache.last_copy_degradation_reason = String();
 
     if (render_buffers_rd && p_final_output.is_valid()) {
         Size2i viewport_size = p_viewport_size;
@@ -1455,6 +1458,9 @@ void OutputCompositor::integrate_final_output(GaussianSplatRenderer *p_renderer,
             if (missing_required_scene_depth && !allow_scene_blend_fallback) {
                 gs_log_scene_depth_contract_skip_once(!has_source_depth, !has_scene_depth);
                 output_cache.last_viewport_copy_success = false;
+                output_cache.last_depth_test_honored = false;
+                output_cache.last_copy_degraded = true;
+                output_cache.last_copy_degradation_reason = "strict depth composite skipped: source or scene depth missing";
             } else if (render_target_framebuffer.is_valid() && !depth_test_enabled) {
                 FramebufferCopyParams params;
                 params.source_texture = p_final_output;
@@ -1464,6 +1470,11 @@ void OutputCompositor::integrate_final_output(GaussianSplatRenderer *p_renderer,
                 params.composite_with_destination = true;
                 params.source_is_premultiplied = true;
                 copy_to_framebuffer(params);
+                if (missing_required_scene_depth && allow_scene_blend_fallback) {
+                    output_cache.last_depth_test_honored = false;
+                    output_cache.last_copy_degraded = true;
+                    output_cache.last_copy_degradation_reason = "relaxed depth composite fallback: source or scene depth missing";
+                }
             } else {
                 OutputCopyParams params;
                 params.source_texture = p_final_output;
@@ -1493,7 +1504,17 @@ void OutputCompositor::integrate_final_output(GaussianSplatRenderer *p_renderer,
                         }
                     }
                 }
-                copy_to_render_target(params);
+                OutputCopyResult copy_result = copy_to_render_target(params);
+                output_cache.last_depth_test_honored = copy_result.depth_test_honored;
+                if (!copy_result.depth_test_honored) {
+                    output_cache.last_copy_degraded = true;
+                    output_cache.last_copy_degradation_reason = copy_result.error.is_empty()
+                            ? String("depth composite fallback did not honor requested depth test")
+                            : copy_result.error;
+                    if (scene_depth_policy == GS_SCENE_COMPOSITE_DEPTH_POLICY_STRICT) {
+                        output_cache.last_viewport_copy_success = false;
+                    }
+                }
             }
         }
         r_render_target = composite_target.is_valid() ? composite_target : pipeline_render_target;

--- a/modules/gaussian_splatting/interfaces/output_compositor.cpp
+++ b/modules/gaussian_splatting/interfaces/output_compositor.cpp
@@ -221,6 +221,13 @@ void OutputCompositor::test_reset_last_viewport_copy_state() {
     output_cache.last_viewport_copy_success = false;
     output_cache.last_viewport_copy_source_size = Size2i();
     output_cache.last_viewport_copy_dest_size = Size2i();
+    output_cache.last_output_copy_attempted = false;
+    output_cache.last_output_copy_success = false;
+    output_cache.last_output_copy_error = String();
+    output_cache.last_depth_test_honored = true;
+    output_cache.last_copy_degraded = false;
+    output_cache.last_copy_degradation_reason = String();
+    output_cache.last_strict_depth_contract_required = false;
 }
 
 void OutputCompositor::set_device_manager(Ref<RenderDeviceManager> p_device_manager) {
@@ -1383,9 +1390,13 @@ void OutputCompositor::integrate_final_output(GaussianSplatRenderer *p_renderer,
 
     final_render_texture = p_final_output;
     output_cache.has_valid_render = p_final_output.is_valid();
+    output_cache.last_output_copy_attempted = false;
+    output_cache.last_output_copy_success = false;
+    output_cache.last_output_copy_error = String();
     output_cache.last_depth_test_honored = true;
     output_cache.last_copy_degraded = false;
     output_cache.last_copy_degradation_reason = String();
+    output_cache.last_strict_depth_contract_required = false;
 
     if (render_buffers_rd && p_final_output.is_valid()) {
         Size2i viewport_size = p_viewport_size;
@@ -1445,6 +1456,8 @@ void OutputCompositor::integrate_final_output(GaussianSplatRenderer *p_renderer,
 
         const bool scene_depth_test_requested = gs_get_composite_depth_test_enabled();
         const GSSceneCompositeDepthPolicy scene_depth_policy = gs_get_scene_composite_depth_policy();
+        output_cache.last_strict_depth_contract_required =
+                scene_depth_test_requested && scene_depth_policy == GS_SCENE_COMPOSITE_DEPTH_POLICY_STRICT;
 
         RID scene_depth = render_buffers_rd ? render_buffers_rd->get_depth_texture() : RID();
         const bool has_source_depth = p_cached_depth.is_valid();
@@ -1457,6 +1470,9 @@ void OutputCompositor::integrate_final_output(GaussianSplatRenderer *p_renderer,
         if (!composited && (render_target_framebuffer.is_valid() || composite_target.is_valid())) {
             if (missing_required_scene_depth && !allow_scene_blend_fallback) {
                 gs_log_scene_depth_contract_skip_once(!has_source_depth, !has_scene_depth);
+                output_cache.last_output_copy_attempted = true;
+                output_cache.last_output_copy_success = false;
+                output_cache.last_output_copy_error = "strict depth composite skipped: source or scene depth missing";
                 output_cache.last_viewport_copy_success = false;
                 output_cache.last_depth_test_honored = false;
                 output_cache.last_copy_degraded = true;
@@ -1469,7 +1485,14 @@ void OutputCompositor::integrate_final_output(GaussianSplatRenderer *p_renderer,
                 params.viewport_size = viewport_size;
                 params.composite_with_destination = true;
                 params.source_is_premultiplied = true;
-                copy_to_framebuffer(params);
+                output_cache.last_output_copy_attempted = true;
+                const bool framebuffer_copy_success = copy_to_framebuffer(params);
+                output_cache.last_output_copy_success = framebuffer_copy_success;
+                if (!framebuffer_copy_success) {
+                    output_cache.last_output_copy_error = "framebuffer copy failed";
+                    output_cache.last_copy_degraded = true;
+                    output_cache.last_copy_degradation_reason = output_cache.last_output_copy_error;
+                }
                 if (missing_required_scene_depth && allow_scene_blend_fallback) {
                     output_cache.last_depth_test_honored = false;
                     output_cache.last_copy_degraded = true;
@@ -1505,8 +1528,23 @@ void OutputCompositor::integrate_final_output(GaussianSplatRenderer *p_renderer,
                     }
                 }
                 OutputCopyResult copy_result = copy_to_render_target(params);
-                output_cache.last_depth_test_honored = copy_result.depth_test_honored;
-                if (!copy_result.depth_test_honored) {
+                const bool relaxed_missing_depth_fallback = missing_required_scene_depth && allow_scene_blend_fallback;
+                output_cache.last_output_copy_attempted = true;
+                output_cache.last_output_copy_success = copy_result.success;
+                output_cache.last_output_copy_error = copy_result.error;
+                output_cache.last_depth_test_honored = relaxed_missing_depth_fallback ? false : copy_result.depth_test_honored;
+                if (!copy_result.success) {
+                    output_cache.last_copy_degraded = true;
+                    output_cache.last_copy_degradation_reason = copy_result.error.is_empty()
+                            ? String("render target copy failed")
+                            : copy_result.error;
+                }
+                if (relaxed_missing_depth_fallback) {
+                    output_cache.last_copy_degraded = true;
+                    if (copy_result.success) {
+                        output_cache.last_copy_degradation_reason = "relaxed depth composite fallback: source or scene depth missing";
+                    }
+                } else if (!copy_result.depth_test_honored) {
                     output_cache.last_copy_degraded = true;
                     output_cache.last_copy_degradation_reason = copy_result.error.is_empty()
                             ? String("depth composite fallback did not honor requested depth test")
@@ -1516,6 +1554,12 @@ void OutputCompositor::integrate_final_output(GaussianSplatRenderer *p_renderer,
                     }
                 }
             }
+        } else if (!composited) {
+            output_cache.last_output_copy_attempted = true;
+            output_cache.last_output_copy_success = false;
+            output_cache.last_output_copy_error = "no valid render target for final output copy";
+            output_cache.last_copy_degraded = true;
+            output_cache.last_copy_degradation_reason = output_cache.last_output_copy_error;
         }
         r_render_target = composite_target.is_valid() ? composite_target : pipeline_render_target;
     }

--- a/modules/gaussian_splatting/interfaces/output_compositor.h
+++ b/modules/gaussian_splatting/interfaces/output_compositor.h
@@ -89,9 +89,13 @@ public:
         Size2i last_viewport_copy_source_size = Size2i();
         Size2i last_viewport_copy_dest_size = Size2i();
         bool last_viewport_copy_success = false;
+        bool last_output_copy_attempted = false;
+        bool last_output_copy_success = false;
+        String last_output_copy_error;
         bool last_depth_test_honored = true;
         bool last_copy_degraded = false;
         String last_copy_degradation_reason;
+        bool last_strict_depth_contract_required = false;
         RID last_render_target;
         bool cached_render_valid = false;
         Transform3D cached_render_camera_to_world_transform;

--- a/modules/gaussian_splatting/interfaces/output_compositor.h
+++ b/modules/gaussian_splatting/interfaces/output_compositor.h
@@ -89,6 +89,9 @@ public:
         Size2i last_viewport_copy_source_size = Size2i();
         Size2i last_viewport_copy_dest_size = Size2i();
         bool last_viewport_copy_success = false;
+        bool last_depth_test_honored = true;
+        bool last_copy_degraded = false;
+        String last_copy_degradation_reason;
         RID last_render_target;
         bool cached_render_valid = false;
         Transform3D cached_render_camera_to_world_transform;

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
@@ -2281,11 +2281,13 @@ void GaussianSplatRenderer::render_scene_instance(RenderDataRD *p_render_data) {
         const String resident_rejection_reason =
                 vformat("%s_not_feasible:%s", backend_plan.resident_backend_reason, resident_attempt_reason);
         const String resident_rejection_route_uid = _resident_not_feasible_route_uid(resident_attempt_reason);
-        get_performance_state().metrics.cull_route_uid = resident_rejection_route_uid;
-        get_performance_state().metrics.cull_route_reason = String("resident_not_feasible_") + resident_attempt_reason;
         if (debug_state_orchestrator) {
             get_debug_state().route_uid = resident_rejection_route_uid;
         }
+        publish_route_skip_stage_metrics(resident_rejection_route_uid, InstanceBackendPolicy::RESIDENT,
+                String("resident_not_feasible_") + resident_attempt_reason,
+                "Cull skipped: resident route not feasible",
+                RenderFallbackReason::DATA_UNAVAILABLE);
         _set_instance_backend_diagnostics(InstanceBackendPolicy::RESIDENT,
                 resident_rejection_reason,
                 false,
@@ -2329,9 +2331,17 @@ void GaussianSplatRenderer::render_scene_instance(RenderDataRD *p_render_data) {
             }
             fallback_route_uid = debug_state.route_uid;
         }
+        if (fallback_route_uid.is_empty()) {
+            const char *state_token = backend_plan.streaming_ready ? "UNKNOWN" : "MISSING_STREAMING_SYSTEM";
+            fallback_route_uid = _streaming_not_ready_route_uid(state_token);
+        }
         const String &reason = backend_plan.streaming_ready
                 ? backend_plan.streaming_not_ready_fallback_reason
                 : backend_plan.streaming_unavailable_fallback_reason;
+        publish_route_skip_stage_metrics(fallback_route_uid, InstanceBackendPolicy::STREAMING,
+                _streaming_not_ready_reason_code(fallback_route_uid),
+                "Cull skipped: streaming path not ready",
+                RenderFallbackReason::STREAMING_DATA_UNAVAILABLE);
         _set_instance_backend_diagnostics(InstanceBackendPolicy::STREAMING, reason,
                 has_instance_pipeline_buffers(), "atlas_emulation");
         WARN_PRINT_ONCE(vformat("[GaussianSplatRenderer] Streaming requested but not ready (route=%s); frame skipped to preserve single-route-per-frame contract.",
@@ -2683,6 +2693,35 @@ void GaussianSplatRenderer::clear_instance_pipeline_buffers() {
     instance_backend_policy = InstanceBackendPolicy::NONE;
     instance_contract_shape = "none";
     instance_contract_source_generation = 0;
+}
+
+void GaussianSplatRenderer::publish_route_skip_stage_metrics(const String &p_route_uid,
+        InstanceBackendPolicy p_backend_policy, const String &p_cull_route_reason,
+        const String &p_cull_stage_reason, RenderFallbackReason p_fallback_reason) {
+    get_debug_state().route_uid = p_route_uid;
+    get_performance_state().metrics.cull_route_uid = p_route_uid;
+    get_performance_state().metrics.cull_route_reason = p_cull_route_reason;
+    get_performance_state().metrics.raster_path = "skipped";
+    get_frame_state().visible_splat_count.store(0, std::memory_order_release);
+    get_frame_state().render_time_ms = 0.0f;
+    get_frame_state().sort_time_ms = 0.0f;
+    get_sorting_state().sorted_splat_count = 0;
+
+    const String cull_stage_reason = p_cull_stage_reason.is_empty()
+            ? String("Cull skipped: route not ready")
+            : p_cull_stage_reason;
+    const String sort_stage_reason = p_cull_stage_reason.is_empty()
+            ? String("Sort skipped: route not ready")
+            : vformat("Sort skipped: %s", p_cull_stage_reason);
+    StageMetrics metrics = RenderPipelineStages::make_route_skip_metrics(p_route_uid,
+            instance_backend_policy_to_string(p_backend_policy), cull_stage_reason, sort_stage_reason,
+            p_fallback_reason);
+    if (debug_state_orchestrator) {
+        debug_state_orchestrator->store_stage_metrics(metrics);
+    } else {
+        get_debug_state().last_stage_metrics = metrics;
+        get_debug_state().last_stage_metrics_valid = true;
+    }
 }
 
 bool GaussianSplatRenderer::update_instance_buffer(LocalVector<InstanceDataGPU> &p_instances, const PublishedInstanceAssetRemap &p_remap) {

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
@@ -782,6 +782,9 @@ public:
     bool has_instance_asset_remap() const { return instance_asset_remap.valid; }
     const PublishedInstanceAssetRemap &get_instance_asset_remap() const { return instance_asset_remap; }
     InstanceBackendPolicy get_instance_backend_policy() const { return instance_backend_policy; }
+    void publish_route_skip_stage_metrics(const String &p_route_uid, InstanceBackendPolicy p_backend_policy,
+            const String &p_cull_route_reason, const String &p_cull_stage_reason,
+            RenderFallbackReason p_fallback_reason);
     const String &get_instance_contract_shape() const { return instance_contract_shape; }
     bool is_instance_contract_ready() const { return instance_pipeline_buffers_valid; }
     bool get_submission_residency_hint(int32_t *r_hint, String *r_source = nullptr) const;

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
@@ -216,6 +216,8 @@ public:
     using SortStageOutput = GaussianRenderPipeline::SortStageOutput;
     using SplatDataSource = GaussianRenderPipeline::SplatDataSource;
     using InstanceBackendPolicy = GaussianRenderPipeline::InstanceBackendPolicy;
+    using RenderRouteBackend = GaussianRenderPipeline::RenderRouteBackend;
+    using RenderRouteDecision = GaussianRenderPipeline::RenderRouteDecision;
     using InstancePipelineBuffers = GaussianRenderPipeline::InstancePipelineBuffers;
     using PublishedInstanceAssetRemap = GaussianRenderPipeline::PublishedInstanceAssetRemap;
     using RenderFrameSnapshot = GaussianRenderPipeline::RenderFrameSnapshot;

--- a/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.cpp
@@ -239,6 +239,136 @@ static void _append_raster_specialization_metrics(const GaussianSplatRenderer::P
 	r_metrics["raster_pipeline_reformats"] = static_cast<int64_t>(p_perf.raster_pipeline_reformats);
 }
 
+static uint32_t _resolve_production_total_splats(const GaussianSplatRenderer::SceneState &p_scene_state) {
+	if (p_scene_state.gaussian_data.is_valid()) {
+		return p_scene_state.gaussian_data->get_count();
+	}
+	return p_scene_state.payload_source_splat_count;
+}
+
+static void _resolve_production_stage_times(const GaussianSplatRenderer::StageMetrics &p_stage_metrics,
+		bool p_stage_valid, const GaussianSplatRenderer::PerformanceMetrics &p_perf,
+		const GaussianSplatRenderer::FrameState &p_frame_state, float &r_cull_ms, float &r_sort_ms,
+		float &r_raster_ms, float &r_composite_ms) {
+	if (p_stage_valid) {
+		r_cull_ms = p_stage_metrics.cull.cull_time_ms;
+		r_sort_ms = p_stage_metrics.sort.sort_time_ms;
+		r_raster_ms = p_stage_metrics.raster.render_time_ms;
+		r_composite_ms = p_stage_metrics.composite_time_ms;
+		return;
+	}
+	r_cull_ms = p_perf.culling_time_ms;
+	r_sort_ms = p_frame_state.sort_time_ms;
+	r_raster_ms = p_frame_state.render_time_ms;
+	r_composite_ms = 0.0f;
+}
+
+static bool _has_gpu_pass_breakdown(const GaussianSplatRenderer::PerformanceMetrics &p_perf) {
+	const bool valid_flags[] = {
+		p_perf.gpu_tile_overlap_count_time_valid,
+		p_perf.gpu_tile_overlap_emit_time_valid,
+		p_perf.gpu_tile_overlap_sort_time_valid,
+		p_perf.tile_overlap_sort_cpu_dispatch_valid,
+		p_perf.gpu_tile_prefix_time_valid,
+		p_perf.tile_prefix_cpu_sync_fallback_valid,
+		p_perf.gpu_tile_raster_time_valid,
+		p_perf.gpu_tile_resolve_time_valid,
+	};
+	for (int i = 0; i < 8; i++) {
+		if (valid_flags[i]) {
+			return true;
+		}
+	}
+
+	const float timing_values[] = {
+		p_perf.gpu_tile_binning_time_ms,
+		p_perf.gpu_tile_prefix_time_ms,
+		p_perf.gpu_tile_raster_time_ms,
+		p_perf.gpu_tile_resolve_time_ms,
+	};
+	for (int i = 0; i < 4; i++) {
+		if (timing_values[i] > 0.0f) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static void _append_production_frame_metrics(Dictionary &r_metrics,
+		const GaussianSplatRenderer::FrameState &p_frame_state, uint32_t p_visible_splats,
+		uint32_t p_total_splats, float p_frame_time_ms, float p_cull_ms, float p_sort_ms,
+		float p_raster_ms, float p_composite_ms) {
+	r_metrics["frame"] = static_cast<int64_t>(p_frame_state.frame_counter);
+	r_metrics["visible_splats"] = static_cast<int64_t>(p_visible_splats);
+	r_metrics["total_splats"] = static_cast<int64_t>(p_total_splats);
+	r_metrics["cull_ms"] = p_cull_ms;
+	r_metrics["sort_ms"] = p_sort_ms;
+	r_metrics["raster_ms"] = p_raster_ms;
+	r_metrics["composite_ms"] = p_composite_ms;
+	r_metrics["stage_total_ms"] = p_cull_ms + p_sort_ms + p_raster_ms;
+	r_metrics["render_ms"] = p_frame_state.render_time_ms;
+	r_metrics["frame_time_ms"] = p_frame_time_ms;
+}
+
+static void _append_production_gpu_metrics(Dictionary &r_metrics,
+		const GaussianSplatRenderer::PerformanceMetrics &p_perf) {
+	r_metrics["gpu_frame_ms"] = p_perf.gpu_frame_time_ms;
+	r_metrics["gpu_frame_valid"] = p_perf.gpu_frame_time_valid;
+	r_metrics["gpu_overlap_count_ms"] = p_perf.gpu_tile_overlap_count_time_ms;
+	r_metrics["gpu_overlap_count_valid"] = p_perf.gpu_tile_overlap_count_time_valid;
+	r_metrics["gpu_overlap_emit_ms"] = p_perf.gpu_tile_overlap_emit_time_ms;
+	r_metrics["gpu_overlap_emit_valid"] = p_perf.gpu_tile_overlap_emit_time_valid;
+	r_metrics["gpu_overlap_sort_ms"] = p_perf.gpu_tile_overlap_sort_time_ms;
+	r_metrics["gpu_overlap_sort_valid"] = p_perf.gpu_tile_overlap_sort_time_valid;
+	r_metrics["overlap_sort_cpu_dispatch_ms"] = p_perf.tile_overlap_sort_cpu_dispatch_ms;
+	r_metrics["overlap_sort_cpu_dispatch_valid"] = p_perf.tile_overlap_sort_cpu_dispatch_valid;
+	r_metrics["gpu_binning_ms"] = p_perf.gpu_tile_binning_time_ms;
+	r_metrics["gpu_prefix_ms"] = p_perf.gpu_tile_prefix_time_ms;
+	r_metrics["gpu_prefix_valid"] = p_perf.gpu_tile_prefix_time_valid;
+	r_metrics["prefix_cpu_sync_fallback_ms"] = p_perf.tile_prefix_cpu_sync_fallback_ms;
+	r_metrics["prefix_cpu_sync_fallback_valid"] = p_perf.tile_prefix_cpu_sync_fallback_valid;
+	r_metrics["gpu_raster_ms"] = p_perf.gpu_tile_raster_time_ms;
+	r_metrics["gpu_raster_valid"] = p_perf.gpu_tile_raster_time_valid;
+	r_metrics["gpu_resolve_ms"] = p_perf.gpu_tile_resolve_time_ms;
+	r_metrics["gpu_resolve_valid"] = p_perf.gpu_tile_resolve_time_valid;
+	r_metrics["gpu_timing_frame_serial"] = static_cast<int64_t>(p_perf.gpu_timing_frame_serial);
+	r_metrics["gpu_timing_frames_behind"] = static_cast<int64_t>(p_perf.gpu_timing_frames_behind);
+	r_metrics["gpu_pass_breakdown_available"] = _has_gpu_pass_breakdown(p_perf);
+}
+
+static String _resolve_production_raster_path(const GaussianSplatRenderer::PerformanceMetrics &p_perf,
+		const GaussianSplatRenderer::StageMetrics &p_stage_metrics, bool p_stage_valid) {
+	String raster_path = p_perf.raster_path;
+	if (p_stage_valid && !p_stage_metrics.raster.raster_path.is_empty()) {
+		raster_path = p_stage_metrics.raster.raster_path;
+	}
+	if (raster_path.is_empty()) {
+		raster_path = "unknown";
+	}
+	return raster_path;
+}
+
+static String _stage_status_snapshot(bool p_stage_valid,
+		GaussianSplatRenderer::StageResult::StageStatus p_status) {
+	if (!p_stage_valid) {
+		return "unknown";
+	}
+	return _stage_status_to_string(p_status);
+}
+
+static void _append_production_stage_contract_metrics(Dictionary &r_metrics,
+		const GaussianSplatRenderer::StageMetrics &p_stage_metrics, bool p_stage_valid) {
+	r_metrics["stage_metrics_valid"] = p_stage_valid;
+	r_metrics["stage_cull_status"] = _stage_status_snapshot(p_stage_valid, p_stage_metrics.cull_result.status);
+	r_metrics["stage_sort_status"] = _stage_status_snapshot(p_stage_valid, p_stage_metrics.sort_result.status);
+	r_metrics["stage_raster_status"] = _stage_status_snapshot(p_stage_valid, p_stage_metrics.raster_result.status);
+	r_metrics["stage_composite_status"] = _stage_status_snapshot(p_stage_valid, p_stage_metrics.composite_result.status);
+	r_metrics["stage_first_failure"] = p_stage_valid ? p_stage_metrics.first_failure_stage : String();
+	r_metrics["stage_skip_cause"] = p_stage_valid ? p_stage_metrics.skip_cause_stage : String();
+	r_metrics["stage_has_degradation"] = p_stage_valid ? p_stage_metrics.has_degradation : false;
+	r_metrics["stage_composite_depth_test_honored"] = p_stage_valid ? p_stage_metrics.composite_depth_test_honored : true;
+}
+
 static Dictionary _build_production_metrics_snapshot(GaussianSplatRenderer &p_renderer,
 		const GaussianSplatRenderer::StageMetrics &p_stage_metrics, bool p_stage_valid, float p_frame_time_ms) {
 	Dictionary metrics;
@@ -249,80 +379,24 @@ static Dictionary _build_production_metrics_snapshot(GaussianSplatRenderer &p_re
 	const auto &debug_state = state_view.get_debug_state_view();
 	uint32_t visible_splats = frame_state.visible_splat_count.load(std::memory_order_acquire);
 	const auto &scene_state = state_view.get_scene_state();
-	uint32_t total_splats = scene_state.gaussian_data.is_valid()
-			? scene_state.gaussian_data->get_count()
-			: scene_state.payload_source_splat_count;
-	float cull_ms = p_stage_valid ? p_stage_metrics.cull.cull_time_ms : perf.culling_time_ms;
-	float sort_ms = p_stage_valid ? p_stage_metrics.sort.sort_time_ms : frame_state.sort_time_ms;
-	float raster_ms = p_stage_valid ? p_stage_metrics.raster.render_time_ms : frame_state.render_time_ms;
-	float composite_ms = p_stage_valid ? p_stage_metrics.composite_time_ms : 0.0f;
-	float stage_total_ms = cull_ms + sort_ms + raster_ms;
+	uint32_t total_splats = _resolve_production_total_splats(scene_state);
+	float cull_ms = 0.0f;
+	float sort_ms = 0.0f;
+	float raster_ms = 0.0f;
+	float composite_ms = 0.0f;
+	_resolve_production_stage_times(p_stage_metrics, p_stage_valid, perf, frame_state,
+			cull_ms, sort_ms, raster_ms, composite_ms);
 
-	metrics["frame"] = static_cast<int64_t>(frame_state.frame_counter);
-	metrics["visible_splats"] = static_cast<int64_t>(visible_splats);
-	metrics["total_splats"] = static_cast<int64_t>(total_splats);
-	metrics["cull_ms"] = cull_ms;
-	metrics["sort_ms"] = sort_ms;
-	metrics["raster_ms"] = raster_ms;
-	metrics["composite_ms"] = composite_ms;
-	metrics["stage_total_ms"] = stage_total_ms;
-	metrics["render_ms"] = frame_state.render_time_ms;
-	metrics["frame_time_ms"] = p_frame_time_ms;
-	metrics["gpu_frame_ms"] = perf.gpu_frame_time_ms;
-	metrics["gpu_frame_valid"] = perf.gpu_frame_time_valid;
-	metrics["gpu_overlap_count_ms"] = perf.gpu_tile_overlap_count_time_ms;
-	metrics["gpu_overlap_count_valid"] = perf.gpu_tile_overlap_count_time_valid;
-	metrics["gpu_overlap_emit_ms"] = perf.gpu_tile_overlap_emit_time_ms;
-	metrics["gpu_overlap_emit_valid"] = perf.gpu_tile_overlap_emit_time_valid;
-	metrics["gpu_overlap_sort_ms"] = perf.gpu_tile_overlap_sort_time_ms;
-	metrics["gpu_overlap_sort_valid"] = perf.gpu_tile_overlap_sort_time_valid;
-	metrics["overlap_sort_cpu_dispatch_ms"] = perf.tile_overlap_sort_cpu_dispatch_ms;
-	metrics["overlap_sort_cpu_dispatch_valid"] = perf.tile_overlap_sort_cpu_dispatch_valid;
-	metrics["gpu_binning_ms"] = perf.gpu_tile_binning_time_ms;
-	metrics["gpu_prefix_ms"] = perf.gpu_tile_prefix_time_ms;
-	metrics["gpu_prefix_valid"] = perf.gpu_tile_prefix_time_valid;
-	metrics["prefix_cpu_sync_fallback_ms"] = perf.tile_prefix_cpu_sync_fallback_ms;
-	metrics["prefix_cpu_sync_fallback_valid"] = perf.tile_prefix_cpu_sync_fallback_valid;
-	metrics["gpu_raster_ms"] = perf.gpu_tile_raster_time_ms;
-	metrics["gpu_raster_valid"] = perf.gpu_tile_raster_time_valid;
-	metrics["gpu_resolve_ms"] = perf.gpu_tile_resolve_time_ms;
-	metrics["gpu_resolve_valid"] = perf.gpu_tile_resolve_time_valid;
-	metrics["gpu_timing_frame_serial"] = static_cast<int64_t>(perf.gpu_timing_frame_serial);
-	metrics["gpu_timing_frames_behind"] = static_cast<int64_t>(perf.gpu_timing_frames_behind);
-	metrics["gpu_pass_breakdown_available"] = perf.gpu_tile_overlap_count_time_valid ||
-			perf.gpu_tile_overlap_emit_time_valid ||
-			perf.gpu_tile_overlap_sort_time_valid ||
-			perf.tile_overlap_sort_cpu_dispatch_valid ||
-			perf.gpu_tile_prefix_time_valid ||
-			perf.tile_prefix_cpu_sync_fallback_valid ||
-			perf.gpu_tile_raster_time_valid ||
-			perf.gpu_tile_resolve_time_valid ||
-			perf.gpu_tile_binning_time_ms > 0.0f ||
-			perf.gpu_tile_prefix_time_ms > 0.0f ||
-			perf.gpu_tile_raster_time_ms > 0.0f ||
-			perf.gpu_tile_resolve_time_ms > 0.0f;
+	_append_production_frame_metrics(metrics, frame_state, visible_splats, total_splats, p_frame_time_ms,
+			cull_ms, sort_ms, raster_ms, composite_ms);
+	_append_production_gpu_metrics(metrics, perf);
 	metrics["data_source"] = perf.data_source;
 	metrics["data_source_error"] = perf.data_source_error;
-	String raster_path = perf.raster_path;
-	if (p_stage_valid && !p_stage_metrics.raster.raster_path.is_empty()) {
-		raster_path = p_stage_metrics.raster.raster_path;
-	}
-	if (raster_path.is_empty()) {
-		raster_path = "unknown";
-	}
-	metrics["raster_path"] = raster_path;
+	metrics["raster_path"] = _resolve_production_raster_path(perf, p_stage_metrics, p_stage_valid);
 	_append_raster_specialization_metrics(perf, metrics);
 	const auto &render_config = state_view.get_render_config_view();
 	metrics["render_mode"] = static_cast<int64_t>(render_config.render_mode);
-	metrics["stage_metrics_valid"] = p_stage_valid;
-	metrics["stage_cull_status"] = p_stage_valid ? _stage_status_to_string(p_stage_metrics.cull_result.status) : String("unknown");
-	metrics["stage_sort_status"] = p_stage_valid ? _stage_status_to_string(p_stage_metrics.sort_result.status) : String("unknown");
-	metrics["stage_raster_status"] = p_stage_valid ? _stage_status_to_string(p_stage_metrics.raster_result.status) : String("unknown");
-	metrics["stage_composite_status"] = p_stage_valid ? _stage_status_to_string(p_stage_metrics.composite_result.status) : String("unknown");
-	metrics["stage_first_failure"] = p_stage_valid ? p_stage_metrics.first_failure_stage : String();
-	metrics["stage_skip_cause"] = p_stage_valid ? p_stage_metrics.skip_cause_stage : String();
-	metrics["stage_has_degradation"] = p_stage_valid ? p_stage_metrics.has_degradation : false;
-	metrics["stage_composite_depth_test_honored"] = p_stage_valid ? p_stage_metrics.composite_depth_test_honored : true;
+	_append_production_stage_contract_metrics(metrics, p_stage_metrics, p_stage_valid);
 	metrics["route_uid"] = debug_state.route_uid;
 	metrics["sort_route_uid"] = debug_state.sort_route_uid;
 	metrics["cull_route_uid"] = _normalize_cull_route_uid_for_stats(perf.cull_route_uid);

--- a/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.cpp
@@ -186,6 +186,10 @@ static Array _production_metrics_contract() {
 	keys.push_back("stage_sort_status");
 	keys.push_back("stage_raster_status");
 	keys.push_back("stage_composite_status");
+	keys.push_back("stage_first_failure");
+	keys.push_back("stage_skip_cause");
+	keys.push_back("stage_has_degradation");
+	keys.push_back("stage_composite_depth_test_honored");
 	keys.push_back("route_uid");
 	keys.push_back("sort_route_uid");
 	keys.push_back("cull_route_uid");
@@ -315,6 +319,10 @@ static Dictionary _build_production_metrics_snapshot(GaussianSplatRenderer &p_re
 	metrics["stage_sort_status"] = p_stage_valid ? _stage_status_to_string(p_stage_metrics.sort_result.status) : String("unknown");
 	metrics["stage_raster_status"] = p_stage_valid ? _stage_status_to_string(p_stage_metrics.raster_result.status) : String("unknown");
 	metrics["stage_composite_status"] = p_stage_valid ? _stage_status_to_string(p_stage_metrics.composite_result.status) : String("unknown");
+	metrics["stage_first_failure"] = p_stage_valid ? p_stage_metrics.first_failure_stage : String();
+	metrics["stage_skip_cause"] = p_stage_valid ? p_stage_metrics.skip_cause_stage : String();
+	metrics["stage_has_degradation"] = p_stage_valid ? p_stage_metrics.has_degradation : false;
+	metrics["stage_composite_depth_test_honored"] = p_stage_valid ? p_stage_metrics.composite_depth_test_honored : true;
 	metrics["route_uid"] = debug_state.route_uid;
 	metrics["sort_route_uid"] = debug_state.sort_route_uid;
 	metrics["cull_route_uid"] = _normalize_cull_route_uid_for_stats(perf.cull_route_uid);
@@ -442,6 +450,15 @@ static void _append_telemetry_extras(const GaussianSplatRenderer &p_renderer,
 	r_metrics["stage_composite_status"] = p_stage_valid ? _stage_status_to_string(p_stage_metrics.composite_result.status) : String("unknown");
 	r_metrics["stage_composite_reason"] = p_stage_metrics.composite_result.reason;
 	r_metrics["stage_composite_is_error"] = p_stage_metrics.composite_result.is_error;
+	r_metrics["stage_first_failure"] = p_stage_metrics.first_failure_stage;
+	r_metrics["stage_skip_cause"] = p_stage_metrics.skip_cause_stage;
+	r_metrics["stage_first_failure_instance_index"] = static_cast<int64_t>(p_stage_metrics.first_failure_instance_index);
+	r_metrics["stage_first_skipped_instance_index"] = static_cast<int64_t>(p_stage_metrics.first_skipped_instance_index);
+	r_metrics["stage_has_degradation"] = p_stage_metrics.has_degradation;
+	r_metrics["stage_degradation_reason"] = p_stage_metrics.degradation_reason;
+	r_metrics["stage_composite_depth_test_honored"] = p_stage_metrics.composite_depth_test_honored;
+	r_metrics["stage_composite_degraded"] = p_stage_metrics.composite_result.degraded;
+	r_metrics["stage_composite_strict_contract_violation"] = p_stage_metrics.composite_result.strict_contract_violation;
 	r_metrics["route_uid"] = debug_state.route_uid;
 	r_metrics["sort_route_uid"] = debug_state.sort_route_uid;
 	_append_raster_specialization_metrics(perf, r_metrics);
@@ -1371,6 +1388,16 @@ Dictionary RenderDiagnosticsOrchestrator::build_render_stats() const {
 	stats["cull_route_reason"] = perf.cull_route_reason;
 	stats["cull_route_reason_label"] =
 			GaussianRenderRouteLabels::describe_cull_route_reason(perf.cull_route_reason);
+	if (debug_state.last_stage_metrics_valid) {
+		const GaussianSplatRenderer::StageMetrics &stage_metrics = debug_state.last_stage_metrics;
+		stats["stage_first_failure"] = stage_metrics.first_failure_stage;
+		stats["stage_skip_cause"] = stage_metrics.skip_cause_stage;
+		stats["stage_first_failure_instance_index"] = static_cast<int64_t>(stage_metrics.first_failure_instance_index);
+		stats["stage_first_skipped_instance_index"] = static_cast<int64_t>(stage_metrics.first_skipped_instance_index);
+		stats["stage_has_degradation"] = stage_metrics.has_degradation;
+		stats["stage_degradation_reason"] = stage_metrics.degradation_reason;
+		stats["stage_composite_depth_test_honored"] = stage_metrics.composite_depth_test_honored;
+	}
 	Dictionary effective_config_snapshot = g_sh_config.get_effective_config_snapshot();
 	GaussianEffectiveConfig::merge_into(effective_config_snapshot, g_pipeline_feature_set.get_effective_config_snapshot());
 	GaussianEffectiveConfig::set_entry(effective_config_snapshot,

--- a/modules/gaussian_splatting/renderer/render_instancing_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_instancing_orchestrator.cpp
@@ -19,6 +19,7 @@ static void _reset_output_cache_after_readiness_failure(OutputCompositor::Output
 	r_output_cache.last_depth_test_honored = true;
 	r_output_cache.last_copy_degraded = false;
 	r_output_cache.last_copy_degradation_reason = String();
+	r_output_cache.last_strict_depth_contract_required = false;
 	r_output_cache.render_buffers_commit_pending = false;
 	r_output_cache.pending_render_buffers_size = Size2i();
 	r_output_cache.pending_painterly_commit = false;

--- a/modules/gaussian_splatting/renderer/render_instancing_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_instancing_orchestrator.cpp
@@ -16,6 +16,9 @@ static void _reset_output_cache_after_readiness_failure(OutputCompositor::Output
 	r_output_cache.last_viewport_copy_success = false;
 	r_output_cache.last_viewport_copy_source_size = Size2i();
 	r_output_cache.last_viewport_copy_dest_size = Size2i();
+	r_output_cache.last_depth_test_honored = true;
+	r_output_cache.last_copy_degraded = false;
+	r_output_cache.last_copy_degradation_reason = String();
 	r_output_cache.render_buffers_commit_pending = false;
 	r_output_cache.pending_render_buffers_size = Size2i();
 	r_output_cache.pending_painterly_commit = false;
@@ -134,6 +137,8 @@ void RenderInstancingOrchestrator::render_instanced(RenderDataRD *p_render_data,
 	uint64_t aggregated_visible_splats = 0;
 	bool any_render_performed = false;
 	bool any_viewport_copy = false;
+	int32_t first_failed_instance_index = -1;
+	int32_t first_skipped_instance_index = -1;
 	Size2i last_copy_source_size;
 	Size2i last_copy_dest_size;
 
@@ -183,9 +188,20 @@ void RenderInstancingOrchestrator::render_instanced(RenderDataRD *p_render_data,
 			&frame_provider
 		};
 		GaussianSplatRenderer::CullStageOutput cull_output;
-		pipeline_stages->execute_cull_stage(cull_input, cull_output);
+		const GaussianSplatRenderer::StageResult cull_result =
+				pipeline_stages->execute_cull_stage(cull_input, cull_output);
 		GaussianSplatRenderer::SortStageOutput sort_output;
-		if (cull_output.has_visible) {
+		if (cull_result.is_error || !cull_result.is_success()) {
+			stage_metrics.sort = GaussianSplatRenderer::SortStageOutput();
+			const String sort_reason = cull_result.reason.is_empty()
+					? String("Sort skipped: cull failed")
+					: vformat("Sort skipped: cull %s", cull_result.reason);
+			stage_metrics.sort_result = RenderPipelineStages::make_downstream_skip_result(
+					"sort", cull_result, sort_reason, cull_result.fallback_reason);
+			RenderPipelineStages::stamp_stage_result_contract(stage_metrics.sort_result, "sort",
+					cull_result.route_uid, cull_result.output_domain,
+					GaussianSplatRenderer::IndexDomain::UNKNOWN, cull_result.output_count, 0);
+		} else if (cull_output.has_visible) {
 			GaussianSplatRenderer::SortStageInput sort_input{
 				frame_context.frame_id,
 				frame_context.world_to_camera_transform,
@@ -195,6 +211,15 @@ void RenderInstancingOrchestrator::render_instanced(RenderDataRD *p_render_data,
 				cull_output.visible_domain
 			};
 			pipeline_stages->execute_sort_stage(sort_input, sort_output);
+		} else {
+			stage_metrics.sort = GaussianSplatRenderer::SortStageOutput();
+			stage_metrics.sort_result = GaussianSplatRenderer::StageResult();
+			stage_metrics.sort_result.status = GaussianSplatRenderer::StageResult::StageStatus::SKIPPED;
+			stage_metrics.sort_result.reason = "Sort skipped: no visible splats";
+			stage_metrics.sort_result.fallback_reason = GaussianSplatRenderer::RenderFallbackReason::NO_VISIBLE_SPLATS;
+			RenderPipelineStages::stamp_stage_result_contract(stage_metrics.sort_result, "sort",
+					cull_result.route_uid, cull_output.visible_domain,
+					GaussianSplatRenderer::IndexDomain::UNKNOWN, cull_output.visible_count, 0);
 		}
 		frame_context.snapshot.valid = true;
 		frame_context.snapshot.cull_visible_domain = cull_output.visible_domain;
@@ -217,6 +242,12 @@ void RenderInstancingOrchestrator::render_instanced(RenderDataRD *p_render_data,
 		uint64_t before_frame_counter = frame_state_view.get_frame_state_view().frame_counter;
 
 		pipeline_stages->render_sorted_splats_with_context(frame_context);
+		if (first_failed_instance_index < 0 && !stage_metrics.first_failure_stage.is_empty()) {
+			first_failed_instance_index = instance_index;
+		}
+		if (first_skipped_instance_index < 0 && !stage_metrics.skip_cause_stage.is_empty()) {
+			first_skipped_instance_index = instance_index;
+		}
 
 		const GaussianSplatRenderer::FrameState &render_frame_state = frame_state_view.get_frame_state_view();
 		accumulated_render_time_ms += render_frame_state.render_time_ms;
@@ -243,6 +274,10 @@ void RenderInstancingOrchestrator::render_instanced(RenderDataRD *p_render_data,
 			static_cast<uint32_t>(MIN<uint64_t>(aggregated_visible_splats, UINT32_MAX)),
 			std::memory_order_release);
 	output_cache.has_valid_render = any_render_performed;
+	if (renderer->get_debug_state().last_stage_metrics_valid) {
+		renderer->get_debug_state().last_stage_metrics.first_failure_instance_index = first_failed_instance_index;
+		renderer->get_debug_state().last_stage_metrics.first_skipped_instance_index = first_skipped_instance_index;
+	}
 
 	if (any_viewport_copy) {
 		output_cache.last_viewport_copy_success = true;

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -658,6 +658,43 @@ static void _finalize_stage_io(GaussianSplatRenderer *p_renderer, const char *p_
 		_record_validation_event(p_renderer, p_stage, p_io);
 	}
 }
+
+static GaussianSplatRenderer::RenderRouteDecision _build_route_decision(
+		GaussianSplatRenderer::InstanceBackendPolicy p_instance_backend_policy,
+		const GaussianSplatRenderer::DataSourcePlan &p_data_source,
+		bool p_has_render_data,
+		const String &p_no_data_reason) {
+	GaussianSplatRenderer::RenderRouteDecision decision;
+	decision.valid = true;
+	decision.has_render_data = p_has_render_data;
+	decision.data_source = p_data_source.source.source_name;
+	if (!p_has_render_data) {
+		decision.selected_backend = GaussianSplatRenderer::RenderRouteBackend::NONE;
+		decision.selected_backend_name = GaussianRenderPipeline::render_route_backend_to_string(decision.selected_backend);
+		decision.route_uid = RenderRouteUID::COMMON_SKIP_NO_DATA;
+		decision.reason = p_no_data_reason.is_empty() ? String("no_render_data") : p_no_data_reason;
+		return decision;
+	}
+	switch (p_instance_backend_policy) {
+		case GaussianSplatRenderer::InstanceBackendPolicy::RESIDENT:
+			decision.selected_backend = GaussianSplatRenderer::RenderRouteBackend::RESIDENT;
+			decision.route_uid = RenderRouteUID::INSTANCE_RESIDENT;
+			decision.reason = "selected_resident_instance_backend";
+			break;
+		case GaussianSplatRenderer::InstanceBackendPolicy::STREAMING:
+			decision.selected_backend = GaussianSplatRenderer::RenderRouteBackend::STREAMING;
+			decision.route_uid = RenderRouteUID::INSTANCE_STREAMING;
+			decision.reason = "selected_streaming_instance_backend";
+			break;
+		case GaussianSplatRenderer::InstanceBackendPolicy::NONE:
+			decision.selected_backend = GaussianSplatRenderer::RenderRouteBackend::NONE;
+			decision.route_uid = RenderRouteUID::COMMON_UNSET_ROUTE;
+			decision.reason = "no_instance_backend_selected";
+			break;
+	}
+	decision.selected_backend_name = GaussianRenderPipeline::render_route_backend_to_string(decision.selected_backend);
+	return decision;
+}
 } // namespace
 
 // Frame planning static helpers (moved from GaussianSplatRenderer)
@@ -690,6 +727,99 @@ void RenderPipelineStages::apply_data_source_plan(const DataSourcePlan &p_plan, 
 	(void)p_resource_state;
 }
 
+void RenderPipelineStages::stamp_stage_result_contract(StageResult &r_result, const char *p_stage_name,
+		const String &p_route_uid, GaussianSplatRenderer::IndexDomain p_input_domain,
+		GaussianSplatRenderer::IndexDomain p_output_domain, uint32_t p_input_count,
+		uint32_t p_output_count) {
+	r_result.stage_name = p_stage_name ? String(p_stage_name) : String();
+	r_result.route_uid = p_route_uid;
+	r_result.input_domain = p_input_domain;
+	r_result.output_domain = p_output_domain;
+	r_result.input_count = p_input_count;
+	r_result.output_count = p_output_count;
+	if (r_result.status == StageResult::StageStatus::FAILED && r_result.first_failure_stage.is_empty()) {
+		r_result.first_failure_stage = r_result.stage_name;
+	}
+}
+
+RenderPipelineStages::StageResult RenderPipelineStages::make_downstream_skip_result(const char *p_stage_name,
+		const StageResult &p_upstream_result, const String &p_reason, RenderFallbackReason p_fallback_reason) {
+	StageResult result = _make_stage_result(StageResult::StageStatus::SKIPPED, p_reason, false, p_fallback_reason);
+	result.stage_name = p_stage_name ? String(p_stage_name) : String();
+	result.route_uid = p_upstream_result.route_uid;
+	result.first_failure_stage = !p_upstream_result.first_failure_stage.is_empty()
+			? p_upstream_result.first_failure_stage
+			: p_upstream_result.stage_name;
+	result.skip_cause_stage = !p_upstream_result.stage_name.is_empty()
+			? p_upstream_result.stage_name
+			: result.first_failure_stage;
+	return result;
+}
+
+void RenderPipelineStages::finalize_stage_contracts(StageMetrics &r_metrics, const RenderFramePlan &p_frame_plan) {
+	const String route_uid = p_frame_plan.route_decision.route_uid;
+	r_metrics.route_uid = route_uid;
+	r_metrics.selected_route_backend = p_frame_plan.route_decision.selected_backend_name;
+	if (r_metrics.cull_result.route_uid.is_empty()) {
+		r_metrics.cull_result.route_uid = route_uid;
+	}
+	if (r_metrics.sort_result.route_uid.is_empty()) {
+		r_metrics.sort_result.route_uid = route_uid;
+	}
+	if (r_metrics.raster_result.route_uid.is_empty()) {
+		r_metrics.raster_result.route_uid = route_uid;
+	}
+	if (r_metrics.composite_result.route_uid.is_empty()) {
+		r_metrics.composite_result.route_uid = route_uid;
+	}
+
+	if (!r_metrics.cull_result.first_failure_stage.is_empty()) {
+		r_metrics.first_failure_stage = r_metrics.cull_result.first_failure_stage;
+	} else if (!r_metrics.sort_result.first_failure_stage.is_empty()) {
+		r_metrics.first_failure_stage = r_metrics.sort_result.first_failure_stage;
+	} else if (!r_metrics.raster_result.first_failure_stage.is_empty()) {
+		r_metrics.first_failure_stage = r_metrics.raster_result.first_failure_stage;
+	} else if (!r_metrics.composite_result.first_failure_stage.is_empty()) {
+		r_metrics.first_failure_stage = r_metrics.composite_result.first_failure_stage;
+	}
+	if (r_metrics.first_failure_stage.is_empty()) {
+		if (r_metrics.cull_result.status == StageResult::StageStatus::FAILED) {
+			r_metrics.first_failure_stage = "cull";
+		} else if (r_metrics.sort_result.status == StageResult::StageStatus::FAILED) {
+			r_metrics.first_failure_stage = "sort";
+		} else if (r_metrics.raster_result.status == StageResult::StageStatus::FAILED) {
+			r_metrics.first_failure_stage = "raster";
+		} else if (r_metrics.composite_result.status == StageResult::StageStatus::FAILED) {
+			r_metrics.first_failure_stage = "composite";
+		}
+	}
+
+	if (!r_metrics.sort_result.skip_cause_stage.is_empty()) {
+		r_metrics.skip_cause_stage = r_metrics.sort_result.skip_cause_stage;
+	}
+	if (!r_metrics.raster_result.skip_cause_stage.is_empty()) {
+		r_metrics.skip_cause_stage = r_metrics.raster_result.skip_cause_stage;
+	}
+	if (!r_metrics.composite_result.skip_cause_stage.is_empty()) {
+		r_metrics.skip_cause_stage = r_metrics.composite_result.skip_cause_stage;
+	}
+
+	r_metrics.has_degradation = r_metrics.cull_result.degraded || r_metrics.sort_result.degraded ||
+			r_metrics.raster_result.degraded || r_metrics.composite_result.degraded;
+	r_metrics.composite_depth_test_honored = r_metrics.composite_result.depth_test_honored;
+	if (r_metrics.degradation_reason.is_empty()) {
+		if (!r_metrics.composite_result.degradation_reason.is_empty()) {
+			r_metrics.degradation_reason = r_metrics.composite_result.degradation_reason;
+		} else if (!r_metrics.raster_result.degradation_reason.is_empty()) {
+			r_metrics.degradation_reason = r_metrics.raster_result.degradation_reason;
+		} else if (!r_metrics.sort_result.degradation_reason.is_empty()) {
+			r_metrics.degradation_reason = r_metrics.sort_result.degradation_reason;
+		} else if (!r_metrics.cull_result.degradation_reason.is_empty()) {
+			r_metrics.degradation_reason = r_metrics.cull_result.degradation_reason;
+		}
+	}
+}
+
 RenderPipelineStages::RenderFramePlan RenderPipelineStages::build_frame_plan(
 		const SceneState &p_scene_state,
 		const StreamingState &p_streaming_state,
@@ -719,6 +849,8 @@ RenderPipelineStages::RenderFramePlan RenderPipelineStages::build_frame_plan(
 	plan.sort_skip_reason_code = p_sort_skip_reason_code;
 	plan.data_source = build_data_source_plan(p_scene_state, p_streaming_state, p_sorting_state,
 			p_instance_buffers, p_instance_backend_policy, p_resource_state, p_subsystem_state);
+	plan.route_decision = _build_route_decision(p_instance_backend_policy, plan.data_source,
+			p_has_render_data, p_cull_skip_reason);
 	return plan;
 }
 
@@ -923,11 +1055,15 @@ void RenderPipelineStages::execute_frame_entry(const RenderFrameContext &p_frame
 					frame_plan.cull_skip_reason,
 					false,
 					frame_plan.cull_skip_reason_code);
+			stamp_stage_result_contract(frame_context.metrics->cull_result, "cull", frame_plan.route_decision.route_uid,
+					GaussianSplatRenderer::IndexDomain::UNKNOWN, GaussianSplatRenderer::IndexDomain::UNKNOWN, 0, 0);
 			frame_context.metrics->sort_result = _make_stage_result(
 					StageResult::StageStatus::SKIPPED,
 					frame_plan.sort_skip_reason,
 					false,
 					frame_plan.sort_skip_reason_code);
+			stamp_stage_result_contract(frame_context.metrics->sort_result, "sort", frame_plan.route_decision.route_uid,
+					GaussianSplatRenderer::IndexDomain::UNKNOWN, GaussianSplatRenderer::IndexDomain::UNKNOWN, 0, 0);
 		}
 		render_sorted_splats_with_context(frame_context);
 		return;
@@ -964,11 +1100,11 @@ void RenderPipelineStages::execute_frame_entry(const RenderFrameContext &p_frame
 			const String sort_reason = cull_result.reason.is_empty()
 					? String("Sort skipped: cull failed")
 					: vformat("Sort skipped: cull %s (%s)", _stage_status_label(cull_result.status), cull_result.reason);
-			frame_context.metrics->sort_result = _make_stage_result(
-					GaussianSplatRenderer::StageResult::StageStatus::SKIPPED,
-					sort_reason,
-					false,
-					cull_result.fallback_reason);
+			frame_context.metrics->sort_result = make_downstream_skip_result(
+					"sort", cull_result, sort_reason, cull_result.fallback_reason);
+			stamp_stage_result_contract(frame_context.metrics->sort_result, "sort", cull_result.route_uid,
+					cull_result.output_domain, GaussianSplatRenderer::IndexDomain::UNKNOWN,
+					cull_result.output_count, 0);
 		}
 		// Set route_uid so the debug HUD reflects the cascade rather than the
 		// previous frame's value. Only attribute a FAILURE UID when cull actually
@@ -1057,6 +1193,9 @@ struct RenderPipelineStages::CullStage {
 		if (!gpu_culler) {
 			result = _make_stage_result(StageResult::StageStatus::FAILED, "Culling failed: GPU culler unavailable", true,
 					GaussianSplatRenderer::RenderFallbackReason::GPU_CULLER_UNAVAILABLE);
+			RenderPipelineStages::stamp_stage_result_contract(result, "cull", RenderRouteUID::COMMON_FAIL_NO_DEVICE,
+					GaussianSplatRenderer::IndexDomain::UNKNOWN, r_output.visible_domain,
+					r_output.candidate_count, r_output.visible_count);
 			_record_pipeline_event(renderer, "cull",
 					"fail: gpu_culler unavailable",
 					0, 0, true,
@@ -1101,6 +1240,9 @@ struct RenderPipelineStages::CullStage {
 		} else {
 			result = _make_stage_result(StageResult::StageStatus::SKIPPED, "Culling skipped: instance buffers missing", false,
 					GaussianSplatRenderer::RenderFallbackReason::DATA_UNAVAILABLE);
+			RenderPipelineStages::stamp_stage_result_contract(result, "cull", RenderRouteUID::COMMON_SKIP_NO_DATA,
+					GaussianSplatRenderer::IndexDomain::UNKNOWN, r_output.visible_domain,
+					0, 0);
 			_record_pipeline_event(renderer, "cull",
 					"skip: instance buffers missing",
 					0, 0, false,
@@ -1132,6 +1274,10 @@ struct RenderPipelineStages::CullStage {
 					"Culling failed: output domain unresolved", true,
 					GaussianSplatRenderer::RenderFallbackReason::NONE);
 		}
+		RenderPipelineStages::stamp_stage_result_contract(result, "cull",
+				result.status == StageResult::StageStatus::FAILED ? String(RenderRouteUID::COMMON_FAIL_SORT_FAILED) : String(RenderRouteUID::INSTANCE_CULL_GPU),
+				GaussianSplatRenderer::IndexDomain::UNKNOWN, r_output.visible_domain,
+				r_output.candidate_count, r_output.visible_count);
 		_record_pipeline_event(renderer, "cull",
 				vformat("output candidates=%d visible=%d domain=%s",
 						r_output.candidate_count, r_output.visible_count,
@@ -1182,13 +1328,22 @@ struct RenderPipelineStages::SortStage {
 			r_output = GaussianSplatRenderer::SortStageOutput();
 			r_output.input_count = p_input.input_count;
 			r_output.input_domain = p_input.input_domain;
+			const String sort_gpu_uid = RenderRouteUID::INSTANCE_SORT_GPU;
 
 			GaussianSplatRenderer::FrameStateProvider fallback_provider(renderer);
 			const GaussianSplatRenderer::IFrameStateView &state_view =
 					p_input.state_view ? *p_input.state_view : fallback_provider;
-			auto finalize_sort_metrics = [&](const StageResult &p_result) {
+			auto finalize_sort_metrics = [&](StageResult p_result) -> StageResult {
+				String sort_route_uid = renderer->get_debug_state().sort_route_uid;
+				if (RenderRouteUID::is_sort_route_uid_missing(sort_route_uid)) {
+					sort_route_uid = p_result.status == StageResult::StageStatus::FAILED
+							? String(RenderRouteUID::COMMON_FAIL_SORT_FAILED)
+							: String(sort_gpu_uid);
+				}
+				RenderPipelineStages::stamp_stage_result_contract(p_result, "sort", sort_route_uid,
+						r_output.input_domain, r_output.output_domain, r_output.input_count, r_output.sorted_count);
 				if (!p_input.metrics) {
-					return;
+					return p_result;
 				}
 				p_input.metrics->sort = r_output;
 				p_input.metrics->sort_result = p_result;
@@ -1201,9 +1356,9 @@ struct RenderPipelineStages::SortStage {
 				validation.count_invalid = count_invalid;
 				validation.count_error = "Sort output exceeds input count";
 				_finalize_stage_io(renderer, "sort", io, validation);
+				return p_result;
 			};
 
-			const String sort_gpu_uid = RenderRouteUID::INSTANCE_SORT_GPU;
 			GPUCuller *gpu_culler = state_view.get_gpu_culler();
 			if (!gpu_culler) {
 				result = _make_stage_result(StageResult::StageStatus::FAILED, "Sort failed: GPU culler unavailable", true,
@@ -1212,8 +1367,7 @@ struct RenderPipelineStages::SortStage {
 						r_output.input_count, 0, true,
 						GaussianSplatRenderer::RenderFallbackReason::GPU_CULLER_UNAVAILABLE,
 						RenderRouteUID::COMMON_FAIL_NO_DEVICE);
-				finalize_sort_metrics(result);
-				return result;
+				return finalize_sort_metrics(result);
 			}
 
 			GPUSortingPipeline *sorting_pipeline = state_view.get_sorting_pipeline();
@@ -1230,8 +1384,7 @@ struct RenderPipelineStages::SortStage {
 							r_output.input_count, 0, false,
 							GaussianSplatRenderer::RenderFallbackReason::DATA_UNAVAILABLE,
 							RenderRouteUID::COMMON_SKIP_NO_DATA);
-					finalize_sort_metrics(result);
-					return result;
+					return finalize_sort_metrics(result);
 				}
 				result = _make_stage_result(StageResult::StageStatus::FAILED,
 						vformat("Sort failed: unsupported input index domain '%s'",
@@ -1242,8 +1395,7 @@ struct RenderPipelineStages::SortStage {
 						r_output.input_count, 0, true,
 						GaussianSplatRenderer::RenderFallbackReason::NONE,
 						RenderRouteUID::COMMON_FAIL_SORT_FAILED);
-				finalize_sort_metrics(result);
-				return result;
+				return finalize_sort_metrics(result);
 			}
 			if (input_domain_chunk && !instance_buffers_ready) {
 				if (sorting_pipeline) {
@@ -1256,8 +1408,7 @@ struct RenderPipelineStages::SortStage {
 							r_output.input_count, 0, false,
 							GaussianSplatRenderer::RenderFallbackReason::DATA_UNAVAILABLE,
 							RenderRouteUID::COMMON_SKIP_NO_DATA);
-					finalize_sort_metrics(result);
-					return result;
+					return finalize_sort_metrics(result);
 				}
 				result = _make_stage_result(StageResult::StageStatus::FAILED,
 						"Sort failed: chunk-domain input requires instance sort buffers", true,
@@ -1266,8 +1417,7 @@ struct RenderPipelineStages::SortStage {
 						r_output.input_count, 0, true,
 						GaussianSplatRenderer::RenderFallbackReason::DATA_UNAVAILABLE,
 						RenderRouteUID::COMMON_FAIL_SORT_FAILED);
-				finalize_sort_metrics(result);
-				return result;
+				return finalize_sort_metrics(result);
 			}
 			if (input_domain_global && instance_buffers_ready) {
 				if (sorting_pipeline) {
@@ -1280,8 +1430,7 @@ struct RenderPipelineStages::SortStage {
 							r_output.input_count, 0, false,
 							GaussianSplatRenderer::RenderFallbackReason::DATA_UNAVAILABLE,
 							RenderRouteUID::COMMON_SKIP_NO_DATA);
-					finalize_sort_metrics(result);
-					return result;
+					return finalize_sort_metrics(result);
 				}
 				result = _make_stage_result(StageResult::StageStatus::FAILED,
 						"Sort failed: global-domain input is incompatible with instance sort buffers", true,
@@ -1290,8 +1439,7 @@ struct RenderPipelineStages::SortStage {
 						r_output.input_count, 0, true,
 						GaussianSplatRenderer::RenderFallbackReason::NONE,
 						RenderRouteUID::COMMON_FAIL_SORT_FAILED);
-				finalize_sort_metrics(result);
-				return result;
+				return finalize_sort_metrics(result);
 			}
 
 			if (sorting_pipeline) {
@@ -1335,8 +1483,7 @@ struct RenderPipelineStages::SortStage {
 						0, 0, false,
 						GaussianSplatRenderer::RenderFallbackReason::NO_VISIBLE_SPLATS,
 						RenderRouteUID::COMMON_SKIP_NO_VISIBLE);
-				finalize_sort_metrics(result);
-				return result;
+				return finalize_sort_metrics(result);
 			}
 
 			GaussianSplatRenderer::SortStageSummary summary =
@@ -1376,6 +1523,15 @@ struct RenderPipelineStages::SortStage {
 				r_output.sorted_count = 0;
 			}
 
+			String final_sort_route_uid = renderer->get_debug_state().sort_route_uid;
+			if (RenderRouteUID::is_sort_route_uid_missing(final_sort_route_uid)) {
+				final_sort_route_uid = result.status == StageResult::StageStatus::FAILED
+						? String(RenderRouteUID::COMMON_FAIL_SORT_FAILED)
+						: sort_gpu_uid;
+			}
+			RenderPipelineStages::stamp_stage_result_contract(result, "sort", final_sort_route_uid,
+					r_output.input_domain, r_output.output_domain, r_output.input_count, r_output.sorted_count);
+
 			if (p_input.metrics) {
 				p_input.metrics->sort = r_output;
 				p_input.metrics->sort_result = result;
@@ -1398,17 +1554,11 @@ struct RenderPipelineStages::SortStage {
 			if (sort_message.is_empty()) {
 				sort_message = "status=" + _stage_status_label(result.status);
 			}
-			String sort_route_uid = renderer->get_debug_state().sort_route_uid;
-			if (RenderRouteUID::is_sort_route_uid_missing(sort_route_uid)) {
-				sort_route_uid = result.status == StageResult::StageStatus::FAILED
-						? String(RenderRouteUID::COMMON_FAIL_SORT_FAILED)
-						: sort_gpu_uid;
-			}
 			_record_pipeline_event(renderer, "sort", sort_message,
 					r_output.input_count, r_output.sorted_count,
 					result.is_error || result.status == StageResult::StageStatus::FAILED,
 					result.fallback_reason,
-					sort_route_uid);
+					final_sort_route_uid);
 			return result;
 		}
 };
@@ -1553,6 +1703,9 @@ struct RenderPipelineStages::RasterCompositeStage {
 			r_raster_result = raster_stage->render_painterly_or_baseline_stage(raster_input, r_raster_output, painterly_status,
 					p_frame_start_usec);
 		}
+		stamp_stage_result_contract(r_raster_result, "raster", String(),
+				raster_input.sorted_index_domain, GaussianSplatRenderer::IndexDomain::UNKNOWN,
+				raster_input.sorted_splat_count, r_raster_output.color.is_valid() ? 1u : 0u);
 
 		if (p_context.metrics && (r_raster_output.reused_cached_render || r_raster_output.painterly_active)) {
 			auto &io = p_context.metrics->raster_io;
@@ -1568,9 +1721,11 @@ struct RenderPipelineStages::RasterCompositeStage {
 		}
 
 		if (r_raster_result.status == StageResult::StageStatus::FAILED) {
-			r_composite_result = _make_stage_result(StageResult::StageStatus::SKIPPED,
-					"Composite skipped: raster stage failed", false,
-					r_raster_result.fallback_reason);
+			r_composite_result = make_downstream_skip_result("composite", r_raster_result,
+					"Composite skipped: raster stage failed", r_raster_result.fallback_reason);
+			stamp_stage_result_contract(r_composite_result, "composite", r_raster_result.route_uid,
+					GaussianSplatRenderer::IndexDomain::UNKNOWN, GaussianSplatRenderer::IndexDomain::UNKNOWN,
+					0, 0);
 			if (p_context.metrics) {
 				p_context.metrics->raster = r_raster_output;
 				p_context.metrics->raster_result = r_raster_result;
@@ -1612,6 +1767,10 @@ struct RenderPipelineStages::RasterCompositeStage {
 		composite_input.state_view = &state_view;
 		uint64_t composite_start_usec = OS::get_singleton()->get_ticks_usec();
 		r_composite_result = composite_stage->execute(composite_input, r_composite_executed);
+		stamp_stage_result_contract(r_composite_result, "composite", r_raster_result.route_uid,
+				GaussianSplatRenderer::IndexDomain::UNKNOWN, GaussianSplatRenderer::IndexDomain::UNKNOWN,
+				r_raster_output.color.is_valid() ? 1u : 0u,
+				r_composite_executed ? 1u : 0u);
 		uint64_t composite_end_usec = OS::get_singleton()->get_ticks_usec();
 		r_composite_time_ms = r_composite_executed ? (composite_end_usec - composite_start_usec) / 1000.0f : 0.0f;
 		if (p_context.metrics) {
@@ -1714,6 +1873,9 @@ void RenderPipelineStages::reset_render_state_for_frame(const GaussianSplatRende
 	output_cache.last_viewport_copy_success = false;
 	output_cache.last_viewport_copy_source_size = Size2i();
 	output_cache.last_viewport_copy_dest_size = Size2i();
+	output_cache.last_depth_test_honored = true;
+	output_cache.last_copy_degraded = false;
+	output_cache.last_copy_degradation_reason = String();
 	GaussianSplatRenderer::PerformanceState &performance_state = state_mut.get_performance_state_mut();
 	auto &metrics = performance_state.metrics;
 	metrics.raster_path_reason = String();
@@ -2527,6 +2689,27 @@ RenderPipelineStages::StageResult RenderPipelineStages::CompositeStage::execute(
 			p_input.render_buffers, p_input.raster_output.color, render_target_copy, p_input.viewport_size,
 			p_input.defer_commit, p_input.raster_output.painterly_active, p_input.raster_output.depth);
 	r_did_composite = true;
+	StageResult composite_result;
+	if (output_cache.last_copy_degraded || !output_cache.last_depth_test_honored) {
+		const String degradation_reason = output_cache.last_copy_degradation_reason.is_empty()
+				? String("Composite depth test was not honored")
+				: output_cache.last_copy_degradation_reason;
+		const bool strict_failure = !output_cache.last_depth_test_honored && !output_cache.last_viewport_copy_success;
+		composite_result = _make_stage_result(
+				strict_failure ? StageResult::StageStatus::FAILED : StageResult::StageStatus::FALLBACK,
+				degradation_reason,
+				strict_failure,
+				GaussianSplatRenderer::RenderFallbackReason::NONE);
+		composite_result.depth_test_honored = output_cache.last_depth_test_honored;
+		composite_result.degraded = true;
+		composite_result.degradation_reason = degradation_reason;
+		composite_result.strict_contract_violation = strict_failure;
+		composite_result.used_graphics_fallback = degradation_reason.find("graphics fallback") >= 0;
+		if (strict_failure) {
+			fill_composite_io(true, degradation_reason);
+			return composite_result;
+		}
+	}
 	if (_pipeline_trace_enabled(renderer)) {
 		_record_pipeline_event(renderer, "composite",
 				vformat("executed copy_success=%s",
@@ -2534,7 +2717,7 @@ RenderPipelineStages::StageResult RenderPipelineStages::CompositeStage::execute(
 				trace_input_count, 1u, false);
 	}
 	fill_composite_io(false, String());
-	return StageResult();
+	return composite_result;
 }
 
 bool RenderPipelineStages::execute_raster_composite_pipeline(const GaussianSplatRenderer::RenderFrameContext &p_context,
@@ -2612,6 +2795,7 @@ void RenderPipelineStages::render_sorted_splats_with_context(const GaussianSplat
 
 	auto emit_stage_metrics = [&]() {
 		if (p_context.metrics) {
+			finalize_stage_contracts(*p_context.metrics, *frame_plan);
 			store_stage_metrics(*p_context.metrics);
 		} else {
 			clear_stage_metrics();
@@ -2640,21 +2824,33 @@ void RenderPipelineStages::render_sorted_splats_with_context(const GaussianSplat
 		log_stage_result("Cull", p_context.metrics->cull_result);
 		log_stage_result("Sort", p_context.metrics->sort_result);
 	}
-	if (p_context.metrics && p_context.metrics->sort_result.status == StageResult::StageStatus::FAILED) {
+	const bool upstream_stage_blocks_raster = p_context.metrics &&
+			(p_context.metrics->sort_result.status == StageResult::StageStatus::FAILED ||
+					(p_context.metrics->sort_result.status == StageResult::StageStatus::SKIPPED &&
+							!p_context.metrics->sort_result.skip_cause_stage.is_empty()));
+	if (upstream_stage_blocks_raster) {
 		performance_state.metrics.raster_path = "skipped";
-		const String reason = p_context.metrics->sort_result.reason.is_empty() ?
-				"Sort failed; skipping raster/composite" :
-				p_context.metrics->sort_result.reason;
-		_record_pipeline_event(renderer, "raster", "skip: sort failed",
-				p_context.metrics->sort.input_count, 0, true, p_context.metrics->sort_result.fallback_reason,
+		const String upstream_stage = !p_context.metrics->sort_result.skip_cause_stage.is_empty()
+				? p_context.metrics->sort_result.skip_cause_stage
+				: String("sort");
+		_record_pipeline_event(renderer, "raster", vformat("skip: %s blocked raster", upstream_stage),
+				p_context.metrics->sort.input_count, 0, false, p_context.metrics->sort_result.fallback_reason,
 				RenderRouteUID::COMMON_FAIL_SORT_FAILED);
-		_record_pipeline_event(renderer, "composite", "skip: sort failed",
+		_record_pipeline_event(renderer, "composite", vformat("skip: %s blocked composite", upstream_stage),
 				0, 0, false, p_context.metrics->sort_result.fallback_reason,
 				RenderRouteUID::COMMON_FAIL_SORT_FAILED);
-		StageResult raster_result = _make_stage_result(StageResult::StageStatus::FAILED,
-				"Raster skipped: sort failed", true, p_context.metrics->sort_result.fallback_reason);
-		StageResult composite_result = _make_stage_result(StageResult::StageStatus::SKIPPED,
-				"Composite skipped: sort failed", false, p_context.metrics->sort_result.fallback_reason);
+		StageResult raster_result = make_downstream_skip_result("raster", p_context.metrics->sort_result,
+				vformat("Raster skipped: %s blocked raster", upstream_stage),
+				p_context.metrics->sort_result.fallback_reason);
+		stamp_stage_result_contract(raster_result, "raster", p_context.metrics->sort_result.route_uid,
+				p_context.metrics->sort_result.output_domain, GaussianSplatRenderer::IndexDomain::UNKNOWN,
+				p_context.metrics->sort_result.output_count, 0);
+		StageResult composite_result = make_downstream_skip_result("composite", p_context.metrics->sort_result,
+				vformat("Composite skipped: %s blocked composite", upstream_stage),
+				p_context.metrics->sort_result.fallback_reason);
+		stamp_stage_result_contract(composite_result, "composite", p_context.metrics->sort_result.route_uid,
+				GaussianSplatRenderer::IndexDomain::UNKNOWN, GaussianSplatRenderer::IndexDomain::UNKNOWN,
+				0, 0);
 		p_context.metrics->raster_result = raster_result;
 		p_context.metrics->composite_result = composite_result;
 		auto &raster_io = p_context.metrics->raster_io;
@@ -2662,8 +2858,7 @@ void RenderPipelineStages::render_sorted_splats_with_context(const GaussianSplat
 				_get_sort_indices_buffer(state_view), RID(),
 				p_context.metrics->sort.input_count > 0);
 		StageIOValidationConfig raster_validation;
-		raster_validation.failed = true;
-		raster_validation.failed_error = reason;
+		raster_validation.record_event = false;
 		_finalize_stage_io(renderer, "raster", raster_io, raster_validation);
 		auto &composite_io = p_context.metrics->composite_io;
 		_init_stage_io(composite_io, p_context.frame_id, 0, 0, RID(), RID(), false);
@@ -2702,9 +2897,13 @@ void RenderPipelineStages::render_sorted_splats_with_context(const GaussianSplat
 			p_context.metrics->raster_result = _make_stage_result(StageResult::StageStatus::SKIPPED,
 					"Raster skipped: no visible splats", false,
 					GaussianSplatRenderer::RenderFallbackReason::NO_VISIBLE_SPLATS);
+			stamp_stage_result_contract(p_context.metrics->raster_result, "raster", RenderRouteUID::COMMON_SKIP_NO_VISIBLE,
+					p_context.snapshot.sorted_index_domain, GaussianSplatRenderer::IndexDomain::UNKNOWN, 0, 0);
 			p_context.metrics->composite_result = _make_stage_result(StageResult::StageStatus::SKIPPED,
 					"Composite skipped: no visible splats", false,
 					GaussianSplatRenderer::RenderFallbackReason::NO_VISIBLE_SPLATS);
+			stamp_stage_result_contract(p_context.metrics->composite_result, "composite", RenderRouteUID::COMMON_SKIP_NO_VISIBLE,
+					GaussianSplatRenderer::IndexDomain::UNKNOWN, GaussianSplatRenderer::IndexDomain::UNKNOWN, 0, 0);
 			auto &raster_io = p_context.metrics->raster_io;
 			_init_stage_io(raster_io, p_context.frame_id, 0, 0, RID(), RID(), false);
 			StageIOValidationConfig raster_validation;
@@ -2729,9 +2928,13 @@ void RenderPipelineStages::render_sorted_splats_with_context(const GaussianSplat
 			p_context.metrics->raster_result = _make_stage_result(StageResult::StageStatus::FAILED,
 					"Raster failed: RenderingDevice unavailable", true,
 					GaussianSplatRenderer::RenderFallbackReason::RENDERING_DEVICE_UNAVAILABLE);
-			p_context.metrics->composite_result = _make_stage_result(StageResult::StageStatus::FAILED,
-					"Composite failed: RenderingDevice unavailable", true,
+			stamp_stage_result_contract(p_context.metrics->raster_result, "raster", RenderRouteUID::COMMON_FAIL_NO_DEVICE,
+					p_context.snapshot.sorted_index_domain, GaussianSplatRenderer::IndexDomain::UNKNOWN, current_visible, 0);
+			p_context.metrics->composite_result = make_downstream_skip_result("composite",
+					p_context.metrics->raster_result, "Composite skipped: raster failed",
 					GaussianSplatRenderer::RenderFallbackReason::RENDERING_DEVICE_UNAVAILABLE);
+			stamp_stage_result_contract(p_context.metrics->composite_result, "composite", RenderRouteUID::COMMON_FAIL_NO_DEVICE,
+					GaussianSplatRenderer::IndexDomain::UNKNOWN, GaussianSplatRenderer::IndexDomain::UNKNOWN, 0, 0);
 			auto &raster_io = p_context.metrics->raster_io;
 			_init_stage_io(raster_io, p_context.frame_id, current_visible, 0,
 					_get_sort_indices_buffer(state_view), RID(), current_visible > 0);

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -95,6 +95,102 @@ static String _fallback_reason_label(GaussianSplatRenderer::RenderFallbackReason
 	return "unknown";
 }
 
+static void _ensure_stage_route_uid(GaussianSplatRenderer::StageResult &r_result, const String &p_route_uid) {
+	if (r_result.route_uid.is_empty()) {
+		r_result.route_uid = p_route_uid;
+	}
+}
+
+static void _ensure_stage_metric_route_uids(GaussianSplatRenderer::StageMetrics &r_metrics,
+		const String &p_route_uid) {
+	_ensure_stage_route_uid(r_metrics.cull_result, p_route_uid);
+	_ensure_stage_route_uid(r_metrics.sort_result, p_route_uid);
+	_ensure_stage_route_uid(r_metrics.raster_result, p_route_uid);
+	_ensure_stage_route_uid(r_metrics.composite_result, p_route_uid);
+}
+
+static bool _assign_stage_first_failure_detail(String &r_first_failure_stage,
+		const GaussianSplatRenderer::StageResult *const *p_results, int p_result_count) {
+	for (int i = 0; i < p_result_count; i++) {
+		const GaussianSplatRenderer::StageResult *result = p_results[i];
+		if (result && !result->first_failure_stage.is_empty()) {
+			r_first_failure_stage = result->first_failure_stage;
+			return true;
+		}
+	}
+	return false;
+}
+
+static void _adopt_failed_stage_name(String &r_first_failure_stage,
+		const GaussianSplatRenderer::StageResult &p_result, const char *p_stage_name) {
+	if (!r_first_failure_stage.is_empty()) {
+		return;
+	}
+	if (p_result.status != GaussianSplatRenderer::StageResult::StageStatus::FAILED) {
+		return;
+	}
+	r_first_failure_stage = p_stage_name ? String(p_stage_name) : String();
+}
+
+static void _resolve_first_failure_stage(GaussianSplatRenderer::StageMetrics &r_metrics) {
+	const GaussianSplatRenderer::StageResult *ordered_results[] = {
+		&r_metrics.cull_result,
+		&r_metrics.sort_result,
+		&r_metrics.raster_result,
+		&r_metrics.composite_result,
+	};
+	if (_assign_stage_first_failure_detail(r_metrics.first_failure_stage, ordered_results, 4)) {
+		return;
+	}
+
+	_adopt_failed_stage_name(r_metrics.first_failure_stage, r_metrics.cull_result, "cull");
+	_adopt_failed_stage_name(r_metrics.first_failure_stage, r_metrics.sort_result, "sort");
+	_adopt_failed_stage_name(r_metrics.first_failure_stage, r_metrics.raster_result, "raster");
+	_adopt_failed_stage_name(r_metrics.first_failure_stage, r_metrics.composite_result, "composite");
+}
+
+static void _adopt_skip_cause_stage(String &r_skip_cause_stage,
+		const GaussianSplatRenderer::StageResult &p_result) {
+	if (!p_result.skip_cause_stage.is_empty()) {
+		r_skip_cause_stage = p_result.skip_cause_stage;
+	}
+}
+
+static bool _any_stage_degraded(const GaussianSplatRenderer::StageMetrics &p_metrics) {
+	const bool degraded[] = {
+		p_metrics.cull_result.degraded,
+		p_metrics.sort_result.degraded,
+		p_metrics.raster_result.degraded,
+		p_metrics.composite_result.degraded,
+	};
+	for (int i = 0; i < 4; i++) {
+		if (degraded[i]) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static void _adopt_degradation_reason(String &r_degradation_reason,
+		const GaussianSplatRenderer::StageResult &p_result) {
+	if (!r_degradation_reason.is_empty()) {
+		return;
+	}
+	if (p_result.degradation_reason.is_empty()) {
+		return;
+	}
+	r_degradation_reason = p_result.degradation_reason;
+}
+
+static void _resolve_stage_degradation_summary(GaussianSplatRenderer::StageMetrics &r_metrics) {
+	r_metrics.has_degradation = _any_stage_degraded(r_metrics);
+	r_metrics.composite_depth_test_honored = r_metrics.composite_result.depth_test_honored;
+	_adopt_degradation_reason(r_metrics.degradation_reason, r_metrics.composite_result);
+	_adopt_degradation_reason(r_metrics.degradation_reason, r_metrics.raster_result);
+	_adopt_degradation_reason(r_metrics.degradation_reason, r_metrics.sort_result);
+	_adopt_degradation_reason(r_metrics.degradation_reason, r_metrics.cull_result);
+}
+
 static bool _pipeline_trace_enabled(GaussianSplatRenderer *p_renderer) {
 	return p_renderer && p_renderer->get_debug_config().enable_pipeline_trace;
 }
@@ -747,12 +843,69 @@ RenderPipelineStages::StageResult RenderPipelineStages::make_downstream_skip_res
 	StageResult result = _make_stage_result(StageResult::StageStatus::SKIPPED, p_reason, false, p_fallback_reason);
 	result.stage_name = p_stage_name ? String(p_stage_name) : String();
 	result.route_uid = p_upstream_result.route_uid;
-	result.first_failure_stage = !p_upstream_result.first_failure_stage.is_empty()
-			? p_upstream_result.first_failure_stage
-			: p_upstream_result.stage_name;
+	if (!p_upstream_result.first_failure_stage.is_empty()) {
+		result.first_failure_stage = p_upstream_result.first_failure_stage;
+	} else if (p_upstream_result.status == StageResult::StageStatus::FAILED || p_upstream_result.is_error) {
+		result.first_failure_stage = p_upstream_result.stage_name;
+	}
 	result.skip_cause_stage = !p_upstream_result.stage_name.is_empty()
 			? p_upstream_result.stage_name
-			: result.first_failure_stage;
+			: p_upstream_result.skip_cause_stage;
+	return result;
+}
+
+RenderPipelineStages::StageMetrics RenderPipelineStages::make_route_skip_metrics(const String &p_route_uid,
+		const String &p_selected_backend, const String &p_cull_reason, const String &p_sort_reason,
+		RenderFallbackReason p_fallback_reason) {
+	StageMetrics metrics;
+	metrics.cull = GaussianSplatRenderer::CullStageOutput();
+	metrics.sort = GaussianSplatRenderer::SortStageOutput();
+	metrics.route_uid = p_route_uid;
+	metrics.selected_route_backend = p_selected_backend;
+	metrics.cull_result = _make_stage_result(StageResult::StageStatus::SKIPPED, p_cull_reason, false,
+			p_fallback_reason);
+	stamp_stage_result_contract(metrics.cull_result, "cull", p_route_uid,
+			GaussianSplatRenderer::IndexDomain::UNKNOWN, GaussianSplatRenderer::IndexDomain::UNKNOWN, 0, 0);
+	metrics.sort_result = make_downstream_skip_result("sort", metrics.cull_result, p_sort_reason,
+			p_fallback_reason);
+	stamp_stage_result_contract(metrics.sort_result, "sort", p_route_uid,
+			GaussianSplatRenderer::IndexDomain::UNKNOWN, GaussianSplatRenderer::IndexDomain::UNKNOWN, 0, 0);
+	metrics.raster_result = make_downstream_skip_result("raster", metrics.cull_result,
+			"Raster skipped: route not ready", p_fallback_reason);
+	stamp_stage_result_contract(metrics.raster_result, "raster", p_route_uid,
+			GaussianSplatRenderer::IndexDomain::UNKNOWN, GaussianSplatRenderer::IndexDomain::UNKNOWN, 0, 0);
+	metrics.composite_result = make_downstream_skip_result("composite", metrics.cull_result,
+			"Composite skipped: route not ready", p_fallback_reason);
+	stamp_stage_result_contract(metrics.composite_result, "composite", p_route_uid,
+			GaussianSplatRenderer::IndexDomain::UNKNOWN, GaussianSplatRenderer::IndexDomain::UNKNOWN, 0, 0);
+	metrics.skip_cause_stage = "cull";
+	return metrics;
+}
+
+RenderPipelineStages::StageResult RenderPipelineStages::make_composite_copy_result(bool p_copy_attempted,
+		bool p_copy_success, const String &p_copy_error, bool p_copy_degraded,
+		const String &p_degradation_reason, bool p_depth_test_honored,
+		bool p_viewport_copy_success, bool p_strict_depth_contract_required) {
+	const bool copy_failed = p_copy_attempted && !p_copy_success;
+	if (!copy_failed && !p_copy_degraded && p_depth_test_honored) {
+		return StageResult();
+	}
+
+	const String copy_error = !p_copy_error.is_empty() ? p_copy_error : p_degradation_reason;
+	const String reason = !copy_error.is_empty()
+			? copy_error
+			: String("Composite depth test was not honored");
+	const bool strict_depth_contract_failed = !p_depth_test_honored && p_copy_degraded &&
+			p_strict_depth_contract_required && !p_viewport_copy_success;
+	const bool strict_failure = copy_failed || strict_depth_contract_failed;
+	StageResult result = _make_stage_result(
+			strict_failure ? StageResult::StageStatus::FAILED : StageResult::StageStatus::FALLBACK,
+			reason, strict_failure, GaussianSplatRenderer::RenderFallbackReason::NONE);
+	result.depth_test_honored = p_depth_test_honored;
+	result.degraded = true;
+	result.degradation_reason = reason;
+	result.strict_contract_violation = strict_failure;
+	result.used_graphics_fallback = reason.find("graphics fallback") >= 0;
 	return result;
 }
 
@@ -760,64 +913,12 @@ void RenderPipelineStages::finalize_stage_contracts(StageMetrics &r_metrics, con
 	const String route_uid = p_frame_plan.route_decision.route_uid;
 	r_metrics.route_uid = route_uid;
 	r_metrics.selected_route_backend = p_frame_plan.route_decision.selected_backend_name;
-	if (r_metrics.cull_result.route_uid.is_empty()) {
-		r_metrics.cull_result.route_uid = route_uid;
-	}
-	if (r_metrics.sort_result.route_uid.is_empty()) {
-		r_metrics.sort_result.route_uid = route_uid;
-	}
-	if (r_metrics.raster_result.route_uid.is_empty()) {
-		r_metrics.raster_result.route_uid = route_uid;
-	}
-	if (r_metrics.composite_result.route_uid.is_empty()) {
-		r_metrics.composite_result.route_uid = route_uid;
-	}
-
-	if (!r_metrics.cull_result.first_failure_stage.is_empty()) {
-		r_metrics.first_failure_stage = r_metrics.cull_result.first_failure_stage;
-	} else if (!r_metrics.sort_result.first_failure_stage.is_empty()) {
-		r_metrics.first_failure_stage = r_metrics.sort_result.first_failure_stage;
-	} else if (!r_metrics.raster_result.first_failure_stage.is_empty()) {
-		r_metrics.first_failure_stage = r_metrics.raster_result.first_failure_stage;
-	} else if (!r_metrics.composite_result.first_failure_stage.is_empty()) {
-		r_metrics.first_failure_stage = r_metrics.composite_result.first_failure_stage;
-	}
-	if (r_metrics.first_failure_stage.is_empty()) {
-		if (r_metrics.cull_result.status == StageResult::StageStatus::FAILED) {
-			r_metrics.first_failure_stage = "cull";
-		} else if (r_metrics.sort_result.status == StageResult::StageStatus::FAILED) {
-			r_metrics.first_failure_stage = "sort";
-		} else if (r_metrics.raster_result.status == StageResult::StageStatus::FAILED) {
-			r_metrics.first_failure_stage = "raster";
-		} else if (r_metrics.composite_result.status == StageResult::StageStatus::FAILED) {
-			r_metrics.first_failure_stage = "composite";
-		}
-	}
-
-	if (!r_metrics.sort_result.skip_cause_stage.is_empty()) {
-		r_metrics.skip_cause_stage = r_metrics.sort_result.skip_cause_stage;
-	}
-	if (!r_metrics.raster_result.skip_cause_stage.is_empty()) {
-		r_metrics.skip_cause_stage = r_metrics.raster_result.skip_cause_stage;
-	}
-	if (!r_metrics.composite_result.skip_cause_stage.is_empty()) {
-		r_metrics.skip_cause_stage = r_metrics.composite_result.skip_cause_stage;
-	}
-
-	r_metrics.has_degradation = r_metrics.cull_result.degraded || r_metrics.sort_result.degraded ||
-			r_metrics.raster_result.degraded || r_metrics.composite_result.degraded;
-	r_metrics.composite_depth_test_honored = r_metrics.composite_result.depth_test_honored;
-	if (r_metrics.degradation_reason.is_empty()) {
-		if (!r_metrics.composite_result.degradation_reason.is_empty()) {
-			r_metrics.degradation_reason = r_metrics.composite_result.degradation_reason;
-		} else if (!r_metrics.raster_result.degradation_reason.is_empty()) {
-			r_metrics.degradation_reason = r_metrics.raster_result.degradation_reason;
-		} else if (!r_metrics.sort_result.degradation_reason.is_empty()) {
-			r_metrics.degradation_reason = r_metrics.sort_result.degradation_reason;
-		} else if (!r_metrics.cull_result.degradation_reason.is_empty()) {
-			r_metrics.degradation_reason = r_metrics.cull_result.degradation_reason;
-		}
-	}
+	_ensure_stage_metric_route_uids(r_metrics, route_uid);
+	_resolve_first_failure_stage(r_metrics);
+	_adopt_skip_cause_stage(r_metrics.skip_cause_stage, r_metrics.sort_result);
+	_adopt_skip_cause_stage(r_metrics.skip_cause_stage, r_metrics.raster_result);
+	_adopt_skip_cause_stage(r_metrics.skip_cause_stage, r_metrics.composite_result);
+	_resolve_stage_degradation_summary(r_metrics);
 }
 
 RenderPipelineStages::RenderFramePlan RenderPipelineStages::build_frame_plan(
@@ -1876,6 +1977,7 @@ void RenderPipelineStages::reset_render_state_for_frame(const GaussianSplatRende
 	output_cache.last_depth_test_honored = true;
 	output_cache.last_copy_degraded = false;
 	output_cache.last_copy_degradation_reason = String();
+	output_cache.last_strict_depth_contract_required = false;
 	GaussianSplatRenderer::PerformanceState &performance_state = state_mut.get_performance_state_mut();
 	auto &metrics = performance_state.metrics;
 	metrics.raster_path_reason = String();
@@ -2689,26 +2791,14 @@ RenderPipelineStages::StageResult RenderPipelineStages::CompositeStage::execute(
 			p_input.render_buffers, p_input.raster_output.color, render_target_copy, p_input.viewport_size,
 			p_input.defer_commit, p_input.raster_output.painterly_active, p_input.raster_output.depth);
 	r_did_composite = true;
-	StageResult composite_result;
-	if (output_cache.last_copy_degraded || !output_cache.last_depth_test_honored) {
-		const String degradation_reason = output_cache.last_copy_degradation_reason.is_empty()
-				? String("Composite depth test was not honored")
-				: output_cache.last_copy_degradation_reason;
-		const bool strict_failure = !output_cache.last_depth_test_honored && !output_cache.last_viewport_copy_success;
-		composite_result = _make_stage_result(
-				strict_failure ? StageResult::StageStatus::FAILED : StageResult::StageStatus::FALLBACK,
-				degradation_reason,
-				strict_failure,
-				GaussianSplatRenderer::RenderFallbackReason::NONE);
-		composite_result.depth_test_honored = output_cache.last_depth_test_honored;
-		composite_result.degraded = true;
-		composite_result.degradation_reason = degradation_reason;
-		composite_result.strict_contract_violation = strict_failure;
-		composite_result.used_graphics_fallback = degradation_reason.find("graphics fallback") >= 0;
-		if (strict_failure) {
-			fill_composite_io(true, degradation_reason);
-			return composite_result;
-		}
+	StageResult composite_result = RenderPipelineStages::make_composite_copy_result(
+			output_cache.last_output_copy_attempted, output_cache.last_output_copy_success,
+			output_cache.last_output_copy_error, output_cache.last_copy_degraded,
+			output_cache.last_copy_degradation_reason, output_cache.last_depth_test_honored,
+			output_cache.last_viewport_copy_success, output_cache.last_strict_depth_contract_required);
+	if (composite_result.status == StageResult::StageStatus::FAILED) {
+		fill_composite_io(true, composite_result.reason);
+		return composite_result;
 	}
 	if (_pipeline_trace_enabled(renderer)) {
 		_record_pipeline_event(renderer, "composite",

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.h
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.h
@@ -39,6 +39,14 @@ public:
 			const SubsystemState &p_subsystem_state);
 	static void apply_data_source_plan(const DataSourcePlan &p_plan, PerformanceMetrics &p_metrics,
 			const ResourceState &p_resource_state);
+	static void stamp_stage_result_contract(StageResult &r_result, const char *p_stage_name,
+			const String &p_route_uid, GaussianSplatRenderer::IndexDomain p_input_domain,
+			GaussianSplatRenderer::IndexDomain p_output_domain, uint32_t p_input_count,
+			uint32_t p_output_count);
+	static StageResult make_downstream_skip_result(const char *p_stage_name,
+			const StageResult &p_upstream_result, const String &p_reason,
+			GaussianSplatRenderer::RenderFallbackReason p_fallback_reason);
+	static void finalize_stage_contracts(StageMetrics &r_metrics, const RenderFramePlan &p_frame_plan);
 	static RenderFramePlan build_frame_plan(const SceneState &p_scene_state,
 			const StreamingState &p_streaming_state,
 			const SortingState &p_sorting_state,

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.h
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.h
@@ -46,6 +46,12 @@ public:
 	static StageResult make_downstream_skip_result(const char *p_stage_name,
 			const StageResult &p_upstream_result, const String &p_reason,
 			GaussianSplatRenderer::RenderFallbackReason p_fallback_reason);
+	static StageMetrics make_route_skip_metrics(const String &p_route_uid,
+			const String &p_selected_backend, const String &p_cull_reason,
+			const String &p_sort_reason, GaussianSplatRenderer::RenderFallbackReason p_fallback_reason);
+		static StageResult make_composite_copy_result(bool p_copy_attempted, bool p_copy_success,
+				const String &p_copy_error, bool p_copy_degraded, const String &p_degradation_reason,
+				bool p_depth_test_honored, bool p_viewport_copy_success, bool p_strict_depth_contract_required);
 	static void finalize_stage_contracts(StageMetrics &r_metrics, const RenderFramePlan &p_frame_plan);
 	static RenderFramePlan build_frame_plan(const SceneState &p_scene_state,
 			const StreamingState &p_streaming_state,

--- a/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
@@ -1383,7 +1383,13 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 	GaussianSplatRenderer::PerformanceState &performance_state = state_mut.get_performance_state_mut();
 	GaussianSplatRenderer::ResourceState &resource_state = state_mut.get_resource_state_mut();
 	auto publish_not_ready_route = [&](StreamingReadinessState p_state) {
-		state_mut.get_debug_state_mut().route_uid = _streaming_not_ready_route_uid(p_state);
+		const String route_uid = _streaming_not_ready_route_uid(p_state);
+		state_mut.get_debug_state_mut().route_uid = route_uid;
+		const String reason_code = String("streaming_not_ready_") +
+				String(_streaming_readiness_state_token(p_state)).to_lower();
+		renderer->publish_route_skip_stage_metrics(route_uid, GaussianSplatRenderer::InstanceBackendPolicy::STREAMING,
+				reason_code, "Cull skipped: streaming path not ready",
+				GaussianSplatRenderer::RenderFallbackReason::STREAMING_DATA_UNAVAILABLE);
 	};
 	if (!streaming_state.current_streaming_system.is_valid()) {
 		const StreamingReadinessState readiness_state = StreamingReadinessState::MISSING_STREAMING_SYSTEM;

--- a/modules/gaussian_splatting/renderer/render_types/render_pipeline_io_types.h
+++ b/modules/gaussian_splatting/renderer/render_types/render_pipeline_io_types.h
@@ -31,6 +31,36 @@ struct RenderFrameSnapshot {
 	IndexDomain sorted_index_domain = IndexDomain::UNKNOWN;
 };
 
+enum class RenderRouteBackend : uint8_t {
+	NONE = 0,
+	RESIDENT,
+	STREAMING,
+};
+
+inline const char *render_route_backend_to_string(RenderRouteBackend p_backend) {
+	switch (p_backend) {
+		case RenderRouteBackend::NONE:
+			return "none";
+		case RenderRouteBackend::RESIDENT:
+			return "resident";
+		case RenderRouteBackend::STREAMING:
+			return "streaming";
+	}
+	return "none";
+}
+
+struct RenderRouteDecision {
+	bool valid = false;
+	RenderRouteBackend selected_backend = RenderRouteBackend::NONE;
+	String selected_backend_name = "none";
+	String route_uid;
+	String reason;
+	String data_source;
+	bool has_render_data = false;
+	bool single_route_per_frame = true;
+	bool alternate_backend_fallback_forbidden = true;
+};
+
 enum class RenderFallbackReason {
 	NONE = 0,
 	DATA_UNAVAILABLE,
@@ -60,6 +90,22 @@ struct StageResult {
 	bool is_error = false;
 	RenderFallbackReason fallback_reason = RenderFallbackReason::NONE;
 	String reason;
+	String stage_name;
+	String route_uid;
+	IndexDomain input_domain = IndexDomain::UNKNOWN;
+	IndexDomain output_domain = IndexDomain::UNKNOWN;
+	uint32_t input_count = 0;
+	uint32_t output_count = 0;
+	String first_failure_stage;
+	String skip_cause_stage;
+	bool depth_test_honored = true;
+	bool degraded = false;
+	String degradation_reason;
+	bool used_cached_output = false;
+	bool used_cpu_fallback = false;
+	bool used_graphics_fallback = false;
+	bool overflow_clamped = false;
+	bool strict_contract_violation = false;
 
 	bool is_success() const { return status == StageStatus::SUCCESS || status == StageStatus::FALLBACK; }
 	bool is_failure() const { return status == StageStatus::FAILED; }
@@ -192,6 +238,15 @@ struct StageMetrics {
 	StageIO sort_io;
 	StageIO raster_io;
 	StageIO composite_io;
+	String route_uid;
+	String selected_route_backend;
+	String first_failure_stage;
+	String skip_cause_stage;
+	int32_t first_failure_instance_index = -1;
+	int32_t first_skipped_instance_index = -1;
+	bool has_degradation = false;
+	bool composite_depth_test_honored = true;
+	String degradation_reason;
 };
 
 struct PipelineEvent {
@@ -224,6 +279,7 @@ struct PainterlyCompositePushConstant {
  * @brief Planning data that determines the render path for a frame.
  */
 struct RenderFramePlan {
+	RenderRouteDecision route_decision;
 	DataSourcePlan data_source;
 	bool has_render_data = false;
 	bool set_skip_metrics = false;

--- a/modules/gaussian_splatting/tests/test_renderer_pipeline.h
+++ b/modules/gaussian_splatting/tests/test_renderer_pipeline.h
@@ -97,6 +97,103 @@ TEST_CASE("[GaussianSplatting] Stage cascade contract preserves first failure an
 	CHECK(raster_skip.output_count == 0);
 }
 
+TEST_CASE("[GaussianSplatting] Downstream skip contract does not invent first failure for benign upstream skips") {
+	GaussianSplatRenderer::StageResult cull_skip;
+	cull_skip.status = GaussianSplatRenderer::StageResult::StageStatus::SKIPPED;
+	cull_skip.reason = "Culling skipped: instance buffers missing";
+	RenderPipelineStages::stamp_stage_result_contract(cull_skip, "cull",
+			RenderRouteUID::COMMON_SKIP_NO_DATA,
+			GaussianSplatRenderer::IndexDomain::UNKNOWN,
+			GaussianSplatRenderer::IndexDomain::UNKNOWN, 0, 0);
+
+	GaussianSplatRenderer::StageResult sort_skip =
+			RenderPipelineStages::make_downstream_skip_result("sort", cull_skip,
+					"Sort skipped: cull skipped",
+					GaussianSplatRenderer::RenderFallbackReason::DATA_UNAVAILABLE);
+	RenderPipelineStages::stamp_stage_result_contract(sort_skip, "sort", cull_skip.route_uid,
+			cull_skip.output_domain, GaussianSplatRenderer::IndexDomain::UNKNOWN, cull_skip.output_count, 0);
+
+	CHECK(sort_skip.status == GaussianSplatRenderer::StageResult::StageStatus::SKIPPED);
+	CHECK(sort_skip.first_failure_stage.is_empty());
+	CHECK(sort_skip.skip_cause_stage == String("cull"));
+
+	GaussianSplatRenderer::StageMetrics metrics;
+	metrics.cull_result = cull_skip;
+	metrics.sort_result = sort_skip;
+	metrics.raster_result = RenderPipelineStages::make_downstream_skip_result("raster", sort_skip,
+			"Raster skipped: sort skipped", GaussianSplatRenderer::RenderFallbackReason::DATA_UNAVAILABLE);
+	metrics.composite_result = RenderPipelineStages::make_downstream_skip_result("composite", sort_skip,
+			"Composite skipped: sort skipped", GaussianSplatRenderer::RenderFallbackReason::DATA_UNAVAILABLE);
+	GaussianSplatRenderer::RenderFramePlan plan;
+	plan.route_decision.valid = true;
+	plan.route_decision.route_uid = RenderRouteUID::COMMON_SKIP_NO_DATA;
+	plan.route_decision.selected_backend_name = "streaming";
+	RenderPipelineStages::finalize_stage_contracts(metrics, plan);
+
+	CHECK(metrics.first_failure_stage.is_empty());
+	CHECK(metrics.skip_cause_stage == String("sort"));
+}
+
+TEST_CASE("[GaussianSplatting] Composite copy failure becomes a failed stage result") {
+	GaussianSplatRenderer::StageResult result = RenderPipelineStages::make_composite_copy_result(
+			true, false, "framebuffer copy failed", false, String(), true, false, false);
+
+	CHECK(result.status == GaussianSplatRenderer::StageResult::StageStatus::FAILED);
+	CHECK(result.is_error);
+	CHECK(result.strict_contract_violation);
+	CHECK(result.reason == String("framebuffer copy failed"));
+}
+
+TEST_CASE("[GaussianSplatting] Composite viewport scaling degradation is not a strict copy failure") {
+	GaussianSplatRenderer::StageResult result = RenderPipelineStages::make_composite_copy_result(
+			true, true, String(), false, String(), false, false, false);
+
+	CHECK(result.status == GaussianSplatRenderer::StageResult::StageStatus::FALLBACK);
+	CHECK(!result.is_error);
+	CHECK(!result.strict_contract_violation);
+	CHECK(result.depth_test_honored == false);
+	CHECK(result.degraded);
+	CHECK(result.reason == String("Composite depth test was not honored"));
+}
+
+TEST_CASE("[GaussianSplatting] Strict depth contract break becomes a failed composite stage") {
+	GaussianSplatRenderer::StageResult result = RenderPipelineStages::make_composite_copy_result(
+			true, true, String(), true,
+			"depth composite fallback did not honor requested depth test", false, false, true);
+
+	CHECK(result.status == GaussianSplatRenderer::StageResult::StageStatus::FAILED);
+	CHECK(result.is_error);
+	CHECK(result.strict_contract_violation);
+	CHECK(result.depth_test_honored == false);
+	CHECK(result.reason == String("depth composite fallback did not honor requested depth test"));
+}
+
+TEST_CASE("[GaussianSplatting] Strict depth degradation with a viewport copy remains fallback") {
+	GaussianSplatRenderer::StageResult result = RenderPipelineStages::make_composite_copy_result(
+			true, true, String(), true,
+			"depth composite fallback did not honor requested depth test", false, true, true);
+
+	CHECK(result.status == GaussianSplatRenderer::StageResult::StageStatus::FALLBACK);
+	CHECK_FALSE(result.is_error);
+	CHECK_FALSE(result.strict_contract_violation);
+	CHECK(result.depth_test_honored == false);
+	CHECK(result.degraded);
+	CHECK(result.reason == String("depth composite fallback did not honor requested depth test"));
+}
+
+TEST_CASE("[GaussianSplatting] Relaxed depth degradation with scaled viewport remains fallback") {
+	GaussianSplatRenderer::StageResult result = RenderPipelineStages::make_composite_copy_result(
+			true, true, String(), true,
+			"relaxed depth composite fallback: source or scene depth missing", false, false, false);
+
+	CHECK(result.status == GaussianSplatRenderer::StageResult::StageStatus::FALLBACK);
+	CHECK_FALSE(result.is_error);
+	CHECK_FALSE(result.strict_contract_violation);
+	CHECK(result.depth_test_honored == false);
+	CHECK(result.degraded);
+	CHECK(result.reason == String("relaxed depth composite fallback: source or scene depth missing"));
+}
+
 TEST_CASE("[GaussianSplatting] Stage contract aggregation reports composite degradation") {
 	GaussianSplatRenderer::StageMetrics metrics;
 	metrics.cull_result.status = GaussianSplatRenderer::StageResult::StageStatus::SUCCESS;
@@ -135,6 +232,43 @@ TEST_CASE("[GaussianSplatting] Stage contract aggregation reports composite degr
 	CHECK(metrics.degradation_reason == String("relaxed depth composite fallback"));
 	CHECK(metrics.route_uid == String(RenderRouteUID::INSTANCE_STREAMING));
 	CHECK(metrics.selected_route_backend == String("streaming"));
+}
+
+TEST_CASE("[GaussianSplatting] Route skip metrics replace stale stage metrics for the current frame") {
+	Ref<GaussianSplatRenderer> renderer;
+	renderer.instantiate();
+	CHECK(renderer.is_valid());
+	if (!renderer.is_valid()) {
+		return;
+	}
+
+	GaussianSplatRenderer::StageMetrics stale_metrics;
+	stale_metrics.cull_result.status = GaussianSplatRenderer::StageResult::StageStatus::SUCCESS;
+	RenderPipelineStages::stamp_stage_result_contract(stale_metrics.cull_result, "cull",
+			RenderRouteUID::INSTANCE_CULL_GPU,
+			GaussianSplatRenderer::IndexDomain::UNKNOWN,
+			GaussianSplatRenderer::IndexDomain::CHUNK_REF, 4, 4);
+	renderer->get_debug_state().last_stage_metrics = stale_metrics;
+	renderer->get_debug_state().last_stage_metrics_valid = true;
+
+	renderer->publish_route_skip_stage_metrics(
+			RenderRouteUID::COMMON_SKIP_STREAMING_NOT_READY,
+			GaussianSplatRenderer::InstanceBackendPolicy::STREAMING,
+			"streaming_not_ready_unknown",
+			"Cull skipped: streaming path not ready",
+			GaussianSplatRenderer::RenderFallbackReason::STREAMING_DATA_UNAVAILABLE);
+
+	const GaussianSplatRenderer::DebugState &debug_state = renderer->get_debug_state();
+	CHECK(debug_state.last_stage_metrics_valid);
+	CHECK(debug_state.last_stage_metrics.route_uid == String(RenderRouteUID::COMMON_SKIP_STREAMING_NOT_READY));
+	CHECK(debug_state.last_stage_metrics.cull_result.status == GaussianSplatRenderer::StageResult::StageStatus::SKIPPED);
+	CHECK(debug_state.last_stage_metrics.sort_result.status == GaussianSplatRenderer::StageResult::StageStatus::SKIPPED);
+	CHECK(debug_state.last_stage_metrics.raster_result.status == GaussianSplatRenderer::StageResult::StageStatus::SKIPPED);
+	CHECK(debug_state.last_stage_metrics.composite_result.status == GaussianSplatRenderer::StageResult::StageStatus::SKIPPED);
+	CHECK(debug_state.last_stage_metrics.first_failure_stage.is_empty());
+	CHECK(debug_state.last_stage_metrics.cull_result.route_uid == String(RenderRouteUID::COMMON_SKIP_STREAMING_NOT_READY));
+
+	renderer.unref();
 }
 
 // Utility to ensure we have a GaussianSplatManager available during the test run.

--- a/modules/gaussian_splatting/tests/test_renderer_pipeline.h
+++ b/modules/gaussian_splatting/tests/test_renderer_pipeline.h
@@ -71,6 +71,72 @@ static_assert(offsetof(TileRenderParamsGPU, effector_spheres) == 704, "TileRende
 static_assert(offsetof(TileRenderParamsGPU, effector_configs) == 768, "TileRenderParamsGPU.effector_configs offset contract changed");
 static_assert(offsetof(TileRenderParamsGPU, effector_opacity_configs) == 832, "TileRenderParamsGPU.effector_opacity_configs offset contract changed");
 
+TEST_CASE("[GaussianSplatting] Stage cascade contract preserves first failure and downstream skip cause") {
+	GaussianSplatRenderer::StageResult sort_failure;
+	sort_failure.status = GaussianSplatRenderer::StageResult::StageStatus::FAILED;
+	sort_failure.is_error = true;
+	sort_failure.reason = "Sort failed: test injection";
+	RenderPipelineStages::stamp_stage_result_contract(sort_failure, "sort",
+			RenderRouteUID::COMMON_FAIL_SORT_FAILED,
+			GaussianSplatRenderer::IndexDomain::CHUNK_REF,
+			GaussianSplatRenderer::IndexDomain::UNKNOWN, 8, 0);
+
+	GaussianSplatRenderer::StageResult raster_skip =
+			RenderPipelineStages::make_downstream_skip_result("raster", sort_failure,
+					"Raster skipped: sort blocked raster",
+					GaussianSplatRenderer::RenderFallbackReason::NONE);
+	RenderPipelineStages::stamp_stage_result_contract(raster_skip, "raster",
+			sort_failure.route_uid, sort_failure.output_domain,
+			GaussianSplatRenderer::IndexDomain::UNKNOWN, sort_failure.output_count, 0);
+
+	CHECK(raster_skip.status == GaussianSplatRenderer::StageResult::StageStatus::SKIPPED);
+	CHECK(raster_skip.first_failure_stage == String("sort"));
+	CHECK(raster_skip.skip_cause_stage == String("sort"));
+	CHECK(raster_skip.route_uid == String(RenderRouteUID::COMMON_FAIL_SORT_FAILED));
+	CHECK(raster_skip.input_count == 0);
+	CHECK(raster_skip.output_count == 0);
+}
+
+TEST_CASE("[GaussianSplatting] Stage contract aggregation reports composite degradation") {
+	GaussianSplatRenderer::StageMetrics metrics;
+	metrics.cull_result.status = GaussianSplatRenderer::StageResult::StageStatus::SUCCESS;
+	RenderPipelineStages::stamp_stage_result_contract(metrics.cull_result, "cull",
+			RenderRouteUID::INSTANCE_CULL_GPU,
+			GaussianSplatRenderer::IndexDomain::UNKNOWN,
+			GaussianSplatRenderer::IndexDomain::CHUNK_REF, 4, 4);
+	metrics.sort_result.status = GaussianSplatRenderer::StageResult::StageStatus::SUCCESS;
+	RenderPipelineStages::stamp_stage_result_contract(metrics.sort_result, "sort",
+			RenderRouteUID::INSTANCE_SORT_GPU,
+			GaussianSplatRenderer::IndexDomain::CHUNK_REF,
+			GaussianSplatRenderer::IndexDomain::SPLAT_REF, 4, 16);
+	metrics.raster_result.status = GaussianSplatRenderer::StageResult::StageStatus::SUCCESS;
+	RenderPipelineStages::stamp_stage_result_contract(metrics.raster_result, "raster",
+			RenderRouteUID::INSTANCE_RASTER_COMPUTE,
+			GaussianSplatRenderer::IndexDomain::SPLAT_REF,
+			GaussianSplatRenderer::IndexDomain::UNKNOWN, 16, 1);
+	metrics.composite_result.status = GaussianSplatRenderer::StageResult::StageStatus::FALLBACK;
+	metrics.composite_result.depth_test_honored = false;
+	metrics.composite_result.degraded = true;
+	metrics.composite_result.degradation_reason = "relaxed depth composite fallback";
+	RenderPipelineStages::stamp_stage_result_contract(metrics.composite_result, "composite",
+			RenderRouteUID::INSTANCE_RASTER_COMPUTE,
+			GaussianSplatRenderer::IndexDomain::UNKNOWN,
+			GaussianSplatRenderer::IndexDomain::UNKNOWN, 1, 1);
+
+	GaussianSplatRenderer::RenderFramePlan plan;
+	plan.route_decision.valid = true;
+	plan.route_decision.route_uid = RenderRouteUID::INSTANCE_STREAMING;
+	plan.route_decision.selected_backend_name = "streaming";
+	RenderPipelineStages::finalize_stage_contracts(metrics, plan);
+
+	CHECK(metrics.first_failure_stage.is_empty());
+	CHECK(metrics.has_degradation);
+	CHECK_FALSE(metrics.composite_depth_test_honored);
+	CHECK(metrics.degradation_reason == String("relaxed depth composite fallback"));
+	CHECK(metrics.route_uid == String(RenderRouteUID::INSTANCE_STREAMING));
+	CHECK(metrics.selected_route_backend == String("streaming"));
+}
+
 // Utility to ensure we have a GaussianSplatManager available during the test run.
 // Note: Named with "Pipeline" suffix to avoid redefinition with test_render_validation.h
 class ScopedGaussianManagerPipeline {


### PR DESCRIPTION
## Scope

This first-wave slice adds a route/stage contract foundation for #351 without taking on shadow isolation, GPU lifetime fixes, or broad renderer decomposition.

- Adds a per-frame `RenderRouteDecision` carried by `RenderFramePlan`.
- Extends `StageResult`/`StageMetrics` with route UID, domains, counts, first failure, skip cause, degradation flags, and composite depth-test reporting.
- Adds shared stage-contract helpers for stamping results, downstream skip cascades, and final aggregation.
- Routes normal and serial instancing cull/sort failure cascades through the same helper semantics.
- Treats compositor `depth_test_honored=false` as stage-visible degradation, and as a strict contract failure when the copy path reports no honored depth test and no successful viewport copy.
- Fixes the sort-failure cascade so raster is `SKIPPED` with `skip_cause_stage=sort` instead of a second `FAILED` stage.

## Invariants

- One frame carries one selected route decision through the frame plan.
- Only the first executed failed stage reports `FAILED`; downstream non-executed stages report `SKIPPED` and name the upstream cause.
- Stage results carry input/output domains and counts at the contract boundary.
- Composite depth fallback is caller-visible via degradation fields and telemetry.
- Serial instancing preserves the first failed/skipped instance index instead of letting later instances mask the first contract break.

## Validation

- `git diff --check`
- `python3 tests/ci/run_module_tests.py --guard-only --base-ref origin/master`
- `scons platform=linuxbsd target=editor tests=yes module_gaussian_splatting_enabled=yes bin/obj/modules/gaussian_splatting/renderer/render_pipeline_stages.linuxbsd.editor.x86_64.o -j2`
- `scons platform=linuxbsd target=editor tests=yes module_gaussian_splatting_enabled=yes bin/obj/modules/gaussian_splatting/interfaces/output_compositor.linuxbsd.editor.x86_64.o bin/obj/modules/gaussian_splatting/renderer/render_instancing_orchestrator.linuxbsd.editor.x86_64.o bin/obj/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.linuxbsd.editor.x86_64.o -j2`
- Attempted `scons ... bin/obj/tests/test_main.linuxbsd.editor.x86_64.o -j2`; it parsed through the new Gaussian test header but was stopped after 9 minutes while still compiling the whole test registry.

## Known follow-ups

- Promote route decisions in the streaming/resident outer selection code so the route object becomes the single source of truth rather than a foundation mirrored from existing backend policy state.
- Add runtime/GPU evidence for compositor fallback visual correctness and raster overflow/indirect-count behavior before claiming those paths solved.
- Deepen serial instancing coverage around per-instance cull/sort/raster failures once lower-level failure injection seams are available.

Refs #351