### PR TITLE
Draft: #352 harden GPU lifetime cleanup

### DIFF
--- a/modules/gaussian_splatting/interfaces/painterly_renderer.cpp
+++ b/modules/gaussian_splatting/interfaces/painterly_renderer.cpp
@@ -1613,10 +1613,10 @@ Error PainterlyRenderer::populate_painterly_gbuffer(GaussianSplatRenderer *p_ren
         manager_gaussian_handle = resource_state.buffer_manager->get_gaussian_handle();
         manager_sorted_handle = resource_state.buffer_manager->get_sorted_indices_handle();
         if (manager_gaussian_handle.is_valid()) {
-            p_renderer->track_resource_owner(manager_gaussian_handle.buffer, manager_gaussian_handle.device);
+            p_renderer->track_resource_owner(manager_gaussian_handle.buffer, manager_gaussian_handle.device, false, "painterly_buffer_manager_gaussian");
         }
         if (manager_sorted_handle.is_valid()) {
-            p_renderer->track_resource_owner(manager_sorted_handle.buffer, manager_sorted_handle.device);
+            p_renderer->track_resource_owner(manager_sorted_handle.buffer, manager_sorted_handle.device, false, "painterly_buffer_manager_sorted_indices");
         }
         manager_gaussian_buffer = manager_gaussian_handle.buffer;
         manager_sorted_indices = manager_sorted_handle.buffer;

--- a/modules/gaussian_splatting/interfaces/render_device_manager.cpp
+++ b/modules/gaussian_splatting/interfaces/render_device_manager.cpp
@@ -117,6 +117,12 @@ Error RenderDeviceManager::initialize(RenderingDevice *p_primary_device) {
 }
 
 void RenderDeviceManager::shutdown() {
+	const uint32_t owned_resource_count = get_tracked_owned_resource_count();
+	if (owned_resource_count > 0) {
+		ERR_PRINT(vformat("[RenderDeviceManager] Shutting down with %d tracked owned resources; owners should release RIDs before manager shutdown",
+				owned_resource_count));
+	}
+
 	resource_owner_map.clear();
 	resource_owner_instance_id_map.clear();
 	resource_ownership_map.clear();
@@ -135,6 +141,26 @@ void RenderDeviceManager::shutdown() {
 	local_rd = nullptr;
 	submission_rd = nullptr;
 	owns_local_rd = false;
+}
+
+uint32_t RenderDeviceManager::get_tracked_owned_resource_count() const {
+	uint32_t count = 0;
+	for (const KeyValue<uint64_t, bool> &entry : resource_ownership_map) {
+		if (entry.value && resource_owner_map.has(entry.key)) {
+			count++;
+		}
+	}
+	return count;
+}
+
+uint32_t RenderDeviceManager::get_tracked_borrowed_resource_count() const {
+	uint32_t count = 0;
+	for (const KeyValue<uint64_t, bool> &entry : resource_ownership_map) {
+		if (!entry.value && resource_owner_map.has(entry.key)) {
+			count++;
+		}
+	}
+	return count;
 }
 
 DeviceContext RenderDeviceManager::get_context() const {

--- a/modules/gaussian_splatting/interfaces/render_device_manager.h
+++ b/modules/gaussian_splatting/interfaces/render_device_manager.h
@@ -107,6 +107,8 @@ public:
 
     // Resource statistics (Phase C addition)
     uint32_t get_tracked_resource_count() const { return resource_owner_map.size(); }
+    uint32_t get_tracked_owned_resource_count() const;
+    uint32_t get_tracked_borrowed_resource_count() const;
     uint32_t get_tracked_texture_count() const { return texture_owner_map.size(); }
 
 protected:

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
@@ -1180,6 +1180,8 @@ void GaussianSplatRenderer::_teardown_resources() {
     if (subsystem_state.output_compositor.is_valid()) {
         subsystem_state.output_compositor->clear_cached_framebuffers();
         subsystem_state.output_compositor->clear_viewport_blit_resources();
+        subsystem_state.output_compositor->shutdown();
+        subsystem_state.output_compositor.unref();
     }
     if (shadow_output_compositor.is_valid()) {
         shadow_output_compositor->clear_cached_framebuffers();
@@ -1253,6 +1255,7 @@ void GaussianSplatRenderer::_teardown_resources() {
     if (get_resource_state().buffer_manager.is_valid()) {
         get_resource_state().buffer_manager.unref();
     }
+    get_resource_state().buffer_manager_initialized = false;
 
     if (get_sorting_state().gpu_sorter.is_valid()) {
         get_sorting_state().gpu_sorter->shutdown();

--- a/modules/gaussian_splatting/renderer/gpu_buffer_manager.cpp
+++ b/modules/gaussian_splatting/renderer/gpu_buffer_manager.cpp
@@ -125,20 +125,46 @@ Error GPUBufferManager::_create_buffer_set(BufferSet &r_set, uint32_t p_gaussian
     ERR_FAIL_NULL_V(device, ERR_CANT_CREATE);
 
     Vector<uint8_t> empty_data;
+    r_set.reset();
+    r_set.device = device;
+    auto rollback_set = [&]() {
+        if (r_set.gaussian_buffer.is_valid()) {
+            device->free(r_set.gaussian_buffer);
+        }
+        if (r_set.sort_key_buffer.is_valid()) {
+            device->free(r_set.sort_key_buffer);
+        }
+        if (r_set.sorted_indices_buffer.is_valid()) {
+            device->free(r_set.sorted_indices_buffer);
+        }
+        if (r_set.fence.is_valid()) {
+            device->free(r_set.fence);
+        }
+        r_set.reset();
+    };
 
     empty_data.resize(p_gaussian_size);
     r_set.gaussian_buffer = device->storage_buffer_create(p_gaussian_size, empty_data);
-    ERR_FAIL_COND_V(!r_set.gaussian_buffer.is_valid(), ERR_CANT_CREATE);
+    if (!r_set.gaussian_buffer.is_valid()) {
+        rollback_set();
+        return ERR_CANT_CREATE;
+    }
     device->set_resource_name(r_set.gaussian_buffer, "GS_GPUBufferManager_GaussianBuffer");
 
     empty_data.resize(p_sort_key_size);
     r_set.sort_key_buffer = device->storage_buffer_create(p_sort_key_size, empty_data);
-    ERR_FAIL_COND_V(!r_set.sort_key_buffer.is_valid(), ERR_CANT_CREATE);
+    if (!r_set.sort_key_buffer.is_valid()) {
+        rollback_set();
+        return ERR_CANT_CREATE;
+    }
     device->set_resource_name(r_set.sort_key_buffer, "GS_GPUBufferManager_SortKeyBuffer");
 
     empty_data.resize(p_index_size);
     r_set.sorted_indices_buffer = device->storage_buffer_create(p_index_size, empty_data);
-    ERR_FAIL_COND_V(!r_set.sorted_indices_buffer.is_valid(), ERR_CANT_CREATE);
+    if (!r_set.sorted_indices_buffer.is_valid()) {
+        rollback_set();
+        return ERR_CANT_CREATE;
+    }
     device->set_resource_name(r_set.sorted_indices_buffer, "GS_GPUBufferManager_SortedIndicesBuffer");
 
     r_set.fence = RID();
@@ -152,9 +178,6 @@ Error GPUBufferManager::_create_buffer_set(BufferSet &r_set, uint32_t p_gaussian
     r_set.debug_cpu_writing = false;
     r_set.debug_gpu_reading = false;
 #endif
-
-    r_set.device = device;
-
     return OK;
 }
 
@@ -211,14 +234,25 @@ Error GPUBufferManager::create_buffers() {
 
     Vector<uint8_t> uniform_data;
     uniform_data.resize(uniform_buffer_size);
+    Error uniform_error = OK;
     {
         GaussianSplatManager::ScopedSubmissionLock submission_lock;
         RenderingDevice *device = _acquire_submission_device(rd, submission_lock);
-        ERR_FAIL_NULL_V(device, ERR_CANT_CREATE);
-        uniform_buffer = device->uniform_buffer_create(uniform_buffer_size, uniform_data);
-        ERR_FAIL_COND_V(!uniform_buffer.is_valid(), ERR_CANT_CREATE);
-        device->set_resource_name(uniform_buffer, "GS_GPUBufferManager_UniformBuffer");
-        uniform_buffer_device = device;
+        if (!device) {
+            uniform_error = ERR_CANT_CREATE;
+        } else {
+            uniform_buffer = device->uniform_buffer_create(uniform_buffer_size, uniform_data);
+            if (!uniform_buffer.is_valid()) {
+                uniform_error = ERR_CANT_CREATE;
+            } else {
+                device->set_resource_name(uniform_buffer, "GS_GPUBufferManager_UniformBuffer");
+                uniform_buffer_device = device;
+            }
+        }
+    }
+    if (uniform_error != OK) {
+        cleanup_buffers();
+        return uniform_error;
     }
 
     buffers_created = true;
@@ -228,6 +262,53 @@ Error GPUBufferManager::create_buffers() {
 
     return OK;
 }
+
+bool GPUBufferManager::_has_allocated_resources() const {
+    if (uniform_buffer.is_valid()) {
+        return true;
+    }
+    for (uint32_t i = 0; i < BUFFER_COUNT; i++) {
+        const BufferSet &set = buffer_sets[i];
+        if (set.gaussian_buffer.is_valid() || set.sort_key_buffer.is_valid() ||
+                set.sorted_indices_buffer.is_valid() || set.fence.is_valid()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+#ifdef TESTS_ENABLED
+bool GPUBufferManager::test_simulate_partial_allocation_cleanup(RenderingDevice *p_test_rd) {
+    ERR_FAIL_NULL_V(p_test_rd, false);
+
+    cleanup_buffers();
+    rd = p_test_rd;
+    buffers_created = false;
+
+    Vector<uint8_t> payload;
+    payload.resize(64);
+    BufferSet &set = buffer_sets[0];
+    set.reset();
+    set.device = p_test_rd;
+    set.gaussian_buffer = p_test_rd->storage_buffer_create(payload.size(), payload);
+    ERR_FAIL_COND_V(!set.gaussian_buffer.is_valid(), false);
+    p_test_rd->set_resource_name(set.gaussian_buffer, "GS_GPUBufferManager_TestPartialAllocation");
+
+    RID partial_buffer = set.gaussian_buffer;
+    cleanup_buffers();
+
+    Vector<uint8_t> update_bytes;
+    update_bytes.resize(4);
+    const bool partial_buffer_still_valid =
+            p_test_rd->buffer_update(partial_buffer, 0, update_bytes.size(), update_bytes.ptr()) == OK;
+    if (partial_buffer_still_valid) {
+        p_test_rd->free(partial_buffer);
+        return false;
+    }
+
+    return !_has_allocated_resources();
+}
+#endif
 
 void GPUBufferManager::_mark_buffer_ready(uint32_t p_index) {
     BufferSet &set = _get_buffer_set(p_index);
@@ -375,13 +456,20 @@ bool GPUBufferManager::_begin_frame_internal(bool p_block) {
 }
 
 void GPUBufferManager::cleanup_buffers() {
-    if (!rd || !buffers_created) {
+    if (!_has_allocated_resources()) {
+        buffers_created = false;
         _reset_state(true);
         return;
     }
 
-    _flush_pending_submission(true);
-    gs_device_utils::safe_submit_and_sync(rd);
+    if (rd) {
+        _flush_pending_submission(true);
+        gs_device_utils::safe_submit_and_sync(rd);
+    } else {
+        pending_submission_device = nullptr;
+        pending_submission_needs_submit = false;
+        pending_submission_requires_sync = false;
+    }
 
     for (uint32_t i = 0; i < BUFFER_COUNT; i++) {
         _destroy_buffer_set(buffer_sets[i]);

--- a/modules/gaussian_splatting/renderer/gpu_buffer_manager.h
+++ b/modules/gaussian_splatting/renderer/gpu_buffer_manager.h
@@ -155,6 +155,7 @@ private:
     void cleanup_buffers();
     Error _create_buffer_set(BufferSet &r_set, uint32_t p_gaussian_size, uint32_t p_sort_key_size, uint32_t p_index_size);
     void _destroy_buffer_set(BufferSet &p_set);
+    bool _has_allocated_resources() const;
     void _reset_state(bool p_reset_handles = true);
     BufferSet &_get_buffer_set(uint32_t p_index);
     const BufferSet &_get_buffer_set(uint32_t p_index) const;
@@ -183,6 +184,10 @@ public:
     Error create_buffers_from_data(const Ref<::GaussianData> &p_data);
     bool is_initialized() const { return buffers_created && rd != nullptr; }
     uint32_t get_buffer_capacity() const { return max_gaussians; }
+
+#ifdef TESTS_ENABLED
+    bool test_simulate_partial_allocation_cleanup(RenderingDevice *p_rd);
+#endif
 
     void begin_frame();
     void end_frame();

--- a/modules/gaussian_splatting/renderer/render_resource_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_resource_orchestrator.cpp
@@ -169,6 +169,7 @@ void RenderResourceOrchestrator::create_gpu_resources_safe() {
 		if (err == OK) {
 			resource_state.buffer_manager_initialized = true;
 		} else {
+			resource_state.buffer_manager_initialized = false;
 			GS_LOG_GPU_MEMORY_WARN("[GPU Buffer] Failed to initialize GPU buffer manager: " + itos(err));
 			buffer_manager_ready = false;
 		}
@@ -179,6 +180,7 @@ void RenderResourceOrchestrator::create_gpu_resources_safe() {
 		if (!test_buffer.is_valid()) {
 			GS_LOG_WARN_DEFAULT("[GPU Buffer] GPU buffer manager initialized without a readable buffer RID");
 			buffer_manager_ready = false;
+			resource_state.buffer_manager_initialized = false;
 		}
 	}
 
@@ -272,6 +274,9 @@ void RenderResourceOrchestrator::create_gpu_resources_safe() {
 			vertex[9] = local_test_data_state.scales[i].z;
 		}
 
+		if (local_test_data_state.vertex_buffer.is_valid()) {
+			(renderer->*runtime_ports.free_owned_resource)(device_state->rd, local_test_data_state.vertex_buffer);
+		}
 		local_test_data_state.vertex_buffer = device_state->rd->vertex_buffer_create(vertex_data.size(), vertex_data);
 		if (local_test_data_state.vertex_buffer.is_valid()) {
 			device_state->rd->set_resource_name(local_test_data_state.vertex_buffer, "GS_RenderResourceOrchestrator_VertexBuffer");

--- a/modules/gaussian_splatting/tests/test_gaussian_splatting.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splatting.h
@@ -18,6 +18,7 @@
 #include "test_data_authority_hardening.h"
 #include "test_gpu_streaming.h"
 #include "test_gpu_sorting.h"
+#include "test_gpu_buffer_manager_lifetime.h"
 #include "test_asset_dependency_manager.h"
 #include "test_batched_async_readback.h"
 #include "test_render_device_manager_ownership.h"

--- a/modules/gaussian_splatting/tests/test_gpu_buffer_manager_lifetime.h
+++ b/modules/gaussian_splatting/tests/test_gpu_buffer_manager_lifetime.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "test_macros.h"
+
+#include "../renderer/gpu_buffer_manager.h"
+
+#include "servers/rendering/rendering_device.h"
+#include "servers/rendering_server.h"
+
+#ifdef TESTS_ENABLED
+
+namespace TestGaussianSplatting {
+
+TEST_CASE("[GaussianSplatting][RequiresGPU] GPUBufferManager cleanup frees partial allocations before buffers_created") {
+	RenderingServer *rs = RenderingServer::get_singleton();
+	if (!rs) {
+		return; // Skip in headless test mode (tag: [RequiresGPU])
+	}
+
+	RenderingDevice *rd = rs->create_local_rendering_device();
+	bool owns_rd = true;
+	if (!rd) {
+		rd = rs->get_rendering_device();
+		owns_rd = false;
+	}
+	if (!rd) {
+		return; // Skip in headless test mode (tag: [RequiresGPU])
+	}
+
+	Ref<GPUBufferManager> buffer_manager;
+	buffer_manager.instantiate();
+
+	CHECK(buffer_manager->test_simulate_partial_allocation_cleanup(rd));
+
+	if (owns_rd) {
+		memdelete(rd);
+	}
+}
+
+} // namespace TestGaussianSplatting
+
+#endif // TESTS_ENABLED

--- a/modules/gaussian_splatting/tests/test_render_device_manager_ownership.h
+++ b/modules/gaussian_splatting/tests/test_render_device_manager_ownership.h
@@ -224,6 +224,133 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] RenderDeviceManager keeps owned RID 
     }
 }
 
+TEST_CASE("[GaussianSplatting][RequiresGPU] RenderDeviceManager exposes owned and borrowed resource counts") {
+	RenderingServer *rs = RenderingServer::get_singleton();
+	if (!rs) {
+		return; // Skip in headless test mode (tag: [RequiresGPU])
+	}
+
+	RenderingDevice *rd = _create_local_test_device();
+	bool owns_rd = true;
+	if (!rd) {
+		rd = rs->get_rendering_device();
+		owns_rd = false;
+	}
+	if (!rd) {
+		return; // Skip in headless test mode (tag: [RequiresGPU])
+	}
+
+	Ref<RenderDeviceManager> manager;
+	manager.instantiate();
+	Error init_err = manager->initialize(rd);
+	CHECK(init_err == OK);
+	if (init_err != OK) {
+		if (owns_rd) {
+			memdelete(rd);
+		}
+		return;
+	}
+
+	RID owned_buffer = rd->storage_buffer_create(64);
+	RID borrowed_buffer = rd->storage_buffer_create(64);
+	CHECK(owned_buffer.is_valid());
+	CHECK(borrowed_buffer.is_valid());
+	if (!owned_buffer.is_valid() || !borrowed_buffer.is_valid()) {
+		if (owned_buffer.is_valid()) {
+			rd->free(owned_buffer);
+		}
+		if (borrowed_buffer.is_valid()) {
+			rd->free(borrowed_buffer);
+		}
+		manager->shutdown();
+		if (owns_rd) {
+			memdelete(rd);
+		}
+		return;
+	}
+
+	manager->track_resource(owned_buffer, rd, true, "owned_count_test");
+	manager->track_resource(borrowed_buffer, rd, false, "borrowed_count_test");
+
+	CHECK(manager->get_tracked_resource_count() == 2);
+	CHECK(manager->get_tracked_owned_resource_count() == 1);
+	CHECK(manager->get_tracked_borrowed_resource_count() == 1);
+
+	RID managed_owned = owned_buffer;
+	manager->free_owned_resource(rd, managed_owned);
+	CHECK_FALSE(managed_owned.is_valid());
+	CHECK(manager->get_tracked_resource_count() == 1);
+	CHECK(manager->get_tracked_owned_resource_count() == 0);
+	CHECK(manager->get_tracked_borrowed_resource_count() == 1);
+
+	manager->forget_resource(borrowed_buffer);
+	rd->free(borrowed_buffer);
+
+	CHECK(manager->get_tracked_resource_count() == 0);
+	CHECK(manager->get_tracked_owned_resource_count() == 0);
+	CHECK(manager->get_tracked_borrowed_resource_count() == 0);
+
+	manager->shutdown();
+	if (owns_rd) {
+		memdelete(rd);
+	}
+}
+
+TEST_CASE("[GaussianSplatting][RequiresGPU] RenderDeviceManager shutdown clears stale ownership state") {
+	RenderingServer *rs = RenderingServer::get_singleton();
+	if (!rs) {
+		return; // Skip in headless test mode (tag: [RequiresGPU])
+	}
+
+	RenderingDevice *rd = _create_local_test_device();
+	bool owns_rd = true;
+	if (!rd) {
+		rd = rs->get_rendering_device();
+		owns_rd = false;
+	}
+	if (!rd) {
+		return; // Skip in headless test mode (tag: [RequiresGPU])
+	}
+
+	Ref<RenderDeviceManager> manager;
+	manager.instantiate();
+	Error init_err = manager->initialize(rd);
+	CHECK(init_err == OK);
+	if (init_err != OK) {
+		if (owns_rd) {
+			memdelete(rd);
+		}
+		return;
+	}
+
+	RID owned_buffer = rd->storage_buffer_create(64);
+	CHECK(owned_buffer.is_valid());
+	if (!owned_buffer.is_valid()) {
+		manager->shutdown();
+		if (owns_rd) {
+			memdelete(rd);
+		}
+		return;
+	}
+
+	manager->track_resource(owned_buffer, rd, true, "shutdown_stale_owned_test");
+	CHECK(manager->get_tracked_resource_count() == 1);
+	CHECK(manager->get_tracked_owned_resource_count() == 1);
+
+	manager->shutdown();
+
+	CHECK(manager->get_tracked_resource_count() == 0);
+	CHECK(manager->get_tracked_owned_resource_count() == 0);
+	CHECK(manager->get_context().main_device == nullptr);
+	CHECK(manager->get_context().resource_device == nullptr);
+	CHECK(manager->get_context().submission_device == nullptr);
+
+	rd->free(owned_buffer);
+	if (owns_rd) {
+		memdelete(rd);
+	}
+}
+
 TEST_CASE("[GaussianSplatting][RequiresGPU] RenderDeviceManager diagnostics use stable device instance IDs") {
     RenderingDevice *source_rd = _create_local_test_device();
     RenderingDevice *target_rd = _create_local_test_device();


### PR DESCRIPTION
## Summary

Refs #352.

This is the first GPU lifetime hardening slice for the audit P0. It focuses on deterministic cleanup and accounting, not allocator redesign.

Changes:
- Add owned vs borrowed tracked-resource counters to `RenderDeviceManager`, and warn if shutdown clears still-owned resources.
- Make `GPUBufferManager` rollback partially-created buffer sets and uniform-buffer failures instead of resetting handles while RIDs can still be live.
- Ensure `GPUBufferManager::cleanup_buffers()` frees any allocated handles even when `buffers_created` is false, covering failed init paths.
- Explicitly `shutdown()` and unref the main `OutputCompositor` during renderer teardown, matching the shadow compositor path.
- Reset `buffer_manager_initialized` during teardown and failed/invalid initialization.
- Free the test vertex buffer before replacement, matching the structured buffer replacement pattern.
- Add GPU ownership-count regression coverage for owned vs borrowed tracked resources.

## Render Engine Goal

GodotGS should be a production-ready Gaussian splat render engine with deterministic GPU resource ownership, explicit lifetime boundaries, stable teardown during editor/runtime reloads, and proof-oriented cleanup gates. This PR moves the renderer closer to that by making ownership visible and by closing confirmed partial-allocation and stale-state cleanup holes.

## Validation

- `python3 tests/ci/run_module_tests.py --guard-only --base-ref origin/master`
- `git diff --check`
- `scons platform=linuxbsd target=editor dev_build=yes tests=yes module_gaussian_splatting_enabled=yes -j4 bin/obj/modules/gaussian_splatting/interfaces/render_device_manager.linuxbsd.editor.dev.x86_64.o bin/obj/modules/gaussian_splatting/renderer/gpu_buffer_manager.linuxbsd.editor.dev.x86_64.o bin/obj/modules/gaussian_splatting/renderer/gaussian_splat_renderer.linuxbsd.editor.dev.x86_64.o bin/obj/modules/gaussian_splatting/renderer/render_resource_orchestrator.linuxbsd.editor.dev.x86_64.o bin/obj/tests/test_main.linuxbsd.editor.dev.x86_64.o`

## Notes

This does not close all of #352. Remaining work should add broader same-process renderer/compositor lifecycle gates and GPU leak proof for scene reload and failed init surfaces.
