### PR TITLE
Draft: #358 define gsplatworld payload semantics

### DIFF
--- a/docs/api/gaussian_splat_world3d.md
+++ b/docs/api/gaussian_splat_world3d.md
@@ -3,6 +3,12 @@
 ## Purpose
 Use `GaussianSplatWorld3D` to render merged multi-asset Gaussian splat worlds from a `GaussianSplatWorld` resource in a `Node3D` scene (`modules/gaussian_splatting/nodes/gaussian_splat_world_3d.h:10`).
 
+## Payload Semantics
+
+`GaussianSplatWorld3D` submits the actual payload carried by its `GaussianSplatWorld` resource. A normal uncompressed `.gsplatworld` load is `streamable_uncompressed`: it has a valid chunk payload source and no resident `GaussianData`, so chunks can be read from the file on demand. Compressed `.gsplatworld`, `.gsplatcache`, explicit `load_resident()`, and direct PLY/SPZ instance imports are `resident_only`.
+
+The route policy controls backend selection, not source residency. Check `GaussianSplatRenderer.get_render_stats()` for `payload_mode`, `payload_streamable`, `payload_source_active`, `resident_payload_active`, and `payload_resident_only_reason` when debugging whether a world is actually out-of-core streamable.
+
 ## Usage
 <table>
   <thead>

--- a/docs/features/streaming.md
+++ b/docs/features/streaming.md
@@ -19,11 +19,17 @@ Streaming behavior depends on the format of the source asset:
 
 | Source | Residency | Chunk payloads | Notes |
 | --- | --- | --- | --- |
-| Uncompressed `.gsplatworld` | Resident `GaussianData` plus file-backed `StagedFileChunkPayloadSource` | Loaded on demand from the source file | Only format that supports file-backed streaming reads. |
+| Uncompressed `.gsplatworld` loaded normally | Source-backed, no resident `GaussianData` by default | Loaded on demand from the source file | Only format that supports out-of-core file-backed streaming reads. |
 | Compressed `.gsplatworld` | Resident only | None — full gaussian array is decoded into memory at load | Format is resident-only and has no "out-of-core" streaming path; the streaming system still manages visibility, LOD, and VRAM residency. |
+| `.gsplatworld` loaded through `load_resident()` | Resident only | None | Compatibility path for callers that explicitly request resident CPU data. |
+| `.gsplatcache` | Resident only | None | Internal PLY importer cache, owned by the source PLY identity tuple. It is not a streamable world format. |
 | `.ply` / `.spz` via `GaussianSplatNode3D` | Resident only | None | Direct instance nodes always publish a resident submission hint. |
 
-`GaussianStreamingSystem` runs in all three cases, but "streaming" here means GPU residency and LOD management, not out-of-core source loading, except for uncompressed `.gsplatworld`.
+`GaussianStreamingSystem` can run for any of these sources, but "streaming" usually means GPU residency and LOD management. Out-of-core source loading currently exists only for normal uncompressed `.gsplatworld` loads.
+
+Generic `ResourceSaver::save()` preserves streamability for source-backed worlds: a normal save/load/save round trip writes uncompressed `.gsplatworld` data and does not leave the in-memory resource materialized as resident `GaussianData`. Compressed output is a resident-only export choice because the current gzip payload has no random-access chunk blocks.
+
+Runtime diagnostics expose the actual payload mode separately from route policy. `GaussianSplatRenderer.get_render_stats()` includes `payload_mode`, `payload_streamable`, `payload_source_active`, `resident_payload_active`, and `payload_resident_only_reason`; a streaming route policy with a compressed world still reports `payload_mode = "resident_only"`.
 
 ## Enabling streaming
 

--- a/docs/reference/project-settings.md
+++ b/docs/reference/project-settings.md
@@ -102,6 +102,8 @@ These settings are registered with `GLOBAL_DEF(...)` and grouped by key prefix.
   </tbody>
 </table>
 
+`gsplatworld_compression_enabled` is legacy import/cache policy. Generic `ResourceSaver::save()` preserves `.gsplatworld` streamability and does not use this setting to compress source-backed world round trips. Compressed `.gsplatworld` output is resident-only and must be requested through an explicit resident compressed export path.
+
 #### Quality
 
 <table>

--- a/docs/workflows/GSPLATWORLD_BAKE.md
+++ b/docs/workflows/GSPLATWORLD_BAKE.md
@@ -31,6 +31,14 @@ Use this workflow when you want to merge multiple Gaussian splat assets into one
 3. Set the output path first.
 4. Run the bake once, then validate the baked world in a clean scene.
 
+## Payload Mode
+
+For runtime worlds, keep baked `.gsplatworld` files uncompressed when you want out-of-core file-backed streaming. Normal uncompressed loads attach a staged chunk payload source and do not allocate resident `GaussianData` by default.
+
+Compressed `.gsplatworld` output is resident-only. It can still use the streaming system for GPU residency, LOD, and culling, but the full gaussian payload must be decoded into CPU memory before rendering because the current compressed layout is not random-access by chunk.
+
+Generic save/load/save round trips preserve streamable uncompressed worlds. Use an explicit resident compressed export path only when the file is intended to be resident-only.
+
 ## Common Failure Modes
 
 | Symptom | Likely cause | What to do |
@@ -40,6 +48,7 @@ Use this workflow when you want to merge multiple Gaussian splat assets into one
 | `Multiple GaussianSplatContainer nodes found...` | Auto-discovery is ambiguous | Pass `--container=<nodepath>` |
 | `Output must end with .gsplatworld` | Output extension is unsupported | Rename the output file |
 | Misaligned runtime world | The baked world is applied to a transformed runtime node | Reset `GaussianSplatWorld3D` to identity before applying the world data |
+| Streaming route policy still reports resident-only payload | The world file is compressed or was loaded resident explicitly | Re-export the world as uncompressed and load normally for out-of-core source streaming |
 
 ## Related Pages
 

--- a/docs/workflows/importing.md
+++ b/docs/workflows/importing.md
@@ -17,7 +17,12 @@ Visual captures for the import dialog are still pending, so this page stays text
 | --- | --- | --- |
 | `.ply` | Imported `GaussianSplatAsset` resource | Common editor import flow |
 | `.spz` | Imported `GaussianSplatAsset` resource | Compressed splat inputs |
+| `.gsplatworld` | Imported binary `GaussianSplatWorld` copy | Prebaked multi-asset worlds |
 | Runtime load path | In-memory `GaussianSplatAsset` | Scripted loading without import-dock output |
+
+Direct `.ply` and `.spz` imports are resident-only scene assets. The PLY importer may write a sibling `.gsplatcache` for faster reloads; that cache is resident-only and owned by the source PLY path, size, mtime, and cache version.
+
+For out-of-core source streaming, use an uncompressed `.gsplatworld` loaded normally. Compressed `.gsplatworld`, `.gsplatcache`, explicit `load_resident()`, and direct PLY/SPZ imports do not provide file-backed chunk reads.
 
 ## Import Steps
 

--- a/modules/gaussian_splatting/core/gaussian_splat_world.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_world.cpp
@@ -13,6 +13,9 @@ void GaussianSplatWorld::_bind_methods() {
     ClassDB::bind_method(D_METHOD("has_chunk_payload_source"), &GaussianSplatWorld::has_chunk_payload_source);
     ClassDB::bind_method(D_METHOD("is_payload_source_backed"), &GaussianSplatWorld::is_payload_source_backed);
     ClassDB::bind_method(D_METHOD("has_renderable_payload"), &GaussianSplatWorld::has_renderable_payload);
+    ClassDB::bind_method(D_METHOD("get_payload_mode"), &GaussianSplatWorld::get_payload_mode);
+    ClassDB::bind_method(D_METHOD("is_streamable_payload"), &GaussianSplatWorld::is_streamable_payload);
+    ClassDB::bind_method(D_METHOD("get_resident_only_reason"), &GaussianSplatWorld::get_resident_only_reason);
     ClassDB::bind_method(D_METHOD("get_splat_count"), &GaussianSplatWorld::get_splat_count);
     ClassDB::bind_method(D_METHOD("get_sh_degree"), &GaussianSplatWorld::get_sh_degree);
     ClassDB::bind_method(D_METHOD("get_sh_first_order_count"), &GaussianSplatWorld::get_sh_first_order_count);
@@ -65,6 +68,26 @@ bool GaussianSplatWorld::_get(const StringName &p_name, Variant &r_ret) const {
         r_ret = bytes / (1024.0 * 1024.0);
         return true;
     }
+    if (p_name == StringName("payload/mode")) {
+        r_ret = get_payload_mode();
+        return true;
+    }
+    if (p_name == StringName("payload/streamable")) {
+        r_ret = is_streamable_payload();
+        return true;
+    }
+    if (p_name == StringName("payload/has_resident_data")) {
+        r_ret = has_resident_gaussian_data();
+        return true;
+    }
+    if (p_name == StringName("payload/has_chunk_source")) {
+        r_ret = has_chunk_payload_source();
+        return true;
+    }
+    if (p_name == StringName("payload/resident_only_reason")) {
+        r_ret = get_resident_only_reason();
+        return true;
+    }
     return false;
 }
 
@@ -74,6 +97,11 @@ void GaussianSplatWorld::_get_property_list(List<PropertyInfo> *p_list) const {
     p_list->push_back(PropertyInfo(Variant::INT, "stats/chunk_count", PROPERTY_HINT_NONE, "", usage));
     p_list->push_back(PropertyInfo(Variant::INT, "stats/lod_levels", PROPERTY_HINT_NONE, "", usage));
     p_list->push_back(PropertyInfo(Variant::FLOAT, "stats/memory_mb", PROPERTY_HINT_NONE, "", usage));
+    p_list->push_back(PropertyInfo(Variant::STRING, "payload/mode", PROPERTY_HINT_NONE, "", usage));
+    p_list->push_back(PropertyInfo(Variant::BOOL, "payload/streamable", PROPERTY_HINT_NONE, "", usage));
+    p_list->push_back(PropertyInfo(Variant::BOOL, "payload/has_resident_data", PROPERTY_HINT_NONE, "", usage));
+    p_list->push_back(PropertyInfo(Variant::BOOL, "payload/has_chunk_source", PROPERTY_HINT_NONE, "", usage));
+    p_list->push_back(PropertyInfo(Variant::STRING, "payload/resident_only_reason", PROPERTY_HINT_NONE, "", usage));
 }
 
 void GaussianSplatWorld::set_gaussian_data(const Ref<GaussianData> &p_data) {
@@ -140,6 +168,39 @@ bool GaussianSplatWorld::is_payload_source_backed() const {
 
 bool GaussianSplatWorld::has_renderable_payload() const {
     return has_resident_gaussian_data() || has_chunk_payload_source();
+}
+
+String GaussianSplatWorld::get_payload_mode() const {
+    if (is_streamable_payload()) {
+        return "streamable_uncompressed";
+    }
+    if (has_resident_gaussian_data()) {
+        return "resident_only";
+    }
+    if (has_chunk_payload_source()) {
+        return "streamable_uncompressed";
+    }
+    return "empty";
+}
+
+bool GaussianSplatWorld::is_streamable_payload() const {
+    return has_chunk_payload_source() && !has_resident_gaussian_data();
+}
+
+String GaussianSplatWorld::get_resident_only_reason() const {
+    if (is_streamable_payload()) {
+        return String();
+    }
+    if (has_resident_gaussian_data() && has_chunk_payload_source()) {
+        return "resident_payload_materialized";
+    }
+    if (has_resident_gaussian_data()) {
+        return "resident_payload_no_file_source";
+    }
+    if (has_chunk_payload_source()) {
+        return String();
+    }
+    return "no_renderable_payload";
 }
 
 void GaussianSplatWorld::set_payload_metadata(uint32_t p_splat_count, uint32_t p_sh_degree,

--- a/modules/gaussian_splatting/core/gaussian_splat_world.h
+++ b/modules/gaussian_splatting/core/gaussian_splat_world.h
@@ -50,6 +50,9 @@ public:
     bool has_chunk_payload_source() const;
     bool is_payload_source_backed() const;
     bool has_renderable_payload() const;
+    String get_payload_mode() const;
+    bool is_streamable_payload() const;
+    String get_resident_only_reason() const;
 
     void set_payload_metadata(uint32_t p_splat_count, uint32_t p_sh_degree,
             uint32_t p_sh_first_order_count, uint32_t p_sh_high_order_count, bool p_is_2d);

--- a/modules/gaussian_splatting/io/gaussian_splat_world_io.cpp
+++ b/modules/gaussian_splatting/io/gaussian_splat_world_io.cpp
@@ -5,7 +5,6 @@
 #include "core/io/json.h"
 #include "core/io/compression.h"
 #include "core/string/ustring.h"
-#include "core/config/project_settings.h"
 #include "core/math/math_funcs.h"
 #include "io_settings_utils.h"
 #include "../core/gaussian_data.h"
@@ -33,6 +32,7 @@ static constexpr uint32_t kFlagIs2D = 1u << 1u;
 static constexpr uint32_t kFlagHasChunks = 1u << 2u;
 static constexpr uint32_t kFlagHasHighSh = 1u << 3u;
 static constexpr uint32_t kFlagCompressed = 1u << 4u;
+static constexpr uint32_t kFlagResidentPayload = 1u << 5u;
 static constexpr uint64_t kHeaderSizeBytes = 104u;
 
 static bool fits_within(uint64_t p_offset, uint64_t p_size, uint64_t p_file_len) {
@@ -134,15 +134,6 @@ static bool _decompress_data(const uint8_t *p_compressed, uint64_t p_compressed_
 	return result == static_cast<int64_t>(p_original_size);
 }
 
-static bool _is_world_compression_enabled() {
-	if (ProjectSettings *ps = ProjectSettings::get_singleton()) {
-		return GaussianSplattingIO::get_bool_setting(ps,
-				"rendering/gaussian_splatting/import/gsplatworld_compression_enabled",
-				false);
-	}
-	return false;
-}
-
 static Error _ensure_file_write_ok(const Ref<FileAccess> &p_file, const char *p_context) {
 	ERR_FAIL_COND_V_MSG(p_file.is_null(), ERR_INVALID_PARAMETER, "FileAccess is null while checking write status.");
 	const Error io_error = p_file->get_error();
@@ -153,6 +144,319 @@ static Error _ensure_file_write_ok(const Ref<FileAccess> &p_file, const char *p_
 		return io_error;
 	}
 	return OK;
+}
+
+static Error _materialize_payload_source_for_save(const GaussianSplatWorld *p_world, Ref<GaussianData> &r_gaussian_data) {
+	ERR_FAIL_COND_V(p_world == nullptr, ERR_INVALID_PARAMETER);
+	Ref<ChunkPayloadSource> payload_source = p_world->get_chunk_payload_source();
+	ERR_FAIL_COND_V_MSG(payload_source.is_null() || !payload_source->is_valid(), ERR_UNCONFIGURED,
+			"GaussianSplatWorld has no valid source-backed payload to save.");
+
+	LocalVector<Gaussian> gaussians;
+	LocalVector<Vector3> sh_high_order;
+	uint32_t sh_first_order = 0;
+	uint32_t sh_high_order_count = 0;
+	if (!payload_source->capture_chunk_snapshot(0, payload_source->get_count(),
+				gaussians, sh_high_order, sh_first_order, sh_high_order_count)) {
+		return ERR_FILE_CANT_READ;
+	}
+
+	r_gaussian_data.instantiate();
+	r_gaussian_data->set_gaussian_payload(gaussians, sh_high_order,
+			sh_first_order, sh_high_order_count, p_world->get_2d_mode());
+	return OK;
+}
+
+struct WorldSaveLayout {
+	uint32_t splat_count = 0;
+	uint32_t sh_degree = 0;
+	uint32_t sh_first_order = 0;
+	uint32_t sh_high_order = 0;
+	uint32_t chunk_count = 0;
+	uint32_t flags = 0;
+	uint64_t gaussian_bytes = 0;
+	uint64_t sh_bytes = 0;
+	uint64_t chunk_table_bytes = 0;
+	uint64_t indices_bytes = 0;
+	uint64_t gaussian_stored_bytes = 0;
+	uint64_t gaussian_offset = kHeaderSizeBytes;
+	uint64_t sh_offset = 0;
+	uint64_t chunk_table_offset = 0;
+	uint64_t indices_offset = 0;
+	uint64_t metadata_offset = 0;
+	uint64_t metadata_size = 0;
+	bool use_compression = false;
+	PackedByteArray compressed_gaussians;
+	PackedByteArray metadata_bytes;
+};
+
+static uint64_t _count_chunk_indices(const Vector<StaticChunk> &p_chunks) {
+	uint64_t total_indices = 0;
+	for (int i = 0; i < p_chunks.size(); i++) {
+		total_indices += p_chunks[i].indices.size();
+	}
+	return total_indices;
+}
+
+static uint32_t _build_world_save_flags(const GaussianSplatWorld *p_world,
+		const Ref<GaussianData> &p_gaussian_data,
+		const Vector<StaticChunk> &p_chunks) {
+	uint32_t flags = 0;
+	if (!p_world->get_metadata().is_empty()) {
+		flags |= kFlagHasMetadata;
+	}
+	if (p_gaussian_data->get_2d_mode()) {
+		flags |= kFlagIs2D;
+	}
+	if (!p_chunks.is_empty()) {
+		flags |= kFlagHasChunks;
+	}
+	if (p_gaussian_data->get_sh_high_order_count() > 0) {
+		flags |= kFlagHasHighSh;
+	}
+	return flags;
+}
+
+static PackedByteArray _build_world_metadata_bytes(const GaussianSplatWorld *p_world, uint32_t p_flags) {
+	String metadata_json;
+	if ((p_flags & kFlagHasMetadata) != 0) {
+		metadata_json = JSON::stringify(p_world->get_metadata());
+	}
+	return metadata_json.to_utf8_buffer();
+}
+
+static bool _compress_world_gaussians(const Ref<GaussianData> &p_gaussian_data,
+		uint64_t p_gaussian_bytes,
+		PackedByteArray &r_compressed_gaussians) {
+	if (p_gaussian_bytes == 0) {
+		return false;
+	}
+
+	r_compressed_gaussians = _compress_data(
+			reinterpret_cast<const uint8_t *>(p_gaussian_data->get_gaussian_storage().ptr()),
+			p_gaussian_bytes);
+	if (r_compressed_gaussians.is_empty()) {
+		return false;
+	}
+
+	GS_LOG_STREAMING_INFO(vformat("Compressed gaussian data: %d KB -> %d KB (%.1fx)",
+			int(p_gaussian_bytes / 1024), int(r_compressed_gaussians.size() / 1024),
+			float(p_gaussian_bytes) / float(r_compressed_gaussians.size())));
+	return true;
+}
+
+static Error _build_world_save_layout(const GaussianSplatWorld *p_world,
+		const Ref<GaussianData> &p_gaussian_data,
+		const Vector<StaticChunk> &p_chunks,
+		ResourceFormatSaverGaussianSplatWorld::PayloadSaveMode p_mode,
+		WorldSaveLayout &r_layout) {
+	WorldSaveLayout layout;
+	layout.splat_count = p_gaussian_data->get_count();
+	layout.sh_degree = p_gaussian_data->get_sh_degree();
+	layout.sh_first_order = p_gaussian_data->get_sh_first_order_count();
+	layout.sh_high_order = p_gaussian_data->get_sh_high_order_count();
+	layout.chunk_count = p_chunks.size();
+	layout.flags = _build_world_save_flags(p_world, p_gaussian_data, p_chunks);
+	layout.metadata_bytes = _build_world_metadata_bytes(p_world, layout.flags);
+
+	const uint64_t total_indices = _count_chunk_indices(p_chunks);
+	layout.gaussian_bytes = uint64_t(layout.splat_count) * sizeof(Gaussian);
+	layout.sh_bytes = uint64_t(layout.splat_count) * uint64_t(layout.sh_high_order) * sizeof(Vector3);
+	layout.chunk_table_bytes = uint64_t(layout.chunk_count) * 56u;
+	layout.indices_bytes = total_indices * sizeof(uint32_t);
+
+	// Generic ResourceSaver::save() must preserve streamability. Compression is
+	// only for the explicit resident export path because this gzip layout cannot
+	// serve random-access chunk reads.
+	const bool resident_only = p_mode == ResourceFormatSaverGaussianSplatWorld::SAVE_PAYLOAD_RESIDENT_COMPRESSED ||
+			p_mode == ResourceFormatSaverGaussianSplatWorld::SAVE_PAYLOAD_RESIDENT_UNCOMPRESSED;
+	if (resident_only) {
+		layout.flags |= kFlagResidentPayload;
+	}
+	if (p_mode == ResourceFormatSaverGaussianSplatWorld::SAVE_PAYLOAD_RESIDENT_COMPRESSED) {
+		layout.use_compression = _compress_world_gaussians(p_gaussian_data, layout.gaussian_bytes, layout.compressed_gaussians);
+		if (!layout.use_compression || layout.compressed_gaussians.is_empty()) {
+			ERR_PRINT("[GaussianSplatWorldIO] Explicit resident-compressed save requested, but gaussian payload compression failed.");
+			return ERR_CANT_CREATE;
+		}
+	}
+	if (layout.use_compression) {
+		layout.flags |= kFlagCompressed;
+	}
+
+	layout.gaussian_stored_bytes = layout.use_compression
+			? (8 + layout.compressed_gaussians.size())
+			: layout.gaussian_bytes;
+	layout.sh_offset = layout.gaussian_offset + layout.gaussian_stored_bytes;
+	layout.chunk_table_offset = layout.sh_offset + layout.sh_bytes;
+	layout.indices_offset = layout.chunk_table_offset + layout.chunk_table_bytes;
+	layout.metadata_offset = layout.metadata_bytes.is_empty() ? 0u
+			: (kHeaderSizeBytes + layout.gaussian_stored_bytes + layout.sh_bytes + layout.chunk_table_bytes + layout.indices_bytes);
+	layout.metadata_size = layout.metadata_bytes.size();
+	r_layout = layout;
+	return OK;
+}
+
+static Error _write_buffer_sliced(const Ref<FileAccess> &p_file,
+		const uint8_t *p_src,
+		uint64_t p_size,
+		const char *p_context) {
+	// Write in <=256 MB slices to avoid MSVC CRT fwrite issues with >2 GB writes.
+	constexpr uint64_t kSliceBytes = 256u * 1024u * 1024u;
+	uint64_t written = 0;
+	while (written < p_size) {
+		const uint64_t slice = MIN(kSliceBytes, p_size - written);
+		p_file->store_buffer(p_src + written, slice);
+		const Error err = _ensure_file_write_ok(p_file, p_context);
+		if (err != OK) {
+			return err;
+		}
+		written += slice;
+	}
+	return OK;
+}
+
+static Error _write_world_save_header(const Ref<FileAccess> &p_file,
+		const GaussianSplatWorld *p_world,
+		const WorldSaveLayout &p_layout) {
+	p_file->store_32(kWorldMagic);
+	p_file->store_32(kWorldVersion);
+	p_file->store_32(p_layout.flags);
+	p_file->store_32(p_layout.splat_count);
+	p_file->store_32(p_layout.sh_degree);
+	p_file->store_32(p_layout.sh_first_order);
+	p_file->store_32(p_layout.sh_high_order);
+	_write_vec3(p_file, p_world->get_bounds().position);
+	_write_vec3(p_file, p_world->get_bounds().size);
+	p_file->store_32(p_layout.chunk_count);
+	p_file->store_64(p_layout.gaussian_offset);
+	p_file->store_64(p_layout.sh_offset);
+	p_file->store_64(p_layout.chunk_table_offset);
+	p_file->store_64(p_layout.indices_offset);
+	p_file->store_64(p_layout.metadata_offset);
+	p_file->store_64(p_layout.metadata_size);
+	return _ensure_file_write_ok(p_file, "save(header)");
+}
+
+static Error _write_world_gaussian_payload(const Ref<FileAccess> &p_file,
+		const Ref<GaussianData> &p_gaussian_data,
+		const WorldSaveLayout &p_layout) {
+	if (p_layout.gaussian_bytes == 0) {
+		return OK;
+	}
+
+	const uint8_t *write_src = nullptr;
+	uint64_t write_total = 0;
+	if (p_layout.use_compression && !p_layout.compressed_gaussians.is_empty()) {
+		// Write compressed format: [8 bytes size][compressed data].
+		p_file->store_64(p_layout.compressed_gaussians.size());
+		write_src = p_layout.compressed_gaussians.ptr();
+		write_total = p_layout.compressed_gaussians.size();
+	} else {
+		// Write uncompressed format: raw gaussian data.
+		write_src = reinterpret_cast<const uint8_t *>(p_gaussian_data->get_gaussian_storage().ptr());
+		write_total = p_layout.gaussian_bytes;
+	}
+
+	return _write_buffer_sliced(p_file, write_src, write_total, "save(gaussian_data)");
+}
+
+static Error _write_world_sh_payload(const Ref<FileAccess> &p_file,
+		const Ref<GaussianData> &p_gaussian_data,
+		const WorldSaveLayout &p_layout) {
+	if (p_layout.sh_bytes == 0) {
+		return OK;
+	}
+
+	const Vector3 *sh_ptr = p_gaussian_data->get_sh_high_order_coefficients_ptr();
+	ERR_FAIL_COND_V_MSG(sh_ptr == nullptr, ERR_INVALID_DATA,
+			"GaussianSplatWorld missing high-order SH coefficients while sh_high_order_count > 0.");
+	p_file->store_buffer(reinterpret_cast<const uint8_t *>(sh_ptr), p_layout.sh_bytes);
+	return _ensure_file_write_ok(p_file, "save(sh_data)");
+}
+
+static Error _write_world_chunk_table(const Ref<FileAccess> &p_file, const Vector<StaticChunk> &p_chunks) {
+	uint64_t indices_cursor = 0;
+	for (int i = 0; i < p_chunks.size(); i++) {
+		const StaticChunk &chunk = p_chunks[i];
+		ChunkRecord record;
+		record.bounds_pos = chunk.bounds.position;
+		record.bounds_size = chunk.bounds.size;
+		record.center = chunk.center;
+		record.radius = chunk.radius;
+		record.indices_offset = indices_cursor;
+		record.index_count = chunk.indices.size();
+		_write_chunk_record(p_file, record);
+		indices_cursor += record.index_count;
+	}
+	return _ensure_file_write_ok(p_file, "save(chunk_table)");
+}
+
+static Error _write_world_chunk_indices(const Ref<FileAccess> &p_file, const Vector<StaticChunk> &p_chunks) {
+	for (int i = 0; i < p_chunks.size(); i++) {
+		const StaticChunk &chunk = p_chunks[i];
+		if (chunk.indices.is_empty()) {
+			continue;
+		}
+		p_file->store_buffer(reinterpret_cast<const uint8_t *>(chunk.indices.ptr()),
+				uint64_t(chunk.indices.size()) * sizeof(uint32_t));
+		const Error err = _ensure_file_write_ok(p_file, "save(chunk_indices)");
+		if (err != OK) {
+			return err;
+		}
+	}
+	return OK;
+}
+
+static Error _write_world_chunks(const Ref<FileAccess> &p_file,
+		const Vector<StaticChunk> &p_chunks,
+		const WorldSaveLayout &p_layout) {
+	if (p_layout.chunk_count == 0) {
+		return OK;
+	}
+
+	const Error chunk_table_err = _write_world_chunk_table(p_file, p_chunks);
+	if (chunk_table_err != OK) {
+		return chunk_table_err;
+	}
+	return _write_world_chunk_indices(p_file, p_chunks);
+}
+
+static Error _write_world_metadata(const Ref<FileAccess> &p_file, const WorldSaveLayout &p_layout) {
+	if (p_layout.metadata_size == 0) {
+		return OK;
+	}
+
+	p_file->store_buffer(p_layout.metadata_bytes.ptr(), p_layout.metadata_size);
+	return _ensure_file_write_ok(p_file, "save(metadata)");
+}
+
+static Error _write_world_save_sections(const Ref<FileAccess> &p_file,
+		const GaussianSplatWorld *p_world,
+		const Ref<GaussianData> &p_gaussian_data,
+		const Vector<StaticChunk> &p_chunks,
+		const WorldSaveLayout &p_layout) {
+	Error err = _write_world_save_header(p_file, p_world, p_layout);
+	if (err != OK) {
+		return err;
+	}
+	err = _write_world_gaussian_payload(p_file, p_gaussian_data, p_layout);
+	if (err != OK) {
+		return err;
+	}
+	err = _write_world_sh_payload(p_file, p_gaussian_data, p_layout);
+	if (err != OK) {
+		return err;
+	}
+	err = _write_world_chunks(p_file, p_chunks, p_layout);
+	if (err != OK) {
+		return err;
+	}
+	err = _write_world_metadata(p_file, p_layout);
+	if (err != OK) {
+		return err;
+	}
+	return _ensure_file_write_ok(p_file, "save(final)");
 }
 
 } // namespace
@@ -316,7 +620,8 @@ static Ref<Resource> _load_gsplatworld_resource(const String &p_path, Error *r_e
 		}
 	}
 
-	const bool should_materialize_resident_payload = gaussian_data_compressed || p_force_resident;
+	const bool resident_payload_file = (flags & kFlagResidentPayload) != 0;
+	const bool should_materialize_resident_payload = gaussian_data_compressed || resident_payload_file || p_force_resident;
 	LocalVector<Gaussian> gaussians;
 
 	if (should_materialize_resident_payload) {
@@ -495,7 +800,7 @@ static Ref<Resource> _load_gsplatworld_resource(const String &p_path, Error *r_e
 	// Only uncompressed files support file-backed chunk payload reads. Compressed
 	// .gsplatworld files are resident-only: the decoded payload lives in memory on
 	// the GaussianData above and no staged-file payload source is attached.
-	if (!gaussian_data_compressed && !p_force_resident) {
+	if (!gaussian_data_compressed && !resident_payload_file && !p_force_resident) {
 		Ref<StagedFileChunkPayloadSource> file_source;
 		file_source.instantiate();
 		const uint64_t staged_sh_offset = ((flags & kFlagHasHighSh) != 0 && sh_high_order > 0) ? sh_offset : 0u;
@@ -550,193 +855,44 @@ String ResourceFormatLoaderGaussianSplatWorld::get_resource_type(const String &p
 }
 
 Error ResourceFormatSaverGaussianSplatWorld::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+	return save_with_payload_mode(p_resource, p_path, SAVE_PAYLOAD_PRESERVE, p_flags);
+}
+
+Error ResourceFormatSaverGaussianSplatWorld::save_resident_compressed(const Ref<Resource> &p_resource,
+		const String &p_path, uint32_t p_flags) {
+	return save_with_payload_mode(p_resource, p_path, SAVE_PAYLOAD_RESIDENT_COMPRESSED, p_flags);
+}
+
+Error ResourceFormatSaverGaussianSplatWorld::save_resident_uncompressed(const Ref<Resource> &p_resource,
+		const String &p_path, uint32_t p_flags) {
+	return save_with_payload_mode(p_resource, p_path, SAVE_PAYLOAD_RESIDENT_UNCOMPRESSED, p_flags);
+}
+
+Error ResourceFormatSaverGaussianSplatWorld::save_with_payload_mode(const Ref<Resource> &p_resource,
+		const String &p_path, PayloadSaveMode p_mode, uint32_t p_flags) {
 	(void)p_flags;
 	GaussianSplatWorld *world = Object::cast_to<GaussianSplatWorld>(*p_resource);
 	ERR_FAIL_COND_V_MSG(world == nullptr, ERR_INVALID_PARAMETER, "Resource is not a GaussianSplatWorld.");
 
 	Ref<GaussianData> gaussian_data = world->get_gaussian_data();
-	if (gaussian_data.is_null() && world->has_chunk_payload_source()) {
-		const Error materialize_err = world->materialize_resident_gaussian_data();
+	const bool source_backed_without_resident = gaussian_data.is_null() && world->has_chunk_payload_source();
+	if (source_backed_without_resident) {
+		const Error materialize_err = _materialize_payload_source_for_save(world, gaussian_data);
 		ERR_FAIL_COND_V_MSG(materialize_err != OK, materialize_err,
-				vformat("Failed to materialize source-backed GaussianSplatWorld before save: %s", p_path));
-		gaussian_data = world->get_gaussian_data();
+				vformat("Failed to read source-backed GaussianSplatWorld payload before save: %s", p_path));
 	}
 	ERR_FAIL_COND_V_MSG(gaussian_data.is_null(), ERR_INVALID_DATA, "GaussianSplatWorld has no GaussianData.");
-	Error err = OK;
+
+	const Vector<StaticChunk> &chunks = world->get_static_chunks();
+	WorldSaveLayout layout;
+	const Error layout_err = _build_world_save_layout(world, gaussian_data, chunks, p_mode, layout);
+	ERR_FAIL_COND_V_MSG(layout_err != OK, layout_err,
+			vformat("Cannot build gsplatworld save layout for %s.", p_path));
 
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE);
 	ERR_FAIL_COND_V_MSG(file.is_null(), ERR_FILE_CANT_WRITE, vformat("Cannot write gsplatworld file: %s", p_path));
 
-	const uint32_t splat_count = gaussian_data->get_count();
-	const uint32_t sh_degree = gaussian_data->get_sh_degree();
-	const uint32_t sh_first_order = gaussian_data->get_sh_first_order_count();
-	const uint32_t sh_high_order = gaussian_data->get_sh_high_order_count();
-	const bool is_2d = gaussian_data->get_2d_mode();
-	const Vector<StaticChunk> &chunks = world->get_static_chunks();
-	const uint32_t chunk_count = chunks.size();
-
-	uint64_t total_indices = 0;
-	for (uint32_t i = 0; i < chunk_count; i++) {
-		total_indices += chunks[i].indices.size();
-	}
-
-	uint32_t flags = 0;
-	if (!world->get_metadata().is_empty()) {
-		flags |= kFlagHasMetadata;
-	}
-	if (is_2d) {
-		flags |= kFlagIs2D;
-	}
-	if (chunk_count > 0) {
-		flags |= kFlagHasChunks;
-	}
-	if (sh_high_order > 0) {
-		flags |= kFlagHasHighSh;
-	}
-
-	String metadata_json;
-	if ((flags & kFlagHasMetadata) != 0) {
-		metadata_json = JSON::stringify(world->get_metadata());
-	}
-	PackedByteArray metadata_bytes = metadata_json.to_utf8_buffer();
-
-	const uint64_t gaussian_bytes = uint64_t(splat_count) * sizeof(Gaussian);
-	const uint64_t sh_bytes = uint64_t(splat_count) * uint64_t(sh_high_order) * sizeof(Vector3);
-	const uint64_t chunk_table_bytes = uint64_t(chunk_count) * 56u;
-	const uint64_t indices_bytes = total_indices * sizeof(uint32_t);
-
-	// Compression is configurable; cache-heavy workflows can disable it to minimize CPU load times.
-	PackedByteArray compressed_gaussians;
-	bool use_compression = _is_world_compression_enabled() && gaussian_bytes > 1024; // Only compress if >1KB
-	if (use_compression && gaussian_bytes > 0) {
-		compressed_gaussians = _compress_data(
-				reinterpret_cast<const uint8_t *>(gaussian_data->get_gaussian_storage().ptr()),
-				gaussian_bytes);
-		if (compressed_gaussians.is_empty()) {
-			use_compression = false; // Compression failed, fall back to uncompressed
-		} else {
-			flags |= kFlagCompressed;
-			GS_LOG_STREAMING_INFO(vformat("Compressed gaussian data: %d KB -> %d KB (%.1fx)",
-					int(gaussian_bytes / 1024), int(compressed_gaussians.size() / 1024),
-					float(gaussian_bytes) / float(compressed_gaussians.size())));
-		}
-	}
-
-	// Calculate stored size (compressed + 8 byte header, or uncompressed)
-	const uint64_t gaussian_stored_bytes = use_compression
-			? (8 + compressed_gaussians.size())
-			: gaussian_bytes;
-
-	const uint64_t metadata_offset = (metadata_bytes.is_empty()) ? 0u
-			: (kHeaderSizeBytes + gaussian_stored_bytes + sh_bytes + chunk_table_bytes + indices_bytes);
-
-	const uint64_t gaussian_offset = kHeaderSizeBytes;
-	const uint64_t sh_offset = gaussian_offset + gaussian_stored_bytes;
-	const uint64_t chunk_table_offset = sh_offset + sh_bytes;
-	const uint64_t indices_offset = chunk_table_offset + chunk_table_bytes;
-	const uint64_t metadata_size = metadata_bytes.size();
-
-	file->store_32(kWorldMagic);
-	file->store_32(kWorldVersion);
-	file->store_32(flags);
-	file->store_32(splat_count);
-	file->store_32(sh_degree);
-	file->store_32(sh_first_order);
-	file->store_32(sh_high_order);
-	_write_vec3(file, world->get_bounds().position);
-	_write_vec3(file, world->get_bounds().size);
-	file->store_32(chunk_count);
-	file->store_64(gaussian_offset);
-	file->store_64(sh_offset);
-	file->store_64(chunk_table_offset);
-	file->store_64(indices_offset);
-	file->store_64(metadata_offset);
-	file->store_64(metadata_size);
-	err = _ensure_file_write_ok(file, "save(header)");
-	if (err != OK) {
-		return err;
-	}
-
-	if (gaussian_bytes > 0) {
-		const uint8_t *write_src = nullptr;
-		uint64_t write_total = 0;
-		if (use_compression && !compressed_gaussians.is_empty()) {
-			// Write compressed format: [8 bytes size][compressed data]
-			file->store_64(compressed_gaussians.size());
-			write_src = compressed_gaussians.ptr();
-			write_total = compressed_gaussians.size();
-		} else {
-			// Write uncompressed format: raw gaussian data
-			write_src = reinterpret_cast<const uint8_t *>(gaussian_data->get_gaussian_storage().ptr());
-			write_total = gaussian_bytes;
-		}
-		// Write in <=256 MB slices to avoid MSVC CRT fwrite issues with >2 GB writes.
-		constexpr uint64_t kSliceBytes = 256u * 1024u * 1024u;
-		uint64_t written = 0;
-		while (written < write_total) {
-			uint64_t slice = MIN(kSliceBytes, write_total - written);
-			file->store_buffer(write_src + written, slice);
-			err = _ensure_file_write_ok(file, "save(gaussian_data)");
-			if (err != OK) {
-				return err;
-			}
-			written += slice;
-		}
-	}
-
-	if (sh_bytes > 0) {
-		const Vector3 *sh_ptr = gaussian_data->get_sh_high_order_coefficients_ptr();
-		ERR_FAIL_COND_V_MSG(sh_ptr == nullptr, ERR_INVALID_DATA,
-				"GaussianSplatWorld missing high-order SH coefficients while sh_high_order_count > 0.");
-		file->store_buffer(reinterpret_cast<const uint8_t *>(sh_ptr), sh_bytes);
-		err = _ensure_file_write_ok(file, "save(sh_data)");
-		if (err != OK) {
-			return err;
-		}
-	}
-
-	if (chunk_count > 0) {
-		uint64_t indices_cursor = 0;
-		for (uint32_t i = 0; i < chunk_count; i++) {
-			const StaticChunk &chunk = chunks[i];
-			ChunkRecord record;
-			record.bounds_pos = chunk.bounds.position;
-			record.bounds_size = chunk.bounds.size;
-			record.center = chunk.center;
-			record.radius = chunk.radius;
-			record.indices_offset = indices_cursor;
-			record.index_count = chunk.indices.size();
-			_write_chunk_record(file, record);
-			indices_cursor += record.index_count;
-		}
-		err = _ensure_file_write_ok(file, "save(chunk_table)");
-		if (err != OK) {
-			return err;
-		}
-
-		for (uint32_t i = 0; i < chunk_count; i++) {
-			const StaticChunk &chunk = chunks[i];
-			if (chunk.indices.is_empty()) {
-				continue;
-			}
-			file->store_buffer(reinterpret_cast<const uint8_t *>(chunk.indices.ptr()),
-					uint64_t(chunk.indices.size()) * sizeof(uint32_t));
-			err = _ensure_file_write_ok(file, "save(chunk_indices)");
-			if (err != OK) {
-				return err;
-			}
-		}
-	}
-
-	if (metadata_size > 0) {
-		file->store_buffer(metadata_bytes.ptr(), metadata_size);
-		err = _ensure_file_write_ok(file, "save(metadata)");
-		if (err != OK) {
-			return err;
-		}
-	}
-
-	return _ensure_file_write_ok(file, "save(final)");
+	return _write_world_save_sections(file, world, gaussian_data, chunks, layout);
 }
 
 void ResourceFormatSaverGaussianSplatWorld::get_recognized_extensions(const Ref<Resource> &p_resource,

--- a/modules/gaussian_splatting/io/gaussian_splat_world_io.h
+++ b/modules/gaussian_splatting/io/gaussian_splat_world_io.h
@@ -19,8 +19,21 @@ public:
 
 class ResourceFormatSaverGaussianSplatWorld : public ResourceFormatSaver {
 public:
+	enum PayloadSaveMode {
+		SAVE_PAYLOAD_PRESERVE = 0,
+		SAVE_PAYLOAD_STREAMABLE_UNCOMPRESSED,
+		SAVE_PAYLOAD_RESIDENT_UNCOMPRESSED,
+		SAVE_PAYLOAD_RESIDENT_COMPRESSED,
+	};
+
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path,
 			uint32_t p_flags = 0) override;
+	Error save_with_payload_mode(const Ref<Resource> &p_resource, const String &p_path,
+			PayloadSaveMode p_mode, uint32_t p_flags = 0);
+	Error save_resident_compressed(const Ref<Resource> &p_resource, const String &p_path,
+			uint32_t p_flags = 0);
+	Error save_resident_uncompressed(const Ref<Resource> &p_resource, const String &p_path,
+			uint32_t p_flags = 0);
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource,
 			List<String> *p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;

--- a/modules/gaussian_splatting/io/ply_loader.cpp
+++ b/modules/gaussian_splatting/io/ply_loader.cpp
@@ -54,6 +54,53 @@ static bool _is_ply_cache_enabled() {
     return true;
 }
 
+static String _get_ply_cache_path(const String &p_source_path) {
+    return p_source_path.get_basename() + ".gsplatcache";
+}
+
+static Ref<GaussianSplatWorld> _load_ply_cache_world(const String &p_cache_path) {
+    ResourceFormatLoaderGaussianSplatWorld format_loader;
+    Error load_err = OK;
+    return format_loader.load_resident(p_cache_path, &load_err);
+}
+
+static bool _cache_source_path_matches(const Dictionary &p_metadata, const String &p_source_path) {
+    const Variant source_path_var = p_metadata.get(StringName("cache_source_path"), Variant());
+    return source_path_var.get_type() == Variant::STRING && String(source_path_var) == p_source_path;
+}
+
+static bool _cache_source_stamp_matches(const Dictionary &p_metadata, uint64_t p_source_size, uint64_t p_source_mtime) {
+    uint64_t cached_size = 0;
+    uint64_t cached_mtime = 0;
+    return _variant_to_uint64(p_metadata.get(StringName("cache_source_size"), Variant()), cached_size) &&
+            _variant_to_uint64(p_metadata.get(StringName("cache_source_mtime"), Variant()), cached_mtime) &&
+            cached_size == p_source_size &&
+            cached_mtime == p_source_mtime;
+}
+
+static bool _cache_version_matches(const Dictionary &p_metadata) {
+    const Variant version_var = p_metadata.get(StringName("cache_version"), Variant());
+    const Variant::Type version_type = version_var.get_type();
+    return (version_type == Variant::INT || version_type == Variant::FLOAT) &&
+            int(version_var) == PLY_CACHE_VERSION;
+}
+
+static bool _cache_metadata_matches(const Dictionary &p_metadata,
+        const String &p_source_path,
+        uint64_t p_source_size,
+        uint64_t p_source_mtime) {
+    return _cache_source_path_matches(p_metadata, p_source_path) &&
+            _cache_source_stamp_matches(p_metadata, p_source_size, p_source_mtime) &&
+            _cache_version_matches(p_metadata);
+}
+
+static bool _cached_gaussian_data_matches(const Ref<::GaussianData> &p_cached_data, int p_expected_vertex_count) {
+    if (p_cached_data.is_null() || p_cached_data->get_count() <= 0) {
+        return false;
+    }
+    return p_expected_vertex_count <= 0 || p_cached_data->get_count() == p_expected_vertex_count;
+}
+
 } // namespace
 
 PLYLoader::PLYLoader() {
@@ -271,7 +318,7 @@ bool PLYLoader::try_load_cache(const String &p_source_path, uint64_t p_source_si
 
     // Use .gsplatcache (not .gsplatworld) so Godot's filesystem scanner does
     // not treat PLY caches as standalone importable resources.
-    const String cache_path = p_source_path.get_basename() + ".gsplatcache";
+    const String cache_path = _get_ply_cache_path(p_source_path);
     if (!FileAccess::exists(cache_path)) {
         return false;
     }
@@ -280,39 +327,18 @@ bool PLYLoader::try_load_cache(const String &p_source_path, uint64_t p_source_si
     // read from disk.  Going through ResourceLoader::load() with the default
     // CACHE_MODE_REUSE would return stale in-memory data when the cache file
     // has been rewritten during the same editor session.
-    ResourceFormatLoaderGaussianSplatWorld format_loader;
-    Error load_err = OK;
-    Ref<GaussianSplatWorld> world = format_loader.load_resident(cache_path, &load_err);
+    Ref<GaussianSplatWorld> world = _load_ply_cache_world(cache_path);
     if (world.is_null()) {
         return false;
     }
 
     Dictionary cache_metadata = world->get_metadata();
-    uint64_t cached_size = 0;
-    uint64_t cached_mtime = 0;
-    if (!_variant_to_uint64(cache_metadata.get(StringName("cache_source_size"), Variant()), cached_size)) {
-        return false;
-    }
-    if (!_variant_to_uint64(cache_metadata.get(StringName("cache_source_mtime"), Variant()), cached_mtime)) {
-        return false;
-    }
-    if (cached_size != p_source_size || cached_mtime != p_source_mtime) {
-        return false;
-    }
-
-    const Variant version_var = cache_metadata.get(StringName("cache_version"), Variant());
-    if (version_var.get_type() != Variant::INT && version_var.get_type() != Variant::FLOAT) {
-        return false;
-    }
-    if (int(version_var) != PLY_CACHE_VERSION) {
+    if (!_cache_metadata_matches(cache_metadata, p_source_path, p_source_size, p_source_mtime)) {
         return false;
     }
 
     Ref<::GaussianData> cached_data = world->get_gaussian_data();
-    if (cached_data.is_null() || cached_data->get_count() <= 0) {
-        return false;
-    }
-    if (header.vertex_count > 0 && cached_data->get_count() != header.vertex_count) {
+    if (!_cached_gaussian_data_matches(cached_data, header.vertex_count)) {
         return false;
     }
 

--- a/modules/gaussian_splatting/io/resource_importer_gsplatworld.cpp
+++ b/modules/gaussian_splatting/io/resource_importer_gsplatworld.cpp
@@ -27,7 +27,17 @@ static bool _checked_mul_u64(uint64_t p_a, uint64_t p_b, uint64_t &r_result) {
 	return true;
 }
 
-static Error _validate_gsplatworld_header(const String &p_source_file) {
+struct GSplatWorldHeaderInfo {
+	bool compressed = false;
+	bool resident_payload = false;
+	uint32_t splat_count = 0;
+	uint32_t chunk_count = 0;
+	uint32_t sh_degree = 0;
+	uint32_t sh_first_order = 0;
+	uint32_t sh_high_order = 0;
+};
+
+static Error _validate_gsplatworld_header(const String &p_source_file, GSplatWorldHeaderInfo *r_info = nullptr) {
 	constexpr uint32_t world_magic = 0x57505347u; // 'GSPW' little-endian.
 	constexpr uint32_t world_version = 1u;
 	constexpr uint32_t max_sh_degree = 3u;
@@ -36,6 +46,7 @@ static Error _validate_gsplatworld_header(const String &p_source_file) {
 	constexpr uint32_t flag_has_chunks = 1u << 2u;
 	constexpr uint32_t flag_has_high_sh = 1u << 3u;
 	constexpr uint32_t flag_compressed = 1u << 4u;
+	constexpr uint32_t flag_resident_payload = 1u << 5u;
 	constexpr uint64_t header_size_bytes = 104u;
 	constexpr uint64_t chunk_record_size_bytes = 56u;
 
@@ -147,6 +158,16 @@ static Error _validate_gsplatworld_header(const String &p_source_file) {
 		}
 	}
 
+	if (r_info) {
+		r_info->compressed = (flags & flag_compressed) != 0u;
+		r_info->resident_payload = (flags & flag_resident_payload) != 0u;
+		r_info->splat_count = splat_count;
+		r_info->chunk_count = chunk_count;
+		r_info->sh_degree = sh_degree;
+		r_info->sh_first_order = sh_first_order;
+		r_info->sh_high_order = sh_high_order;
+	}
+
 	return OK;
 }
 
@@ -244,7 +265,8 @@ Error ResourceImporterGSplatWorld::import(ResourceUID::ID p_source_id, const Str
 		r_platform_variants->clear();
 	}
 
-	Error validation_err = _validate_gsplatworld_header(p_source_file);
+	GSplatWorldHeaderInfo header_info;
+	Error validation_err = _validate_gsplatworld_header(p_source_file, &header_info);
 	if (validation_err != OK) {
 		GS_LOG_ERROR_DEFAULT(vformat("GaussianSplatWorld importer rejected invalid payload %s (error %d)",
 				p_source_file, validation_err));
@@ -273,9 +295,24 @@ Error ResourceImporterGSplatWorld::import(ResourceUID::ID p_source_id, const Str
 	}
 
 	if (r_metadata) {
+		const bool resident_only = header_info.compressed || header_info.resident_payload;
+		const String resident_only_reason = header_info.compressed
+				? String("compressed_world_has_no_random_access_chunks")
+				: (header_info.resident_payload ? String("explicit_resident_payload") : String());
 		Dictionary import_metadata;
 		import_metadata[StringName("source_path")] = p_source_file;
 		import_metadata[StringName("resource_path")] = save_path;
+		import_metadata[StringName("compressed")] = header_info.compressed;
+		import_metadata[StringName("payload_mode")] = resident_only
+				? String("resident_only")
+				: String("streamable_uncompressed");
+		import_metadata[StringName("streamable")] = !resident_only;
+		import_metadata[StringName("resident_only_reason")] = resident_only_reason;
+		import_metadata[StringName("splat_count")] = static_cast<int64_t>(header_info.splat_count);
+		import_metadata[StringName("chunk_count")] = static_cast<int64_t>(header_info.chunk_count);
+		import_metadata[StringName("sh_degree")] = static_cast<int64_t>(header_info.sh_degree);
+		import_metadata[StringName("sh_first_order")] = static_cast<int64_t>(header_info.sh_first_order);
+		import_metadata[StringName("sh_high_order")] = static_cast<int64_t>(header_info.sh_high_order);
 		*r_metadata = import_metadata;
 	}
 

--- a/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.cpp
@@ -1362,6 +1362,17 @@ Dictionary RenderDiagnosticsOrchestrator::build_render_stats() const {
 	stats["cull_route_label"] = GaussianRenderRouteLabels::describe_cull_route_uid(normalized_cull_route_uid);
 	stats["requested_route_policy"] = debug_state.requested_route_policy;
 	stats["requested_route_policy_source"] = debug_state.requested_route_policy_source;
+	const bool resident_payload_active = scene_state.gaussian_data.is_valid() && scene_state.gaussian_data->get_count() > 0;
+	const bool payload_source_active = !resident_payload_active && scene_state.payload_source_splat_count > 0;
+	const String payload_mode = payload_source_active ? String("streamable_uncompressed")
+			: (resident_payload_active ? String("resident_only") : String("empty"));
+	const String payload_resident_only_reason = payload_source_active ? String()
+			: (resident_payload_active ? String("resident_payload_no_file_source") : String("no_renderable_payload"));
+	stats["payload_mode"] = payload_mode;
+	stats["payload_streamable"] = payload_source_active;
+	stats["payload_source_active"] = payload_source_active;
+	stats["resident_payload_active"] = resident_payload_active;
+	stats["payload_resident_only_reason"] = payload_resident_only_reason;
 	stats["instance_backend_policy"] = debug_state.instance_backend_policy;
 	stats["backend_selection_reason"] = debug_state.backend_selection_reason;
 	stats["backend_selection_reason_label"] =
@@ -1383,6 +1394,11 @@ Dictionary RenderDiagnosticsOrchestrator::build_render_stats() const {
 			debug_state.instance_backend_policy,
 			debug_state.backend_selection_reason,
 			GaussianRenderRouteLabels::describe_backend_selection_reason(debug_state.backend_selection_reason));
+	GaussianEffectiveConfig::set_entry(effective_config_snapshot,
+			StringName("payload_mode"),
+			payload_mode,
+			payload_resident_only_reason,
+			payload_source_active ? String("out-of-core source-backed reads active") : String("resident-only payload"));
 	String active_route_display = String(stats["route_label"]);
 	if (!normalized_route_uid.is_empty()) {
 		active_route_display += " [" + normalized_route_uid + "]";

--- a/modules/gaussian_splatting/renderer/render_types/render_debug_types.h
+++ b/modules/gaussian_splatting/renderer/render_types/render_debug_types.h
@@ -147,6 +147,11 @@ struct DebugState {
 	String sort_route_uid;
 	String requested_route_policy = "streaming";
 	String requested_route_policy_source = "default_fallback";
+	String payload_mode = "empty";
+	String payload_resident_only_reason = "no_renderable_payload";
+	bool payload_streamable = false;
+	bool payload_source_active = false;
+	bool resident_payload_active = false;
 	String instance_backend_policy = "none";
 	String backend_selection_reason = "not_evaluated";
 	String instance_contract_shape = "none";

--- a/modules/gaussian_splatting/tests/test_gaussian_importer.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_importer.h
@@ -7,6 +7,7 @@
 #include "../io/resource_importer_ply.h"
 #include "../io/resource_importer_spz.h"
 #include "../io/resource_importer_gsplatworld.h"
+#include "../io/gaussian_splat_world_io.h"
 #include "../io/ply_loader.h"
 #include "../io/spz_loader.h"
 #include "../editor/gaussian_import_dialog.h"
@@ -1802,8 +1803,9 @@ TEST_CASE("[GaussianSplatting][Importer] gsplatworld importer preserves payload 
     CHECK(importer->get_format_version() == 2);
 
     HashMap<StringName, Variant> options;
+    Variant import_metadata_variant;
     Error import_err = importer->import(ResourceUID::INVALID_ID, source_path, save_base_path, options,
-            nullptr, nullptr, nullptr);
+            nullptr, nullptr, &import_metadata_variant);
     CHECK_MESSAGE(import_err == OK, "ResourceImporterGSplatWorld import should succeed.");
     if (import_err != OK) {
         _remove_user_file(source_path);
@@ -1813,9 +1815,20 @@ TEST_CASE("[GaussianSplatting][Importer] gsplatworld importer preserves payload 
 
     Ref<GaussianSplatWorld> imported_world = ResourceLoader::load(imported_path, "GaussianSplatWorld");
     CHECK_MESSAGE(imported_world.is_valid(), "Imported gsplatworld should be loadable.");
+    CHECK(import_metadata_variant.get_type() == Variant::DICTIONARY);
+    if (import_metadata_variant.get_type() == Variant::DICTIONARY) {
+        Dictionary import_metadata = import_metadata_variant;
+        CHECK(String(import_metadata.get(StringName("payload_mode"), String())) == String("streamable_uncompressed"));
+        CHECK(bool(import_metadata.get(StringName("streamable"), false)));
+        CHECK_FALSE(bool(import_metadata.get(StringName("compressed"), true)));
+        CHECK(int64_t(import_metadata.get(StringName("splat_count"), int64_t(0))) == 2);
+        CHECK(int64_t(import_metadata.get(StringName("chunk_count"), int64_t(0))) == 1);
+    }
     if (imported_world.is_valid()) {
         CHECK_FALSE(imported_world->has_resident_gaussian_data());
         CHECK(imported_world->has_chunk_payload_source());
+        CHECK(imported_world->is_streamable_payload());
+        CHECK(imported_world->get_payload_mode() == String("streamable_uncompressed"));
         CHECK(imported_world->get_splat_count() == 2);
         CHECK(imported_world->materialize_resident_gaussian_data() == OK);
         Ref<GaussianData> imported_data = imported_world->get_gaussian_data();
@@ -2065,7 +2078,8 @@ TEST_CASE("[GaussianSplatting][Importer] gsplatworld importer accepts compressed
     const String save_base_path = "user://gsplatworld_importer_compressed";
     const String imported_path = save_base_path + ".gsplatworld";
 
-    Error save_err = ResourceSaver::save(source_world, source_path);
+    ResourceFormatSaverGaussianSplatWorld world_saver;
+    Error save_err = world_saver.save_resident_compressed(source_world, source_path);
     CHECK_MESSAGE(save_err == OK, "Saving compressed gsplatworld source should succeed.");
     if (save_err != OK) {
         ps->set_setting(compression_key, previous_value);
@@ -2083,16 +2097,120 @@ TEST_CASE("[GaussianSplatting][Importer] gsplatworld importer accepts compressed
     Ref<ResourceImporterGSplatWorld> importer;
     importer.instantiate();
     HashMap<StringName, Variant> options;
+    Variant import_metadata_variant;
     Error import_err = importer->import(ResourceUID::INVALID_ID, source_path, save_base_path, options,
-            nullptr, nullptr, nullptr);
+            nullptr, nullptr, &import_metadata_variant);
     CHECK_MESSAGE(import_err == OK, "Importer should accept valid compressed gsplatworld payloads.");
 
     Ref<GaussianSplatWorld> imported_world = ResourceLoader::load(imported_path, "GaussianSplatWorld");
     CHECK_MESSAGE(imported_world.is_valid(), "Imported compressed gsplatworld should be loadable.");
+    CHECK(import_metadata_variant.get_type() == Variant::DICTIONARY);
+    if (import_metadata_variant.get_type() == Variant::DICTIONARY) {
+        Dictionary import_metadata = import_metadata_variant;
+        CHECK(String(import_metadata.get(StringName("payload_mode"), String())) == String("resident_only"));
+        CHECK_FALSE(bool(import_metadata.get(StringName("streamable"), true)));
+        CHECK(bool(import_metadata.get(StringName("compressed"), false)));
+        CHECK(String(import_metadata.get(StringName("resident_only_reason"), String())) ==
+                String("compressed_world_has_no_random_access_chunks"));
+    }
+    if (imported_world.is_valid()) {
+        CHECK(imported_world->has_resident_gaussian_data());
+        CHECK_FALSE(imported_world->has_chunk_payload_source());
+        CHECK(imported_world->get_payload_mode() == String("resident_only"));
+    }
 
     _remove_user_file(source_path);
     _remove_user_file(imported_path);
     ps->set_setting(compression_key, previous_value);
+}
+
+TEST_CASE("[GaussianSplatting][Importer] gsplatworld importer reports resident-uncompressed payloads as non-streamable") {
+	Ref<GaussianData> data;
+	data.instantiate();
+	data->resize(2);
+
+	PackedVector3Array positions;
+	positions.push_back(Vector3(0.0f, 0.0f, 0.0f));
+	positions.push_back(Vector3(1.0f, 0.0f, 0.0f));
+	data->set_positions(positions);
+
+	PackedVector3Array scales;
+	scales.push_back(Vector3(1.0f, 1.0f, 1.0f));
+	scales.push_back(Vector3(1.0f, 1.0f, 1.0f));
+	data->set_scales(scales);
+
+	TypedArray<Quaternion> rotations;
+	rotations.push_back(Quaternion(0.0f, 0.0f, 0.0f, 1.0f));
+	rotations.push_back(Quaternion(0.0f, 0.0f, 0.0f, 1.0f));
+	data->set_rotations(rotations);
+
+	PackedFloat32Array opacities;
+	opacities.push_back(1.0f);
+	opacities.push_back(1.0f);
+	data->set_opacities(opacities);
+
+	PackedFloat32Array sh_dc;
+	sh_dc.push_back(1.0f);
+	sh_dc.push_back(0.0f);
+	sh_dc.push_back(0.0f);
+	sh_dc.push_back(0.0f);
+	sh_dc.push_back(1.0f);
+	sh_dc.push_back(0.0f);
+	data->set_spherical_harmonics(sh_dc);
+
+	Ref<GaussianSplatWorld> source_world;
+	source_world.instantiate();
+	source_world->set_gaussian_data(data);
+	source_world->set_bounds(AABB(Vector3(-1.0f, -1.0f, -1.0f), Vector3(4.0f, 4.0f, 4.0f)));
+
+	const String source_path = "user://gsplatworld_importer_resident_uncompressed_source.gsplatworld";
+	const String save_base_path = "user://gsplatworld_importer_resident_uncompressed";
+	const String imported_path = save_base_path + ".gsplatworld";
+
+	ResourceFormatSaverGaussianSplatWorld world_saver;
+	const Error save_err = world_saver.save_resident_uncompressed(source_world, source_path);
+	CHECK_MESSAGE(save_err == OK, "Saving resident-uncompressed gsplatworld source should succeed.");
+	if (save_err != OK) {
+		return;
+	}
+
+	Ref<FileAccess> source_file = FileAccess::open(source_path, FileAccess::READ);
+	CHECK(source_file.is_valid());
+	if (source_file.is_valid()) {
+		source_file->seek(8); // magic + version
+		const uint32_t flags = source_file->get_32();
+		CHECK_MESSAGE((flags & (1u << 4u)) == 0u, "Resident-uncompressed source must not set compression flag.");
+		CHECK_MESSAGE((flags & (1u << 5u)) != 0u, "Resident-uncompressed source must set resident payload flag.");
+	}
+
+	Ref<ResourceImporterGSplatWorld> importer;
+	importer.instantiate();
+	HashMap<StringName, Variant> options;
+	Variant import_metadata_variant;
+	const Error import_err = importer->import(ResourceUID::INVALID_ID, source_path, save_base_path, options,
+			nullptr, nullptr, &import_metadata_variant);
+	CHECK_MESSAGE(import_err == OK, "Importer should accept valid resident-uncompressed gsplatworld payloads.");
+
+	Ref<GaussianSplatWorld> imported_world = ResourceLoader::load(imported_path, "GaussianSplatWorld");
+	CHECK_MESSAGE(imported_world.is_valid(), "Imported resident-uncompressed gsplatworld should be loadable.");
+	CHECK(import_metadata_variant.get_type() == Variant::DICTIONARY);
+	if (import_metadata_variant.get_type() == Variant::DICTIONARY) {
+		Dictionary import_metadata = import_metadata_variant;
+		CHECK(String(import_metadata.get(StringName("payload_mode"), String())) == String("resident_only"));
+		CHECK_FALSE(bool(import_metadata.get(StringName("streamable"), true)));
+		CHECK_FALSE(bool(import_metadata.get(StringName("compressed"), true)));
+		CHECK(String(import_metadata.get(StringName("resident_only_reason"), String())) ==
+				String("explicit_resident_payload"));
+	}
+	if (imported_world.is_valid()) {
+		CHECK(imported_world->has_resident_gaussian_data());
+		CHECK_FALSE(imported_world->has_chunk_payload_source());
+		CHECK_FALSE(imported_world->is_streamable_payload());
+		CHECK(imported_world->get_payload_mode() == String("resident_only"));
+	}
+
+	_remove_user_file(source_path);
+	_remove_user_file(imported_path);
 }
 
 TEST_CASE("[GaussianSplatting][Importer] GaussianSplatAsset save_to_file rejects empty assets") {

--- a/modules/gaussian_splatting/tests/test_gaussian_splat_world_io.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splat_world_io.h
@@ -115,6 +115,15 @@ void _remove_world_io_fixture(const String &p_path) {
     DirAccess::remove_absolute(p_path);
 }
 
+bool _world_io_file_has_compression_flag(const String &p_path) {
+    Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
+    if (!f.is_valid() || f->get_length() < 12) {
+        return false;
+    }
+    f->seek(8); // magic + version
+    return (f->get_32() & (1u << 4u)) != 0u;
+}
+
 Vector<Gaussian> build_staged_payload_gaussians(uint32_t p_count) {
     Vector<Gaussian> gaussians;
     gaussians.resize(p_count);
@@ -313,10 +322,24 @@ TEST_CASE("[GaussianSplatting][WorldIO] gsplatworld direct format saver/loader")
 
     const String resave_path = _make_world_io_fixture_path("direct_resave");
     const Error resave_err = saver.save(loaded, resave_path);
-    CHECK_MESSAGE(resave_err == OK, "Saving a source-backed gsplatworld should materialize its payload.");
-    CHECK_MESSAGE(loaded->has_resident_gaussian_data(),
-            "Saving should leave the source-backed world with resident GaussianData for load-edit-save workflows.");
+    CHECK_MESSAGE(resave_err == OK, "Saving a source-backed gsplatworld should write a preserved streamable payload.");
+    CHECK_FALSE_MESSAGE(loaded->has_resident_gaussian_data(),
+            "Generic save must not mutate a source-backed world into resident GaussianData.");
+    CHECK(loaded->has_chunk_payload_source());
+    CHECK(loaded->get_payload_mode() == String("streamable_uncompressed"));
     CHECK_MESSAGE(FileAccess::exists(resave_path), "Resaved source-backed gsplatworld should exist.");
+    CHECK_FALSE_MESSAGE(_world_io_file_has_compression_flag(resave_path),
+            "Generic save of a streamable source-backed world must stay uncompressed.");
+    Error resaved_load_err = OK;
+    Ref<Resource> resaved_res = loader.load(resave_path, "", &resaved_load_err);
+    CHECK(resaved_load_err == OK);
+    Ref<GaussianSplatWorld> resaved_world = resaved_res;
+    CHECK(resaved_world.is_valid());
+    if (resaved_world.is_valid()) {
+        CHECK_FALSE(resaved_world->has_resident_gaussian_data());
+        CHECK(resaved_world->has_chunk_payload_source());
+        CHECK(resaved_world->is_streamable_payload());
+    }
     _remove_world_io_fixture(resave_path);
 
     Ref<GaussianSplatWorld> resident_loaded = loader.load_resident(path, &load_err);
@@ -468,7 +491,7 @@ TEST_CASE("[GaussianSplatting][WorldIO] compressed gsplatworld remains resident-
 
     const String path = _make_world_io_fixture_path("compressed_resident");
     ResourceFormatSaverGaussianSplatWorld saver;
-    const Error save_err = saver.save(world, path);
+    const Error save_err = saver.save_resident_compressed(world, path);
     CHECK(save_err == OK);
     if (save_err != OK) {
         return;
@@ -494,6 +517,178 @@ TEST_CASE("[GaussianSplatting][WorldIO] compressed gsplatworld remains resident-
     }
 
     _remove_world_io_fixture(path);
+}
+
+TEST_CASE("[GaussianSplatting][WorldIO] explicit resident-uncompressed save loads resident by default") {
+    Ref<GaussianData> gaussian_data;
+    gaussian_data.instantiate();
+    Vector<Gaussian> gaussians = build_gaussians();
+    gaussian_data->set_gaussians(gaussians);
+
+    Ref<GaussianSplatWorld> source_world;
+    source_world.instantiate();
+    source_world->set_gaussian_data(gaussian_data);
+    source_world->set_bounds(gaussian_data->get_aabb());
+    source_world->set_static_chunks(build_chunks());
+
+    const String streamable_path = _make_world_io_fixture_path("resident_uncompressed_source");
+    const String resident_path = _make_world_io_fixture_path("resident_uncompressed_export");
+    ResourceFormatSaverGaussianSplatWorld saver;
+    REQUIRE(saver.save(source_world, streamable_path) == OK);
+
+    ResourceFormatLoaderGaussianSplatWorld loader;
+    Error load_err = OK;
+    Ref<GaussianSplatWorld> source_backed = loader.load(streamable_path, "", &load_err);
+    REQUIRE(load_err == OK);
+    REQUIRE(source_backed.is_valid());
+    CHECK(source_backed->has_chunk_payload_source());
+    CHECK_FALSE(source_backed->has_resident_gaussian_data());
+
+    REQUIRE(saver.save_resident_uncompressed(source_backed, resident_path) == OK);
+    CHECK_FALSE_MESSAGE(_world_io_file_has_compression_flag(resident_path),
+            "Explicit resident-uncompressed save must remain uncompressed.");
+
+    Ref<GaussianSplatWorld> resident_loaded = loader.load(resident_path, "", &load_err);
+    REQUIRE(load_err == OK);
+    REQUIRE(resident_loaded.is_valid());
+    CHECK(resident_loaded->has_resident_gaussian_data());
+    CHECK_FALSE(resident_loaded->has_chunk_payload_source());
+    CHECK_FALSE(resident_loaded->is_streamable_payload());
+    REQUIRE(resident_loaded->get_gaussian_data().is_valid());
+    CHECK_EQ(resident_loaded->get_gaussian_data()->get_count(), gaussians.size());
+
+    _remove_world_io_fixture(streamable_path);
+    _remove_world_io_fixture(resident_path);
+}
+
+TEST_CASE("[GaussianSplatting][WorldIO] explicit compressed save compresses small resident payloads") {
+    Ref<GaussianData> gaussian_data;
+    gaussian_data.instantiate();
+    Vector<Gaussian> gaussians;
+    gaussians.resize(1);
+    gaussians.write[0] = make_gaussian(Vector3(0.25f, 0.5f, 0.75f), Color(0.25f, 0.5f, 0.75f, 1.0f));
+    gaussian_data->set_gaussians(gaussians);
+
+    Ref<GaussianSplatWorld> world;
+    world.instantiate();
+    world->set_gaussian_data(gaussian_data);
+    world->set_bounds(gaussian_data->get_aabb());
+
+    const String path = _make_world_io_fixture_path("small_explicit_compressed");
+    ResourceFormatSaverGaussianSplatWorld saver;
+    const Error save_err = saver.save_resident_compressed(world, path);
+    CHECK_MESSAGE(save_err == OK, "Explicit resident-compressed save must compress even <=1024-byte payloads.");
+    if (save_err != OK) {
+        _remove_world_io_fixture(path);
+        return;
+    }
+    CHECK_MESSAGE(_world_io_file_has_compression_flag(path),
+            "Explicit resident-compressed small payload save must not silently fall back to uncompressed output.");
+
+    ResourceFormatLoaderGaussianSplatWorld loader;
+    Error load_err = OK;
+    Ref<Resource> loaded_res = loader.load(path, "", &load_err);
+    CHECK(load_err == OK);
+    Ref<GaussianSplatWorld> loaded = loaded_res;
+    CHECK(loaded.is_valid());
+    if (loaded.is_valid()) {
+        CHECK(loaded->has_resident_gaussian_data());
+        CHECK_FALSE(loaded->has_chunk_payload_source());
+        CHECK_EQ(loaded->get_payload_mode(), String("resident_only"));
+        REQUIRE(loaded->get_gaussian_data().is_valid());
+        CHECK_EQ(loaded->get_gaussian_data()->get_count(), 1);
+    }
+
+    _remove_world_io_fixture(path);
+}
+
+TEST_CASE("[GaussianSplatting][WorldIO] explicit compressed save fails when no compressed payload can be produced") {
+    Ref<GaussianData> gaussian_data;
+    gaussian_data.instantiate();
+    gaussian_data->resize(0);
+
+    Ref<GaussianSplatWorld> world;
+    world.instantiate();
+    world->set_gaussian_data(gaussian_data);
+
+    const String path = _make_world_io_fixture_path("empty_explicit_compressed");
+    ResourceFormatSaverGaussianSplatWorld saver;
+    const Error save_err = saver.save_resident_compressed(world, path);
+    CHECK_MESSAGE(save_err != OK,
+            "Explicit resident-compressed save must fail loudly when there is no gaussian payload to compress.");
+    CHECK_FALSE_MESSAGE(FileAccess::exists(path),
+            "Failed explicit resident-compressed save must not leave an uncompressed world file behind.");
+
+    _remove_world_io_fixture(path);
+}
+
+TEST_CASE("[GaussianSplatting][WorldIO] ResourceSaver preserves streamable payload when compression setting is enabled") {
+    GsplatWorldSaverGuard saver_guard;
+    GsplatWorldCompressionSettingGuard compression_guard(true);
+
+    Ref<GaussianData> gaussian_data;
+    gaussian_data.instantiate();
+    Vector<Gaussian> gaussians;
+    gaussians.resize(16);
+    for (int i = 0; i < gaussians.size(); i++) {
+        gaussians.write[i] = make_gaussian(Vector3(float(i), float(i % 4), 0.0f), Color(1.0f, 1.0f, 1.0f, 1.0f));
+    }
+    gaussian_data->set_gaussians(gaussians);
+
+    Ref<GaussianSplatWorld> world;
+    world.instantiate();
+    world->set_gaussian_data(gaussian_data);
+    world->set_bounds(gaussian_data->get_aabb());
+    world->set_static_chunks(build_chunks());
+
+    const String source_path = _make_world_io_fixture_path("resource_saver_source");
+    const String resave_path = _make_world_io_fixture_path("resource_saver_resave");
+    const Error save_err = ResourceSaver::save(world, source_path);
+    CHECK(save_err == OK);
+    CHECK_FALSE_MESSAGE(_world_io_file_has_compression_flag(source_path),
+            "Generic ResourceSaver::save() must not use ambient compression for world files.");
+    if (save_err != OK) {
+        _remove_world_io_fixture(source_path);
+        _remove_world_io_fixture(resave_path);
+        return;
+    }
+
+    Ref<GaussianSplatWorld> loaded = ResourceLoader::load(source_path, "GaussianSplatWorld",
+            ResourceFormatLoader::CACHE_MODE_IGNORE);
+    CHECK(loaded.is_valid());
+    if (!loaded.is_valid()) {
+        _remove_world_io_fixture(source_path);
+        _remove_world_io_fixture(resave_path);
+        return;
+    }
+    CHECK(loaded->is_streamable_payload());
+    CHECK_FALSE(loaded->has_resident_gaussian_data());
+
+    const Error resave_err = ResourceSaver::save(loaded, resave_path);
+    CHECK(resave_err == OK);
+    CHECK_FALSE(loaded->has_resident_gaussian_data());
+    CHECK(loaded->is_streamable_payload());
+    CHECK_FALSE_MESSAGE(_world_io_file_has_compression_flag(resave_path),
+            "Save/load/save of a streamable world must remain uncompressed even when compression is enabled globally.");
+
+    Ref<GaussianSplatWorld> reloaded = ResourceLoader::load(resave_path, "GaussianSplatWorld",
+            ResourceFormatLoader::CACHE_MODE_IGNORE);
+    CHECK(reloaded.is_valid());
+    if (reloaded.is_valid()) {
+        CHECK_FALSE(reloaded->has_resident_gaussian_data());
+        CHECK(reloaded->has_chunk_payload_source());
+        CHECK(reloaded->is_streamable_payload());
+        CHECK(reloaded->get_payload_mode() == String("streamable_uncompressed"));
+    }
+
+    ResourceFormatSaverGaussianSplatWorld explicit_saver;
+    const String compressed_path = _make_world_io_fixture_path("resource_saver_explicit_compressed");
+    CHECK(explicit_saver.save_resident_compressed(world, compressed_path) == OK);
+    CHECK_MESSAGE(_world_io_file_has_compression_flag(compressed_path),
+            "Compressed world export must be explicit resident-only output.");
+    _remove_world_io_fixture(compressed_path);
+    _remove_world_io_fixture(source_path);
+    _remove_world_io_fixture(resave_path);
 }
 
 namespace {

--- a/modules/gaussian_splatting/tests/test_ply_importer.h
+++ b/modules/gaussian_splatting/tests/test_ply_importer.h
@@ -196,6 +196,56 @@ TEST_CASE("[GaussianSplatting][PLYLoader] Cache version mismatch forces re-parse
     DirAccess::remove_absolute(cache_path);
 }
 
+TEST_CASE("[GaussianSplatting][PLYLoader] Cache source path mismatch forces re-parse") {
+    const String ply_path = _make_ply_fixture_path("cache_source_path");
+
+    {
+        Ref<FileAccess> f = FileAccess::open(ply_path, FileAccess::WRITE);
+        REQUIRE_MESSAGE(f.is_valid(), "Should create test PLY file");
+        f->store_string(MINIMAL_PLY_CONTENT);
+        float v0[14] = { 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 0 };
+        f->store_buffer((const uint8_t *)v0, sizeof(v0));
+        float v1[14] = { 1, 0, 0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 0 };
+        f->store_buffer((const uint8_t *)v1, sizeof(v1));
+    }
+
+    {
+        PLYLoader loader;
+        Error err = loader.load_file(ply_path);
+        CHECK_MESSAGE(err == OK, "Initial PLY load should succeed");
+        CHECK(loader.get_splat_count() == 2);
+    }
+
+    const String cache_path = ply_path.get_basename() + ".gsplatcache";
+    if (FileAccess::exists(cache_path)) {
+        ResourceFormatLoaderGaussianSplatWorld format_loader;
+        Error load_err = OK;
+        Ref<GaussianSplatWorld> world = format_loader.load_resident(cache_path, &load_err);
+        REQUIRE_MESSAGE(world.is_valid(), "Cache should be a valid GaussianSplatWorld");
+
+        Dictionary metadata = world->get_metadata();
+        metadata[StringName("cache_source_path")] = ply_path + ".other";
+        world->set_metadata(metadata);
+        ResourceFormatSaverGaussianSplatWorld format_saver;
+        format_saver.save_resident_uncompressed(world, cache_path);
+
+        PLYLoader loader;
+        Error err = loader.load_file(ply_path);
+        CHECK_MESSAGE(err == OK, "PLY load should still succeed (re-parse fallback)");
+        CHECK(loader.get_splat_count() == 2);
+
+        Dictionary stats = loader.get_load_statistics();
+        if (stats.has("cache_hit")) {
+            CHECK_MESSAGE(!(bool)stats["cache_hit"], "Source-path-mismatched cache should not be a cache hit");
+        }
+    } else {
+        MESSAGE("Cache file not created (caching may be disabled); skipping source path guard test");
+    }
+
+    _remove_ply_fixture(ply_path);
+    DirAccess::remove_absolute(cache_path);
+}
+
 TEST_CASE("[GaussianSplatting][PLYLoader] Legacy sibling gsplatworld caches are ignored") {
     const String ply_path = _make_ply_fixture_path("legacy_cache_migration");
 

--- a/modules/gaussian_splatting/tests/test_renderer_pipeline.h
+++ b/modules/gaussian_splatting/tests/test_renderer_pipeline.h
@@ -1086,6 +1086,10 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] Direct gaussian data publishes a res
     CHECK(stats.get("instance_backend_policy", String()) == String("resident"));
     CHECK(stats.get("backend_selection_reason", String()) == String("requested_resident_policy"));
     CHECK(stats.get("backend_selection_reason_label", String()) == String("Resident was requested by the route policy"));
+    CHECK(stats.get("payload_mode", String()) == String("resident_only"));
+    CHECK_FALSE(bool(stats.get("payload_streamable", true)));
+    CHECK_FALSE(bool(stats.get("payload_source_active", true)));
+    CHECK(bool(stats.get("resident_payload_active", false)));
     CHECK(stats.get("instance_contract_shape", String()) == String("atlas_emulation"));
     CHECK(bool(stats.get("instance_contract_ready", false)));
     CHECK(stats.get("data_source", String()) == String(GaussianRenderPipeline::SplatDataSource::kSourceResidentInstance));
@@ -4266,6 +4270,12 @@ TEST_CASE("[GaussianSplatting] file-backed payload forces streaming backend even
 	CHECK_FALSE(backend_plan.prefer_resident_backend);
 	CHECK(backend_plan.should_attempt_streaming_bootstrap);
 	CHECK(backend_plan.streaming_backend_reason == String("file_backed_payload_requires_streaming"));
+
+	Dictionary stats = renderer->get_render_stats();
+	CHECK(String(stats.get(StringName("payload_mode"), String())) == String("streamable_uncompressed"));
+	CHECK(bool(stats.get(StringName("payload_streamable"), false)));
+	CHECK(bool(stats.get(StringName("payload_source_active"), false)));
+	CHECK_FALSE(bool(stats.get(StringName("resident_payload_active"), true)));
 }
 
 TEST_CASE("[GaussianSplatting] get_streaming_route_policy defaults to STREAMING when unset") {


### PR DESCRIPTION
## Summary

Defines the `.gsplatworld` payload-mode contract from #358 so streamable worlds stay streamable by default and resident-only formats are explicit.

Changes:
- Adds `GaussianSplatWorld` payload diagnostics (`payload_mode`, `payload/streamable`, resident-only reason) and render stats fields for payload mode vs route policy.
- Makes generic `ResourceSaver::save()` preserve streamable `.gsplatworld` output by writing uncompressed data and not mutating source-backed worlds into resident `GaussianData`.
- Adds explicit resident compressed/uncompressed save entry points for resident-only exports.
- Records `.gsplatworld` importer payload metadata and validates `.gsplatcache` source path identity.
- Updates docs for uncompressed streamable worlds, compressed resident-only worlds, `.gsplatcache`, direct PLY/SPZ imports, and diagnostics.
- Adds regression coverage for save/load streamability preservation, compressed resident-only import, cache source-path mismatch, and render stats payload fields.

## Validation

- `git diff --check`
- `python3 tests/ci/run_module_tests.py --guard-only --base-ref origin/master`
- Targeted SCons object check for `gaussian_splat_world`, `gaussian_splat_world_io`, `resource_importer_gsplatworld`, `ply_loader`, and `render_diagnostics_orchestrator`
- Targeted SCons object check for `bin/obj/tests/test_main.linuxbsd.editor.dev.x86_64.o`

## Notes

This intentionally does not add random-access compressed `.gsplatworld` streaming. Compressed world payloads remain resident-only until a separate format change adds per-chunk compressed blocks.

Refs #358
