### PR TITLE
[codex] Refresh renderer ownership W0 contracts

### DIFF
--- a/docs/architecture/gaussian-renderer-refactor-memory.md
+++ b/docs/architecture/gaussian-renderer-refactor-memory.md
@@ -8,6 +8,52 @@ This document is the implementation memory for the staged Gaussian Splatting ren
 
 This is not a rewrite plan. It is a migration plan that preserves shipping behavior and keeps `GaussianSplatRenderer` as the public facade.
 
+## W0 Ownership Refresh For Issue #356
+
+Date: 2026-05-20
+Branch context: `codex/ownership-w0-356` from `origin/master` at `d89bdd5d42`
+
+This W0 slice refreshed the ownership inventory before any route-controller
+extraction. The live tree has already completed several older inventory items:
+
+- Render-thread synchronization state is owned by `RenderThreadDispatcher`
+  behind `IRenderThreadDispatcher`; `GaussianSplatRenderer` delegates dispatch
+  and completion calls.
+- `GPUSortingPipeline` has the `ISortResultSink` and
+  `ISortBufferHostContext` seam, and `ensure_sort_buffers()` uses the host
+  context instead of accepting a renderer pointer.
+- `TileRenderer` owns `subgroup_support_cache` and
+  `adaptive_overlap_budget_runtime_state` as members; the old process-global
+  tile cache cleanup should not be reimplemented.
+
+Still coupled after this W0 slice:
+
+- `render_scene_instance()` remains the frame-entry route knot. It still owns
+  camera extraction, route policy diagnostics, resident/streaming selection,
+  typed skip publication, and early-return policy.
+- `FrameStateProvider` is still broad. It exposes many read/write buckets and
+  uses fallback static state when a renderer or dependency pointer is missing.
+- `RenderPipelineStages` is the useful stage boundary, but
+  `prepare_frame_context()`, `execute_frame_entry()`, and
+  `render_sorted_splats_with_context()` still reach broadly into renderer-owned
+  buckets and reset output/raster/GPU metrics.
+- Sorting still carries renderer lifetime through
+  `InstancePipelineInputs::owner_renderer`, and `RenderSortingOrchestrator`
+  binds the renderer as both sort result sink and host context.
+- Shared renderer settings arbitration in
+  `nodes/gaussian_splat_node_helpers.cpp` is an intentional external contract;
+  it should not move in the same PR as renderer route decomposition.
+
+Characterization strengthened in this slice:
+
+- Instance contract publish/clear semantics now assert that republishing
+  replaces the renderer-side remap/backend/shape before clearing resets the
+  contract.
+- Streaming-requested failure now asserts the stats/debug route UID contract and
+  backend diagnostics, in addition to blocking a silent resident bounce.
+- Cull-failure stage cascade now asserts route/stage status consistency so a
+  later route-controller extraction cannot leave stale success metrics behind.
+
 ## Reality Check Performed
 1. Regenerated architecture artifacts from current branch code using:
    - `python3 scripts/generate_architecture_diagrams.py`

--- a/docs/architecture/stage-first-ownership-inventory.md
+++ b/docs/architecture/stage-first-ownership-inventory.md
@@ -1,6 +1,7 @@
 # Stage-First Ownership Inventory
 
-W0.1 artifact for the stage-first decomposition plan.
+W0.2 artifact for issue #356, refreshed against `origin/master` at
+`d89bdd5d42` on 2026-05-20.
 
 This document records the current ownership boundary, single-writer rules, and hidden mutable state for the four highest-value decomposition targets:
 
@@ -9,7 +10,11 @@ This document records the current ownership boundary, single-writer rules, and h
 - `GPUSortingPipeline`
 - `GaussianSplatRenderer`
 
-The goal is to make the current implementation readable as an ownership map before code is moved. This is not the target end-state; it is the contract the refactor has to preserve while W1 and W2 land.
+The goal is to make the current implementation readable as an ownership map
+before code is moved. This is not the target end-state; it is the contract the
+refactor has to preserve before route-controller extraction. Items previously
+listed as pending but already moved in the live tree are called out as done, so
+future PRs do not re-implement stale work.
 
 ## Ownership Rules
 
@@ -17,15 +22,18 @@ The goal is to make the current implementation readable as an ownership map befo
 - Worker threads may produce payloads, but they do not mutate renderer-owned state directly.
 - Render-thread dispatch, async readback, and resource tracking must have a single authoritative owner.
 - Hidden process-global caches are temporary debt unless they are explicitly assigned to an owner.
+- Existing seams are treated as contracts: do not replace `IRenderThreadDispatcher`,
+  `ISortResultSink`, `ISortBufferHostContext`, or member-owned tile caches with
+  duplicate cleanup work.
 
 ## Current Ownership Matrix
 
 | System | Current owner | Mutable state buckets | Single-writer rule | Extraction risk |
 | --- | --- | --- | --- | --- |
 | `GaussianStreamingSystem` | `core/gaussian_streaming.*` | `VisibilityState`, `EvictionState`, `SchedulerState`, `DiagnosticsState`, `GlobalAtlasState`, `ConfigOverrides`, `PackTelemetry`, `frame_data`, `uploads`, `budget`, `chunks`, `atlas_allocator`, quantization buffers, `memory_stream_proxy`, `last_upload_device` | Main streaming update path owns frame ordering, visibility, eviction, upload scheduling, and atlas sync. Pack workers only build payloads for queued jobs and do not own streaming state. | High. Configuration overrides, frame ordering, and atlas sync are all coupled in `_run_streaming_frame_pipeline()` and `_apply_config_overrides()`. |
-| `TileRenderer` | `renderer/tile_renderer.*` plus its stage helpers | `render_settings`, `shader_resources`, `diagnostics`, `async_readback`, `tracked_device_manager`, tracked output RIDs, `adaptive_overlap_budget` runtime state, subgroup-support cache | The renderer owns tile frame execution. Readback callbacks may update the readback state machine, but they must not take ownership of resource lifetime or output tracking. | High. There are still process-global mutable caches keyed by renderer/device identity. |
-| `GPUSortingPipeline` | `interfaces/gpu_sorting_pipeline.*` | Sort buffer RIDs and capacities, depth compute RIDs, CPU byte buffers, `SortReadbackState`, `InstanceCountReadbackState`, `InstancePipelineInputs`, cached camera transforms, `last_compute_error` | The pipeline owns its sort buffers, depth resources, and readback generations. Renderer state must be reached through an explicit seam, not a raw pointer handoff. | High. The current implementation still mutates renderer-owned state directly in `_apply_sorted_results()`. |
-| `GaussianSplatRenderer` | `renderer/gaussian_splat_renderer.*` | `DeviceState`, `ResourceState`, `PerformanceState`, `PipelineState`, `FrameState`, `ViewState`, `SortingState`, `StreamingState`, `SceneState`, `SubsystemState`, `RenderFrameContextManager`, render-thread dispatch primitives, orchestrator pointers | The renderer owns frame entry, orchestration, and Godot-facing API. Concrete subsystem mutation should happen through orchestrators or service objects, not through direct cross-subsystem writes. | Medium. The facade is already partly decomposed, but it still owns render-thread dispatch and several mutable caches. |
+| `TileRenderer` | `renderer/tile_renderer.*` plus its stage helpers | `render_settings`, `shader_resources`, `diagnostics`, `async_readback`, `tracked_device_manager`, tracked output RIDs, `adaptive_overlap_budget_runtime_state`, `subgroup_support_cache`, `TileResourceController` | The renderer owns tile frame execution. Readback callbacks may update the readback state machine, but they must not take ownership of resource lifetime or output tracking. | Medium. The old process-global adaptive-overlap and subgroup caches are now members, but execution, diagnostics, and resource lifetime are still tightly packed in the tile renderer. |
+| `GPUSortingPipeline` | `interfaces/gpu_sorting_pipeline.*` | Sort buffer RIDs and capacities, depth compute RIDs, CPU byte buffers, `SortReadbackState`, `InstanceCountReadbackState`, `InstancePipelineInputs`, cached camera transforms, `last_compute_error`, sink/context pointers | The pipeline owns its sort buffers, depth resources, and readback generations. Renderer interaction must stay behind `ISortResultSink` and `ISortBufferHostContext` except for the still-open instance input seam. | High. `InstancePipelineInputs::owner_renderer` and orchestrator-bound renderer sink/context wiring still couple sorting to renderer lifetime. |
+| `GaussianSplatRenderer` | `renderer/gaussian_splat_renderer.*` | `DeviceState`, `ResourceState`, `PerformanceState`, `PipelineState`, `FrameState`, `ViewState`, `SortingState`, `StreamingState`, `SceneState`, `SubsystemState`, `RenderFrameContextManager`, `IRenderThreadDispatcher`, orchestrator pointers | The renderer owns frame entry, orchestration, and Godot-facing API. Concrete subsystem mutation should happen through orchestrators or service objects, not through direct cross-subsystem writes. | High. The dispatch state is now a service, but `render_scene_instance()`, `FrameStateProvider`, and `RenderPipelineStages` still expose broad ownership surfaces. |
 
 ## Subsystem Details
 
@@ -59,17 +67,17 @@ Refactor note:
 
 ### TileRenderer
 
-Current state is a mix of member-owned state and process-global caches:
+Current state is member-owned:
 
-- Adaptive overlap runtime state is currently kept in a static pointer-keyed map in `tile_renderer.cpp:139` through `tile_renderer.cpp:157`
-- Subgroup support is cached in a static device-id keyed cache in `tile_renderer.cpp:1927` through `tile_renderer.cpp:1947`
-- Resource ownership and tracking are handled by `_resolve_texture_owner()`, `track_output_resources()`, and `clear_output_resource_tracking()`
+- Adaptive overlap runtime state lives in `TileRenderer::adaptive_overlap_budget_runtime_state` (`tile_renderer.h:430`) plus its initialized flag.
+- Subgroup support cache lives in `TileRenderer::subgroup_support_cache` (`tile_renderer.h:423`).
+- Resource ownership and tracking are handled by `TileResourceController`, `_resolve_texture_owner()`, `track_output_resources()`, and `clear_output_resource_tracking()`.
 
 Current write ownership:
 
 - The tile renderer owns the frame execution path and the tile stage helpers.
-- `adaptive_overlap_budget_runtime_states` is a temporary process-global cache keyed by `TileRenderer *`.
-- `subgroup_support_cache` is a temporary process-global cache keyed by rendering device ID.
+- Adaptive-overlap state is instance-owned by `TileRenderer`.
+- Subgroup-support cache is instance-owned by `TileRenderer`; it is a device capability cache, not a process-global mutable map.
 - Output RID tracking belongs to the renderer instance and the `RenderDeviceManager`, not to the caller.
 
 Implementation anchors:
@@ -79,8 +87,8 @@ Implementation anchors:
 
 Refactor note:
 
-- W1 should extract the tile resource controller before W2 expands the execution-path split.
-- The current static caches are temporary debt and should not survive the W1/W2 migration.
+- Do not implement the old "move static tile caches" task; that is already done.
+- Remaining tile work should be leaf cleanup: narrow resource-controller calls and split execution/diagnostics only after route and frame-state contracts are pinned.
 
 ### GPUSortingPipeline
 
@@ -90,25 +98,30 @@ Current state in `interfaces/gpu_sorting_pipeline.h` is concentrated but still t
 - Depth compute resources live at `gpu_sorting_pipeline.h:150` through `gpu_sorting_pipeline.h:176`
 - CPU-side sort and depth buffers live at `gpu_sorting_pipeline.h:178` through `gpu_sorting_pipeline.h:183`
 - `SortReadbackState` and `InstanceCountReadbackState` live at `gpu_sorting_pipeline.h:197` through `gpu_sorting_pipeline.h:212`
-- `pending_renderer` lives at `gpu_sorting_pipeline.h:213`
+- `ISortResultSink *sort_result_sink` and `ISortBufferHostContext *sort_buffer_host_context` live at `gpu_sorting_pipeline.h:247` through `gpu_sorting_pipeline.h:248`
+- `InstancePipelineInputs::owner_renderer` still lives at `gpu_sorting_pipeline.h:40`
 
 Current write ownership:
 
 - The pipeline owns its RIDs, capacities, and readback generation counters.
 - `sort_readback_state` controls publication of sorted results.
 - `instance_count_readback_state` controls publication of instance count readbacks.
-- Renderer-owned state is currently mutated inside `_apply_sorted_results()` and reached via `pending_renderer`.
+- Sort result publication is routed through `ISortResultSink`; sort buffer sizing and host state are routed through `ISortBufferHostContext`.
+- Instance sorting still receives renderer lifetime through `InstancePipelineInputs::owner_renderer`.
 
 Implementation anchors:
 
-- `_apply_sorted_results()` writes through `GaussianSplatRenderer` state accessors and updates culler, sorting, frame, and performance state in one step.
-- `ensure_sort_buffers()` still takes a renderer pointer and reaches into renderer state to validate/size resources.
+- `_apply_sorted_results()` now writes through `ISortResultSink`, not `pending_renderer`.
+- `ensure_sort_buffers()` now uses `ISortBufferHostContext` rather than taking a renderer pointer.
+- `RenderSortingOrchestrator::_sync_instance_sort_inputs()` still copies `owner_renderer` into `InstancePipelineInputs`.
+- `RenderSortingOrchestrator::_bind_sort_pipeline_host_context()` still binds both sink and host context to the renderer object.
 - `clear_instance_pipeline_inputs()` and the readback reset path are the current state reset boundary for instance-pipeline work.
 
 Refactor note:
 
-- W1 should replace the renderer pointer seam with `ISortResultSink` plus a minimal host context.
-- W2 should extract the sort buffer, depth compute, execution, and validation stages only after the W1 seam exists.
+- The `ISortResultSink` and `ISortBufferHostContext` seam is already live; do not duplicate it.
+- The next sorting ownership step is replacing `InstancePipelineInputs::owner_renderer` with an instance-state view/snapshot that preserves async readback and generation semantics.
+- W2 should extract sort buffer, depth compute, execution, and validation stages only after that instance seam is pinned by tests.
 
 ### GaussianSplatRenderer
 
@@ -118,20 +131,26 @@ Current state is spread across explicit sub-buckets and orchestrators:
 - `DeviceState` is the owner of the current render-device and scene-render handles
 - `ResourceState` owns buffer lifecycle and per-frame GPU resource state
 - `SubsystemState` owns orchestrator and interface handles
-- `render_thread_dispatch_mutex`, `render_thread_dispatch_semaphore`, and related dispatch counters own the render-thread synchronization path
+- `RenderThreadDispatcher` owns mutex/semaphore/request state behind `IRenderThreadDispatcher`
+- `FrameStateProvider` exposes broad read and mutable access across scene, streaming, debug, sorting, config, resource, frame, performance, subsystem, and pipeline feature state
 
 Implementation anchors:
 
-- `gaussian_splat_renderer.h:531` through `gaussian_splat_renderer.h:538` hold the render-thread dispatch state.
-- `gaussian_splat_renderer.h:518` through `gaussian_splat_renderer.h:529` hold the orchestrator graph.
-- `_dispatch_call_on_render_thread_blocking()` and `_safe_submit_sync()` are the current synchronization chokepoints.
+- `interfaces/render_thread_dispatcher.h:10` through `:25` define the dispatch interface and `:44` through `:51` hold the owned mutex/semaphore/request state.
+- `_dispatch_call_on_render_thread_blocking()` and `_notify_render_thread_dispatch_completed()` delegate to the dispatcher.
+- `render_scene_instance()` still owns per-frame cleanup, camera extraction, route policy diagnostics, resident/streaming selection, and typed skip publication.
+- `RenderPipelineStages::prepare_frame_context()` still builds `FrameDeps` by reaching broadly into renderer state buckets.
+- `RenderPipelineStages::execute_frame_entry()` still owns the cull -> sort cascade and zero-safe snapshot updates.
+- `RenderPipelineStages::render_sorted_splats_with_context()` still resets raster/GPU/output-cache metrics before raster/composite.
 - `gaussian_splat_renderer.cpp:156` through `gaussian_splat_renderer.cpp:163` hold the frame-log settings cache.
 
 Current write ownership:
 
 - The renderer owns Godot-facing API entry points, frame setup, orchestration, and cross-subsystem lifecycle.
 - Orchestrators own the finer-grained subsystem work that has already been peeled out.
-- Render-thread dispatch remains renderer-owned for now, but it should move behind a dedicated seam in W1.
+- Render-thread dispatch state is dispatcher-owned; remaining work is call-site policy and teardown/data-submit ownership.
+- `render_scene_instance()` remains the route/frame-entry knot and should be the first extraction target after this W0 characterization PR.
+- `FrameStateProvider` should become a temporary adapter over smaller snapshots/sinks, not a renamed god object.
 
 Refactor note:
 
@@ -143,17 +162,19 @@ Refactor note:
 | Location | Symbol / state | Why it matters | Current owner status |
 | --- | --- | --- | --- |
 | `renderer/gaussian_splat_renderer.cpp:156` | `g_frame_log_settings` | Process-global cache for frame logging/debug behavior. It is updated from project settings and shared by all renderer instances. | Temporary global cache, should become explicit renderer or process service state. |
-| `renderer/tile_renderer.cpp:139` | `adaptive_overlap_budget_runtime_states` | Process-global cache keyed by `TileRenderer *`. This is hidden instance state stored outside the instance. | Temporary debt, should move into `TileRenderer` ownership or a dedicated controller. |
-| `renderer/tile_renderer.cpp:1927` | `subgroup_support_cache` | Process-global cache keyed by device ID. It affects shader path selection and must not be reinterpreted as per-instance state. | Temporary cache, should be explicitly owned or documented as device capability cache. |
-| `renderer/gaussian_splat_renderer.h:531` through `:538` | render-thread dispatch mutex, semaphore, request/completion counters, timeout | Synchronization state is embedded in the renderer facade. | Renderer-owned for now, but the W1 dispatcher seam should take it over. |
-| `interfaces/gpu_sorting_pipeline.h:213` | `pending_renderer` | Cross-object mutable handoff state. It makes the pipeline depend on renderer lifetime and shape. | Temporary coupling, should be removed by W1. |
+| `interfaces/render_thread_dispatcher.h:44` through `:51` | dispatcher mutex, semaphore, request/completion counters, timeout, latest data result | Synchronization state is now service-owned instead of embedded in the renderer facade. | Done as an ownership move. Remaining coupling is renderer call-site policy, not field ownership. |
+| `interfaces/gpu_sorting_pipeline.h:40` | `InstancePipelineInputs::owner_renderer` | Cross-object lifetime handoff remains for instance sorting, even after sink/host extraction. | Open coupling; replace with an instance-state snapshot/view after characterization tests. |
+| `interfaces/gpu_sorting_pipeline.h:247` through `:248` | `sort_result_sink`, `sort_buffer_host_context` | Explicit sort result and buffer-host seams. | Done seam, but currently bound to the renderer by `RenderSortingOrchestrator`; future work should narrow the concrete host object. |
+| `renderer/gaussian_splat_renderer.cpp:603` through `:770` | `FrameStateProvider` fallback statics and broad mutable accessors | Provider methods can expose fallback mutable objects and broad write surfaces. | Open coupling; split into read-only snapshots plus small mutation sinks per stage. |
+| `nodes/gaussian_splat_node_helpers.cpp:33` through `:78` | shared renderer settings owner map | Node-side renderer settings ownership is process-global arbitration and protects shared renderer peers. | Intentional external contract for now; moving it belongs in a later node/director boundary issue. |
 | `core/gaussian_streaming.cpp:2400` | `debug_frame` static counter | Telemetry pacing is process-global, not instance-owned. | Benign but still hidden mutable state; keep the scope explicit. |
 
 ## What This Means For Decomposition
 
 - `W0` must stay stable: the ownership matrix and the characterization tests are the hard gate.
-- `W1` should cut concrete seams first: sort result sink, render-thread dispatcher, tile resource controller, and hidden-static cleanup.
-- `W2` should extract execution stages only after ownership is explicit.
+- `W1` must not redo completed seam work. The live done list is: render-thread dispatcher state, sort result sink, sort buffer host context, member-owned tile subgroup cache, and member-owned tile adaptive-overlap runtime state.
+- `W1` should cut the still-open seams first: route/frame-entry controller contract, smaller frame-state snapshots/sinks, sorting instance-state snapshot, and resident publisher product boundaries.
+- `W2` should extract execution stages only after ownership is explicit and characterization tests protect route/stage stats, fallback semantics, instance generations, shared renderer settings, dispatch recovery, and resource-owner rejection.
 - `W3` should be cleanup only: remove the shims, slim the facades, and enforce the dependency rules.
 
 ## Related Docs

--- a/modules/gaussian_splatting/tests/test_renderer_pipeline.h
+++ b/modules/gaussian_splatting/tests/test_renderer_pipeline.h
@@ -764,6 +764,32 @@ TEST_CASE("[GaussianSplatting] Clearing the published instance contract also cle
     CHECK(renderer->get_instance_contract_shape() == String("atlas_emulation"));
     CHECK(renderer->get_instance_asset_remap().generation == 11u);
 
+    GaussianRenderPipeline::InstancePipelineBuffers replacement_buffers;
+    replacement_buffers.instance_count = 5;
+    replacement_buffers.max_visible_splats = 12;
+
+    GaussianRenderPipeline::PublishedInstanceAssetRemap replacement_remap;
+    replacement_remap.asset_to_dense_id.insert(8u, 4u);
+    replacement_remap.generation = 22u;
+    replacement_remap.valid = true;
+
+    renderer->publish_instance_pipeline_contract(
+            replacement_buffers,
+            replacement_remap,
+            GaussianRenderPipeline::InstanceBackendPolicy::STREAMING,
+            replacement_remap.generation,
+            "streaming_atlas");
+
+    CHECK(renderer->has_instance_pipeline_buffers());
+    CHECK(renderer->has_instance_asset_remap());
+    CHECK(renderer->get_instance_backend_policy() == GaussianRenderPipeline::InstanceBackendPolicy::STREAMING);
+    CHECK(renderer->get_instance_contract_shape() == String("streaming_atlas"));
+    CHECK(renderer->get_instance_pipeline_buffers().instance_count == 5u);
+    CHECK(renderer->get_instance_pipeline_buffers().max_visible_splats == 12u);
+    CHECK_FALSE(renderer->get_instance_asset_remap().asset_to_dense_id.has(5u));
+    CHECK(renderer->get_instance_asset_remap().asset_to_dense_id.has(8u));
+    CHECK(renderer->get_instance_asset_remap().generation == 22u);
+
     renderer->clear_instance_pipeline_buffers();
 
     CHECK_FALSE(renderer->has_instance_pipeline_buffers());
@@ -1729,6 +1755,14 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] Streaming-requested failure hard-fai
             "Streaming-requested failure must not bounce to INSTANCE.RESIDENT");
 
     const Dictionary stats = renderer->get_render_stats();
+    CHECK_MESSAGE(stats.get("route_uid", String()) == route_uid,
+            "Streaming-requested failure must publish the same route UID through render stats");
+    CHECK_MESSAGE(stats.get("requested_route_policy", String()) == String("streaming"),
+            "Streaming-requested failure must preserve requested route policy diagnostics");
+    CHECK_MESSAGE(stats.get("instance_backend_policy", String()) == String("streaming"),
+            "Streaming-requested failure must keep streaming backend diagnostics");
+    CHECK_MESSAGE(String(stats.get("backend_selection_reason", String())).find("streaming") != -1,
+            "Streaming-requested failure must publish a streaming backend reason");
     const String cull_route_uid = stats.get("cull_route_uid", String());
     CHECK_MESSAGE(cull_route_uid != String(RenderRouteUID::INSTANCE_RESIDENT),
             "Streaming-requested failure must not produce a resident cull route");
@@ -2930,6 +2964,12 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] Stage results report cull/sort skipp
             "Expected cull route UID to report the GPU-culler-disabled bypass");
     CHECK_MESSAGE(stats.get("cull_route_reason", String()) == String("gpu_culler_unavailable"),
             "Expected cull route reason to report the missing GPU culler");
+    CHECK_MESSAGE(stats.get("route_uid", String()) == stats.get("cull_route_uid", String()),
+            "Cull-stage failure should publish the same top-level and cull route UID");
+    CHECK_MESSAGE(!bool(stats.get("route_uid_missing", true)),
+            "Expected route UID to be present for GPU-culler-unavailable cascade");
+    CHECK_MESSAGE(!bool(stats.get("cull_route_uid_missing", true)),
+            "Expected cull route UID to be present for GPU-culler-unavailable cascade");
     const String cull_status = stats.get("stage_cull_status", String());
     CHECK_MESSAGE(cull_status == String("skipped"),
             vformat("Expected cull stage skipped, got '%s'", cull_status));


### PR DESCRIPTION
## Summary

- Refreshes the issue #356 W0 ownership inventory against current `origin/master`, marking render-thread dispatcher extraction, sort sink/host seams, and member-owned tile caches as already live.
- Records remaining coupled boundaries: `render_scene_instance()`, broad `FrameStateProvider`, `RenderPipelineStages` renderer dependency, sorting `owner_renderer`, resident publisher complexity, and shared renderer settings arbitration.
- Strengthens renderer characterization tests for instance contract publish/clear replacement, streaming-requested no-bounce diagnostics, and cull-stage cascade route/status consistency.

## Validation

- `python3 tests/ci/run_module_tests.py --guard-only`
- `python3 tests/ci/run_module_tests.py --allow-tests-unavailable` (guards passed, then failed before doctests because `godot` on PATH is not executable/available in this WSL environment: `PermissionError: [Errno 13] Permission denied: 'godot'`)
- `timeout 900 scons platform=linuxbsd target=editor dev_build=yes tests=yes module_gaussian_splatting_enabled=yes -j2` (compiled through `tests/test_main.cpp` including `test_renderer_pipeline.h` and `libtests`; timed out/interrupted in third-party HarfBuzz before final editor link)
- `git diff --check`

Refs #356
