### PR TITLE
[codex] Calibrate streaming GPU budget gate

### DIFF
--- a/tests/runtime/run_runtime_validation.py
+++ b/tests/runtime/run_runtime_validation.py
@@ -84,6 +84,7 @@ GDS_TESTS: Dict[str, Path] = {
     "Scene Effector Runtime Controls": RUNTIME_DIR / "test_scene_effector_runtime_controls.gd",
     "World Streaming Gate": RUNTIME_DIR / "test_world_streaming_gate.gd",
     "Streaming Residency API": RUNTIME_DIR / "test_streaming_residency_api.gd",
+    "Streaming GPU Tier Budget Contract": RUNTIME_DIR / "test_streaming_gpu_tier_budget_contract.gd",
     "Data Flow Recent Window": RUNTIME_DIR / "test_data_flow_recent_window.gd",
     "Pipeline Trace Freshness": RUNTIME_DIR / "test_pipeline_trace_freshness.gd",
     "Monitor Lifecycle Hardening": RUNTIME_DIR / "test_monitor_lifecycle_hardening.gd",

--- a/tests/runtime/runtime_scenarios.json
+++ b/tests/runtime/runtime_scenarios.json
@@ -10,6 +10,7 @@
         "Animation Persistence"
       ],
       "gd_tests": [
+        "Streaming GPU Tier Budget Contract",
         "Streaming Residency API",
         "Monitor Lifecycle Hardening"
       ],

--- a/tests/runtime/streaming_gpu_tier_budget.gd
+++ b/tests/runtime/streaming_gpu_tier_budget.gd
@@ -1,0 +1,83 @@
+extends RefCounted
+
+# Shared runtime budget contract for the streaming GPU stress gate.
+# Sort-evidence checks intentionally stay in test_gpu_streaming_stress.gd's
+# GPU-backed _validate_sort_metrics() path; this helper only owns the tier
+# budget and telemetry invariants evaluated from already-collected metrics.
+
+static func tier_1m_budget() -> Dictionary:
+	return {
+		"name": "tier_1m",
+		"size": 1000000,
+		"max_first_visible_ms": 3500.0,
+		"min_residency_ratio": 0.75,
+		# Runner-specific end-to-end guardrail, not a renderer product target.
+		# Current clean Windows Vulkan evidence has tier_1m p95 at 236.772 ms
+		# (PR #361 run 26112198038), 240.731 ms (master run 26095036307),
+		# 292.4 ms (checked-in report), and 304.903 ms (PR #351 run
+		# 26112075257) with residency=1.0, fallback_rate=0.0, and telemetry
+		# present. 325 ms stays above that current self-hosted runner envelope
+		# while preserving a hard ceiling for gross regressions. Tighten this in
+		# a dedicated calibration PR after several clean master runs establish a
+		# lower stable envelope.
+		"max_frame_p95_ms": 325.0,
+		"max_frame_p95_to_avg_ratio": 2.25,
+		"max_fallback_rate": 0.35,
+		"enforce": true
+	}
+
+
+static func evaluate_tier_budget(tier: Dictionary, tier_result: Dictionary, residency: Dictionary) -> Dictionary:
+	var budget_failures: Array[String] = []
+	var telemetry_failures: Array[String] = []
+	var within_budget := true
+
+	var first_visible_ms := float(tier_result.get("first_visible_ms", -1.0))
+	var residency_ratio := float(residency.get("residency_ratio", 0.0))
+	var frame_p95_ms := float(tier_result.get("frame_p95_ms", 0.0))
+	var frame_p95_to_avg_ratio := float(tier_result.get("frame_p95_to_avg_ratio", 0.0))
+	var source_data_available := bool(tier_result.get("source_data_available", false))
+	var fallback_rate_available := bool(tier_result.get("fallback_rate_available", false))
+	var fallback_rate: Variant = tier_result.get("fallback_rate", null)
+
+	var max_first_visible_ms := float(tier.get("max_first_visible_ms", 0.0))
+	if first_visible_ms < 0.0:
+		within_budget = false
+		budget_failures.append("first_visible_missing")
+	elif max_first_visible_ms > 0.0 and first_visible_ms > max_first_visible_ms:
+		within_budget = false
+		budget_failures.append("first_visible_exceeded")
+
+	var min_residency_ratio := float(tier.get("min_residency_ratio", 0.0))
+	if residency_ratio < min_residency_ratio:
+		within_budget = false
+		budget_failures.append("residency_ratio_low")
+
+	var max_frame_p95_ms := float(tier.get("max_frame_p95_ms", 0.0))
+	if max_frame_p95_ms > 0.0 and frame_p95_ms > max_frame_p95_ms:
+		within_budget = false
+		budget_failures.append("frame_p95_exceeded")
+	var max_frame_p95_to_avg_ratio := float(tier.get("max_frame_p95_to_avg_ratio", 0.0))
+	if max_frame_p95_to_avg_ratio > 0.0 and frame_p95_to_avg_ratio > max_frame_p95_to_avg_ratio:
+		within_budget = false
+		budget_failures.append("frame_p95_to_avg_ratio_high")
+
+	var max_fallback_rate := float(tier.get("max_fallback_rate", 1.0))
+	if not source_data_available:
+		within_budget = false
+		telemetry_failures.append("fallback_source_data_missing")
+	elif not fallback_rate_available:
+		within_budget = false
+		telemetry_failures.append("fallback_rate_missing")
+	elif fallback_rate == null:
+		within_budget = false
+		telemetry_failures.append("fallback_rate_missing")
+	elif float(fallback_rate) > max_fallback_rate:
+		within_budget = false
+		budget_failures.append("fallback_rate_high")
+
+	return {
+		"within_budget": within_budget,
+		"budget_failures": budget_failures,
+		"telemetry_failures": telemetry_failures
+	}

--- a/tests/runtime/test_gpu_streaming_stress.gd
+++ b/tests/runtime/test_gpu_streaming_stress.gd
@@ -3,50 +3,7 @@ extends SceneTree
 # Runtime large-tier stress probe for the large-world proof ladder. Exercises
 # the radix path and validates that performance counters are being populated.
 
-const STREAM_TIERS := [
-    {
-        "name": "tier_250k",
-        "size": 250000,
-        "max_first_visible_ms": 2500.0,
-        "min_residency_ratio": 0.70,
-        "max_frame_p95_ms": 90.0,
-        "max_frame_p95_to_avg_ratio": 2.25,
-        "max_fallback_rate": 0.40,
-        "enforce": false
-    },
-    {
-        "name": "tier_1m",
-        "size": 1000000,
-        "max_first_visible_ms": 3500.0,
-        "min_residency_ratio": 0.75,
-        # Recalibrated after the shared-renderer teardown race (PR #282) and
-        # the instance-grading RID pass-through (PR #283) made tier_1m
-        # actually run to completion. The prior 120 ms budget was set before
-        # any clean run existed — the lifecycle and grading bugs caused tier_1m
-        # to bail on stale state before its real frame timing could be
-        # measured. First measurements from a healthy pipeline:
-        #   - self-hosted Windows CI, post-grading-fix: 163.5 ms p95
-        #   - local dev (RTX-class):                    155–168 ms p95
-        # 200 ms leaves ~22 % noise margin above the CI reading without making
-        # the gate meaningless. Narrow the budget downward in a dedicated perf
-        # pass once there is a multi-run baseline to argue from; do not treat
-        # this value as a performance target in its own right.
-        "max_frame_p95_ms": 200.0,
-        "max_frame_p95_to_avg_ratio": 2.25,
-        "max_fallback_rate": 0.35,
-        "enforce": true
-    },
-    {
-        "name": "tier_2_5m",
-        "size": 2500000,
-        "max_first_visible_ms": 5000.0,
-        "min_residency_ratio": 0.75,
-        "max_frame_p95_ms": 160.0,
-        "max_frame_p95_to_avg_ratio": 2.50,
-        "max_fallback_rate": 0.35,
-        "enforce": false
-    }
-]
+const StreamingGpuTierBudget = preload("streaming_gpu_tier_budget.gd")
 const BASELINE_TIER_NAME := "tier_1m"
 const SORT_METHOD_NAME := "GPU_RADIX"
 const TARGET_SORT_MS := 2.5
@@ -80,6 +37,31 @@ func _init() -> void:
 func _is_headless_runtime() -> bool:
     return OS.has_feature("headless") or DisplayServer.get_name() == "headless"
 
+func _stream_tiers() -> Array:
+    return [
+        {
+            "name": "tier_250k",
+            "size": 250000,
+            "max_first_visible_ms": 2500.0,
+            "min_residency_ratio": 0.70,
+            "max_frame_p95_ms": 90.0,
+            "max_frame_p95_to_avg_ratio": 2.25,
+            "max_fallback_rate": 0.40,
+            "enforce": false
+        },
+        StreamingGpuTierBudget.tier_1m_budget(),
+        {
+            "name": "tier_2_5m",
+            "size": 2500000,
+            "max_first_visible_ms": 5000.0,
+            "min_residency_ratio": 0.75,
+            "max_frame_p95_ms": 160.0,
+            "max_frame_p95_to_avg_ratio": 2.50,
+            "max_fallback_rate": 0.35,
+            "enforce": false
+        }
+    ]
+
 ## Initializes the renderer and exercises streaming datasets.
 func _run() -> void:
     if _is_headless_runtime():
@@ -104,7 +86,7 @@ func _run() -> void:
 
     var tier_results: Array = []
     var baseline_found := false
-    for tier in STREAM_TIERS:
+    for tier in _stream_tiers():
         var tier_result := await _exercise_tier(tier)
         tier_results.append(tier_result)
         if String(tier_result.get("name", "")) == BASELINE_TIER_NAME:
@@ -221,61 +203,6 @@ func _evaluate_sort_evidence(stats: Dictionary, history: Array) -> Dictionary:
             "gpu_sorter_total_sorts": total_sorts,
             "history_entries": history_entries
         }
-    }
-
-func _evaluate_tier_budget(tier: Dictionary, tier_result: Dictionary, residency: Dictionary) -> Dictionary:
-    var budget_failures: Array[String] = []
-    var telemetry_failures: Array[String] = []
-    var within_budget := true
-
-    var first_visible_ms := float(tier_result.get("first_visible_ms", -1.0))
-    var residency_ratio := float(residency.get("residency_ratio", 0.0))
-    var frame_p95_ms := float(tier_result.get("frame_p95_ms", 0.0))
-    var frame_p95_to_avg_ratio := float(tier_result.get("frame_p95_to_avg_ratio", 0.0))
-    var source_data_available := bool(tier_result.get("source_data_available", false))
-    var fallback_rate_available := bool(tier_result.get("fallback_rate_available", false))
-    var fallback_rate: Variant = tier_result.get("fallback_rate", null)
-
-    var max_first_visible_ms := float(tier.get("max_first_visible_ms", 0.0))
-    if first_visible_ms < 0.0:
-        within_budget = false
-        budget_failures.append("first_visible_missing")
-    elif max_first_visible_ms > 0.0 and first_visible_ms > max_first_visible_ms:
-        within_budget = false
-        budget_failures.append("first_visible_exceeded")
-
-    var min_residency_ratio := float(tier.get("min_residency_ratio", 0.0))
-    if residency_ratio < min_residency_ratio:
-        within_budget = false
-        budget_failures.append("residency_ratio_low")
-
-    var max_frame_p95_ms := float(tier.get("max_frame_p95_ms", 0.0))
-    if max_frame_p95_ms > 0.0 and frame_p95_ms > max_frame_p95_ms:
-        within_budget = false
-        budget_failures.append("frame_p95_exceeded")
-    var max_frame_p95_to_avg_ratio := float(tier.get("max_frame_p95_to_avg_ratio", 0.0))
-    if max_frame_p95_to_avg_ratio > 0.0 and frame_p95_to_avg_ratio > max_frame_p95_to_avg_ratio:
-        within_budget = false
-        budget_failures.append("frame_p95_to_avg_ratio_high")
-
-    var max_fallback_rate := float(tier.get("max_fallback_rate", 1.0))
-    if not source_data_available:
-        within_budget = false
-        telemetry_failures.append("fallback_source_data_missing")
-    elif not fallback_rate_available:
-        within_budget = false
-        telemetry_failures.append("fallback_rate_missing")
-    elif fallback_rate == null:
-        within_budget = false
-        telemetry_failures.append("fallback_rate_missing")
-    elif float(fallback_rate) > max_fallback_rate:
-        within_budget = false
-        budget_failures.append("fallback_rate_high")
-
-    return {
-        "within_budget": within_budget,
-        "budget_failures": budget_failures,
-        "telemetry_failures": telemetry_failures
     }
 
 ## Runs a streaming and sorting pass for a configured tier.
@@ -522,7 +449,7 @@ func _exercise_tier(tier: Dictionary) -> Dictionary:
 
     _validate_sort_metrics(SORT_METHOD_NAME, size, stats, sort_history)
     var residency := _validate_residency(size, stats)
-    var budget_eval := _evaluate_tier_budget(tier, {
+    var budget_eval := StreamingGpuTierBudget.evaluate_tier_budget(tier, {
         "first_visible_ms": first_visible_ms,
         "frame_p95_ms": frame_p95_ms,
         "frame_p95_to_avg_ratio": frame_p95_to_avg_ratio,

--- a/tests/runtime/test_streaming_gpu_tier_budget_contract.gd
+++ b/tests/runtime/test_streaming_gpu_tier_budget_contract.gd
@@ -1,0 +1,176 @@
+extends SceneTree
+
+const FAIL_MARKER := "[RUNTIME_FAIL]"
+const METRICS_MARKER := "[RUNTIME_METRICS]"
+const StreamingGpuTierBudget = preload("streaming_gpu_tier_budget.gd")
+
+var failures: Array[String] = []
+
+
+func _init() -> void:
+	call_deferred("_run")
+
+
+func _record_failure(reason: String, context: Dictionary = {}) -> void:
+	var message := reason
+	if not context.is_empty():
+		message = "%s | context=%s" % [reason, str(context)]
+	failures.append(message)
+	push_error("%s %s" % [FAIL_MARKER, message])
+
+
+func _base_tier_result() -> Dictionary:
+	return {
+		"first_visible_ms": 240.0,
+		"frame_p95_ms": 292.4,
+		"frame_p95_to_avg_ratio": 1.24,
+		"source_data_available": true,
+		"fallback_rate_available": true,
+		"fallback_rate": 0.0,
+		"source_frame_count": 120
+	}
+
+
+func _base_residency() -> Dictionary:
+	return {
+		"residency_ratio": 1.0
+	}
+
+
+func _merge(base: Dictionary, overrides: Dictionary) -> Dictionary:
+	var merged := base.duplicate(true)
+	for key in overrides.keys():
+		merged[key] = overrides[key]
+	return merged
+
+
+func _array_equals(actual: Array, expected: Array) -> bool:
+	if actual.size() != expected.size():
+		return false
+	for index in range(actual.size()):
+		if String(actual[index]) != String(expected[index]):
+			return false
+	return true
+
+
+func _run_case(test_case: Dictionary) -> void:
+	var tier := StreamingGpuTierBudget.tier_1m_budget()
+	tier = _merge(tier, test_case.get("tier_overrides", {}))
+	var tier_result := _merge(_base_tier_result(), test_case.get("result_overrides", {}))
+	var residency := _merge(_base_residency(), test_case.get("residency_overrides", {}))
+
+	var evaluation := StreamingGpuTierBudget.evaluate_tier_budget(tier, tier_result, residency)
+	var expected_within := bool(test_case.get("within_budget", false))
+	var actual_within := bool(evaluation.get("within_budget", false))
+	if actual_within != expected_within:
+		_record_failure("Budget contract within_budget mismatch", {
+			"case": test_case.get("name", "<unnamed>"),
+			"expected": expected_within,
+			"actual": actual_within,
+			"evaluation": evaluation
+		})
+
+	var expected_budget_failures: Array = test_case.get("budget_failures", [])
+	var actual_budget_failures: Array = evaluation.get("budget_failures", [])
+	if not _array_equals(actual_budget_failures, expected_budget_failures):
+		_record_failure("Budget contract budget_failures mismatch", {
+			"case": test_case.get("name", "<unnamed>"),
+			"expected": expected_budget_failures,
+			"actual": actual_budget_failures,
+			"evaluation": evaluation
+		})
+
+	var expected_telemetry_failures: Array = test_case.get("telemetry_failures", [])
+	var actual_telemetry_failures: Array = evaluation.get("telemetry_failures", [])
+	if not _array_equals(actual_telemetry_failures, expected_telemetry_failures):
+		_record_failure("Budget contract telemetry_failures mismatch", {
+			"case": test_case.get("name", "<unnamed>"),
+			"expected": expected_telemetry_failures,
+			"actual": actual_telemetry_failures,
+			"evaluation": evaluation
+		})
+
+
+func _run() -> void:
+	var cases := [
+		{
+			"name": "clean_current_result",
+			"within_budget": true,
+			"budget_failures": [],
+			"telemetry_failures": []
+		},
+		{
+			"name": "frame_p95_exceeded",
+			"result_overrides": {"frame_p95_ms": 325.001},
+			"within_budget": false,
+			"budget_failures": ["frame_p95_exceeded"],
+			"telemetry_failures": []
+		},
+		{
+			"name": "frame_p95_to_avg_ratio_high",
+			"result_overrides": {"frame_p95_to_avg_ratio": 2.251},
+			"within_budget": false,
+			"budget_failures": ["frame_p95_to_avg_ratio_high"],
+			"telemetry_failures": []
+		},
+		{
+			"name": "first_visible_missing",
+			"result_overrides": {"first_visible_ms": -1.0},
+			"within_budget": false,
+			"budget_failures": ["first_visible_missing"],
+			"telemetry_failures": []
+		},
+		{
+			"name": "first_visible_exceeded",
+			"result_overrides": {"first_visible_ms": 3500.001},
+			"within_budget": false,
+			"budget_failures": ["first_visible_exceeded"],
+			"telemetry_failures": []
+		},
+		{
+			"name": "fallback_source_data_missing",
+			"result_overrides": {"source_data_available": false},
+			"within_budget": false,
+			"budget_failures": [],
+			"telemetry_failures": ["fallback_source_data_missing"]
+		},
+		{
+			"name": "fallback_rate_missing_flag",
+			"result_overrides": {"fallback_rate_available": false, "fallback_rate": null},
+			"within_budget": false,
+			"budget_failures": [],
+			"telemetry_failures": ["fallback_rate_missing"]
+		},
+		{
+			"name": "fallback_rate_high",
+			"result_overrides": {"fallback_rate": 0.3501},
+			"within_budget": false,
+			"budget_failures": ["fallback_rate_high"],
+			"telemetry_failures": []
+		},
+		{
+			"name": "residency_ratio_low",
+			"residency_overrides": {"residency_ratio": 0.749},
+			"within_budget": false,
+			"budget_failures": ["residency_ratio_low"],
+			"telemetry_failures": []
+		}
+	]
+
+	for test_case in cases:
+		_run_case(test_case)
+
+	var summary := {
+		"status": "passed" if failures.is_empty() else "failed",
+		"cases": cases.size(),
+		"failures": failures,
+		"tier_1m_max_frame_p95_ms": float(StreamingGpuTierBudget.tier_1m_budget().get("max_frame_p95_ms", 0.0)),
+		"sort_evidence_contract": "covered_by_gpu_streaming_stress_validate_sort_metrics"
+	}
+	print("%s %s" % [METRICS_MARKER, JSON.stringify(summary)])
+
+	if failures.is_empty():
+		print("GPU streaming tier budget contract checks passed.")
+		quit(0)
+	else:
+		quit(1)


### PR DESCRIPTION
## Summary

- Recalibrates the enforced tier_1m streaming GPU p95 budget to 325 ms as a runner-specific end-to-end guardrail, with the current Windows Vulkan evidence captured in the shared budget helper.
- Factors tier budget evaluation into a shared headless-safe GDScript helper used by the GPU stress script and the new contract test.
- Adds the named Streaming GPU Tier Budget Contract runtime test to headless-ci with synthetic coverage for p95, ratio, first-visible, source/fallback telemetry, fallback rate, residency, and the clean 292.4 ms baseline shape.

Sort evidence remains covered by the GPU stress script via _validate_sort_metrics(); the budget helper intentionally does not claim that contract.

Fixes #367

## Validation

- git diff --check
- python3 tests/runtime/run_runtime_validation.py --godot-binary /mnt/c/projects/godotgs-clean/bin/godot.linuxbsd.editor.x86_64 --profile headless-ci --skip-cpp --gd-test "Streaming GPU Tier Budget Contract" --report-path tests/runtime/build/streaming_gpu_tier_budget_contract_report.json
- python3 tests/runtime/run_runtime_validation.py --godot-binary /mnt/c/projects/godotgs-clean/bin/godot.linuxbsd.editor.x86_64 --profile headless-ci --skip-cpp --report-path tests/runtime/build/headless_ci_report.json
- /mnt/c/projects/godotgs-clean/bin/godot.linuxbsd.editor.x86_64 --headless --verbose --script tests/runtime/test_gpu_streaming_stress.gd (syntax/load check; expected headless skip)
- python3 tests/ci/run_module_tests.py --guard-only --base-ref origin/master

## Notes

- tests/runtime/runtime_validation_report.json was left untouched because this was not regenerated from a real Windows Vulkan run.
