### PR TITLE
[codex] Harden asset snapshots and HUD lifetime

### DIFF
--- a/docs/api/gaussian_splat_asset.md
+++ b/docs/api/gaussian_splat_asset.md
@@ -120,9 +120,9 @@ Use `GaussianSplatAsset` to store, serialize, and exchange Gaussian splat data a
     </tr>
     <tr>
       <td><code>import/thumbnail</code></td>
-      <td><code>Texture2D</code></td>
-      <td><code>set_thumbnail</code>, <code>get_thumbnail</code></td>
-      <td>Optional preview thumbnail for the asset browser.</td>
+      <td><code>Image</code></td>
+      <td><code>set_preview_image</code>, <code>get_preview_image</code>, legacy <code>set_thumbnail</code>/<code>get_thumbnail</code></td>
+      <td>Optional preview thumbnail stored as CPU image data. Texture creation is main-thread-only; threaded import/preview paths should use the image API.</td>
       <td><code>modules/gaussian_splatting/core/gaussian_splat_asset.cpp:90</code></td>
     </tr>
     <tr>
@@ -225,6 +225,14 @@ Use `GaussianSplatAsset` to store, serialize, and exchange Gaussian splat data a
     </tr>
   </tbody>
 </table>
+
+### Threading and Snapshot Contract
+
+`GaussianSplatAsset` serializes payload arrays, import metadata, preview image state, runtime cache handout, and `copy_from()` hot-reload replacement with its internal `populate_mutex`. Code that needs a coherent view of more than one asset field should use `capture_payload_snapshot()` and work from the copied `PayloadSnapshot`; this is the contract used by the node asset refresh and editor thumbnail generation paths.
+
+Packed-array setters remain import/deserialization APIs, not live runtime mutation APIs. After `get_gaussian_data()` hands out runtime authority, the asset is sealed and public packed setters reject mutation. `copy_from()` is the explicit hot-reload replacement boundary and is serialized against snapshot reads.
+
+Preview thumbnails are stored as `Image` data. `get_preview_texture()`, `get_thumbnail()`, and editor `generate_thumbnail()` create `ImageTexture` resources and must run on the main thread. Worker/import code should call `get_preview_image()`, `set_preview_image()`, or thumbnail image generation APIs only.
 
 ### Methods
 

--- a/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_asset.cpp
@@ -326,13 +326,47 @@ uint32_t GaussianSplatAsset::get_splat_count() const {
     return splat_count;
 }
 
+GaussianSplatAsset::PayloadSnapshot GaussianSplatAsset::capture_payload_snapshot() const {
+    MutexLock cache_lock(populate_mutex);
+    PayloadSnapshot snapshot;
+    snapshot.splat_count = splat_count;
+    snapshot.sh_first_order_terms = sh_first_order_terms;
+    snapshot.sh_high_order_terms = sh_high_order_terms;
+    snapshot.compression_flags = compression_flags;
+    snapshot.import_quality_preset = import_quality_preset;
+    snapshot.import_metadata = import_metadata;
+    snapshot.preview_image = preview_image;
+    snapshot.positions = positions;
+    snapshot.colors = colors;
+    snapshot.scales = scales;
+    snapshot.rotations = rotations;
+    snapshot.sh_dc_coefficients = has_sh_dc_coefficients ? sh_dc_coefficients : PackedFloat32Array();
+    snapshot.sh_first_order_coefficients = sh_first_order_coefficients;
+    snapshot.sh_high_order_coefficients = sh_high_order_coefficients;
+    snapshot.opacity_logits = opacity_logits;
+    snapshot.palette_ids = palette_ids;
+    snapshot.painterly_flags = painterly_flags;
+    snapshot.normals = normals;
+    snapshot.brush_axes = brush_axes;
+    snapshot.stroke_ages = stroke_ages;
+    snapshot.streaming_chunk_records = streaming_chunk_records;
+    snapshot.streaming_primary_source_indices = streaming_primary_source_indices;
+    snapshot.streaming_quantization_records = streaming_quantization_records;
+    snapshot.streaming_chunk_size_used = streaming_chunk_size_used;
+    snapshot.has_sh_dc_coefficients = has_sh_dc_coefficients;
+    return snapshot;
+}
+
 // ---------------------------------------------------------------------------
 // Raw-array getters: warn once when the asset has no loaded data so that
 // callers can distinguish "empty because unloaded" from "legitimately empty".
-// These use WARN_PRINT_ONCE because they may be called per-frame.
+// These use WARN_PRINT_ONCE because they may be called per-frame. Multi-field
+// readers must prefer capture_payload_snapshot() so they take populate_mutex once
+// and cannot observe fields from different copy_from()/reload generations.
 // ---------------------------------------------------------------------------
 
 PackedFloat32Array GaussianSplatAsset::get_positions() const {
+    MutexLock cache_lock(populate_mutex);
     if (splat_count == 0 && positions.is_empty()) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_positions() called on unloaded asset; returning empty array.");
     }
@@ -340,6 +374,7 @@ PackedFloat32Array GaussianSplatAsset::get_positions() const {
 }
 
 PackedColorArray GaussianSplatAsset::get_colors() const {
+    MutexLock cache_lock(populate_mutex);
     if (splat_count == 0 && colors.is_empty()) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_colors() called on unloaded asset; returning empty array.");
     }
@@ -347,6 +382,7 @@ PackedColorArray GaussianSplatAsset::get_colors() const {
 }
 
 PackedFloat32Array GaussianSplatAsset::get_scales() const {
+    MutexLock cache_lock(populate_mutex);
     if (splat_count == 0 && scales.is_empty()) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_scales() called on unloaded asset; returning empty array.");
     }
@@ -354,6 +390,7 @@ PackedFloat32Array GaussianSplatAsset::get_scales() const {
 }
 
 PackedFloat32Array GaussianSplatAsset::get_rotations() const {
+    MutexLock cache_lock(populate_mutex);
     if (splat_count == 0 && rotations.is_empty()) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_rotations() called on unloaded asset; returning empty array.");
     }
@@ -361,6 +398,7 @@ PackedFloat32Array GaussianSplatAsset::get_rotations() const {
 }
 
 PackedFloat32Array GaussianSplatAsset::get_sh_dc_coefficients() const {
+    MutexLock cache_lock(populate_mutex);
     if (splat_count == 0 && !has_sh_dc_coefficients) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_sh_dc_coefficients() called on unloaded asset; returning empty array.");
     }
@@ -368,6 +406,7 @@ PackedFloat32Array GaussianSplatAsset::get_sh_dc_coefficients() const {
 }
 
 PackedFloat32Array GaussianSplatAsset::get_sh_first_order_coefficients() const {
+    MutexLock cache_lock(populate_mutex);
     if (splat_count == 0 && sh_first_order_coefficients.is_empty()) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_sh_first_order_coefficients() called on unloaded asset; returning empty array.");
     }
@@ -375,6 +414,7 @@ PackedFloat32Array GaussianSplatAsset::get_sh_first_order_coefficients() const {
 }
 
 PackedFloat32Array GaussianSplatAsset::get_sh_high_order_coefficients() const {
+    MutexLock cache_lock(populate_mutex);
     if (splat_count == 0 && sh_high_order_coefficients.is_empty()) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_sh_high_order_coefficients() called on unloaded asset; returning empty array.");
     }
@@ -382,6 +422,7 @@ PackedFloat32Array GaussianSplatAsset::get_sh_high_order_coefficients() const {
 }
 
 PackedFloat32Array GaussianSplatAsset::get_opacity_logits() const {
+    MutexLock cache_lock(populate_mutex);
     if (splat_count == 0 && opacity_logits.is_empty()) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_opacity_logits() called on unloaded asset; returning empty array.");
     }
@@ -389,6 +430,7 @@ PackedFloat32Array GaussianSplatAsset::get_opacity_logits() const {
 }
 
 PackedInt32Array GaussianSplatAsset::get_palette_ids() const {
+    MutexLock cache_lock(populate_mutex);
     if (splat_count == 0 && palette_ids.is_empty()) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_palette_ids() called on unloaded asset; returning empty array.");
     }
@@ -396,6 +438,7 @@ PackedInt32Array GaussianSplatAsset::get_palette_ids() const {
 }
 
 PackedInt32Array GaussianSplatAsset::get_painterly_flags() const {
+    MutexLock cache_lock(populate_mutex);
     if (splat_count == 0 && painterly_flags.is_empty()) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_painterly_flags() called on unloaded asset; returning empty array.");
     }
@@ -403,6 +446,7 @@ PackedInt32Array GaussianSplatAsset::get_painterly_flags() const {
 }
 
 PackedInt32Array GaussianSplatAsset::get_brush_override_ids() const {
+    MutexLock cache_lock(populate_mutex);
     if (splat_count == 0 && painterly_flags.is_empty()) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_brush_override_ids() called on unloaded asset; returning empty array.");
     }
@@ -410,6 +454,7 @@ PackedInt32Array GaussianSplatAsset::get_brush_override_ids() const {
 }
 
 PackedFloat32Array GaussianSplatAsset::get_normals() const {
+    MutexLock cache_lock(populate_mutex);
     if (splat_count == 0 && normals.is_empty()) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_normals() called on unloaded asset; returning empty array.");
     }
@@ -417,6 +462,7 @@ PackedFloat32Array GaussianSplatAsset::get_normals() const {
 }
 
 PackedFloat32Array GaussianSplatAsset::get_brush_axes() const {
+    MutexLock cache_lock(populate_mutex);
     if (splat_count == 0 && brush_axes.is_empty()) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_brush_axes() called on unloaded asset; returning empty array.");
     }
@@ -424,6 +470,7 @@ PackedFloat32Array GaussianSplatAsset::get_brush_axes() const {
 }
 
 PackedFloat32Array GaussianSplatAsset::get_stroke_ages() const {
+    MutexLock cache_lock(populate_mutex);
     if (splat_count == 0 && stroke_ages.is_empty()) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_stroke_ages() called on unloaded asset; returning empty array.");
     }
@@ -437,6 +484,7 @@ PackedFloat32Array GaussianSplatAsset::get_stroke_ages() const {
 // ---------------------------------------------------------------------------
 
 PackedVector3Array GaussianSplatAsset::get_position_vectors() const {
+    MutexLock cache_lock(populate_mutex);
     PackedVector3Array result;
     if (splat_count == 0) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_position_vectors() called on unloaded asset (splat_count == 0); returning empty array.");
@@ -469,6 +517,7 @@ PackedVector3Array GaussianSplatAsset::get_position_vectors() const {
 }
 
 PackedVector3Array GaussianSplatAsset::get_scale_vectors() const {
+    MutexLock cache_lock(populate_mutex);
     PackedVector3Array result;
     if (splat_count == 0) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_scale_vectors() called on unloaded asset (splat_count == 0); returning empty array.");
@@ -501,6 +550,7 @@ PackedVector3Array GaussianSplatAsset::get_scale_vectors() const {
 }
 
 TypedArray<Quaternion> GaussianSplatAsset::get_rotation_quaternions() const {
+    MutexLock cache_lock(populate_mutex);
     TypedArray<Quaternion> result;
     if (splat_count == 0) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_rotation_quaternions() called on unloaded asset (splat_count == 0); returning empty array.");
@@ -531,6 +581,7 @@ TypedArray<Quaternion> GaussianSplatAsset::get_rotation_quaternions() const {
 }
 
 PackedFloat32Array GaussianSplatAsset::get_spherical_harmonics_buffer() const {
+    MutexLock cache_lock(populate_mutex);
     PackedFloat32Array result;
     if (splat_count == 0) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_spherical_harmonics_buffer() called on unloaded asset (splat_count == 0); returning empty array.");
@@ -611,6 +662,7 @@ PackedFloat32Array GaussianSplatAsset::get_spherical_harmonics_buffer() const {
 }
 
 PackedFloat32Array GaussianSplatAsset::get_opacities() const {
+    MutexLock cache_lock(populate_mutex);
     PackedFloat32Array result;
     if (splat_count == 0) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_opacities() called on unloaded asset (splat_count == 0); returning empty array.");
@@ -641,6 +693,7 @@ PackedFloat32Array GaussianSplatAsset::get_opacities() const {
 }
 
 PackedInt32Array GaussianSplatAsset::get_palette_ids_buffer() const {
+    MutexLock cache_lock(populate_mutex);
     PackedInt32Array result;
     if (splat_count == 0) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_palette_ids_buffer() called on unloaded asset (splat_count == 0); returning empty array.");
@@ -660,6 +713,7 @@ PackedInt32Array GaussianSplatAsset::get_palette_ids_buffer() const {
 }
 
 PackedInt32Array GaussianSplatAsset::get_painterly_flags_buffer() const {
+    MutexLock cache_lock(populate_mutex);
     PackedInt32Array result;
     if (splat_count == 0) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_painterly_flags_buffer() called on unloaded asset (splat_count == 0); returning empty array.");
@@ -683,6 +737,7 @@ PackedInt32Array GaussianSplatAsset::get_brush_override_ids_buffer() const {
 }
 
 PackedVector3Array GaussianSplatAsset::get_normal_vectors() const {
+    MutexLock cache_lock(populate_mutex);
     PackedVector3Array result;
     if (splat_count == 0) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_normal_vectors() called on unloaded asset (splat_count == 0); returning empty array.");
@@ -706,6 +761,7 @@ PackedVector3Array GaussianSplatAsset::get_normal_vectors() const {
 }
 
 PackedVector2Array GaussianSplatAsset::get_brush_axes_vector2() const {
+    MutexLock cache_lock(populate_mutex);
     PackedVector2Array result;
     if (splat_count == 0) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_brush_axes_vector2() called on unloaded asset (splat_count == 0); returning empty array.");
@@ -729,6 +785,7 @@ PackedVector2Array GaussianSplatAsset::get_brush_axes_vector2() const {
 }
 
 PackedFloat32Array GaussianSplatAsset::get_stroke_ages_buffer() const {
+    MutexLock cache_lock(populate_mutex);
     PackedFloat32Array result;
     if (splat_count == 0) {
         WARN_PRINT_ONCE("[GaussianSplatAsset] get_stroke_ages_buffer() called on unloaded asset (splat_count == 0); returning empty array.");
@@ -744,6 +801,16 @@ PackedFloat32Array GaussianSplatAsset::get_stroke_ages_buffer() const {
     }
 
     return result;
+}
+
+uint32_t GaussianSplatAsset::get_sh_first_order_terms() const {
+    MutexLock cache_lock(populate_mutex);
+    return sh_first_order_terms;
+}
+
+uint32_t GaussianSplatAsset::get_sh_high_order_terms() const {
+    MutexLock cache_lock(populate_mutex);
+    return sh_high_order_terms;
 }
 
 void GaussianSplatAsset::set_positions(const PackedFloat32Array &p_positions) {
@@ -978,23 +1045,47 @@ void GaussianSplatAsset::set_stroke_ages(const PackedFloat32Array &p_stroke_ages
 }
 
 void GaussianSplatAsset::set_streaming_chunk_records(const PackedByteArray &p_records) {
+    MutexLock cache_lock(populate_mutex);
     streaming_chunk_records = p_records;
     _invalidate_gaussian_data_cache();
 }
 
+PackedByteArray GaussianSplatAsset::get_streaming_chunk_records() const {
+    MutexLock cache_lock(populate_mutex);
+    return streaming_chunk_records;
+}
+
 void GaussianSplatAsset::set_streaming_primary_source_indices(const PackedInt32Array &p_indices) {
+    MutexLock cache_lock(populate_mutex);
     streaming_primary_source_indices = p_indices;
     _invalidate_gaussian_data_cache();
 }
 
+PackedInt32Array GaussianSplatAsset::get_streaming_primary_source_indices() const {
+    MutexLock cache_lock(populate_mutex);
+    return streaming_primary_source_indices;
+}
+
 void GaussianSplatAsset::set_streaming_quantization_records(const PackedByteArray &p_records) {
+    MutexLock cache_lock(populate_mutex);
     streaming_quantization_records = p_records;
     _invalidate_gaussian_data_cache();
 }
 
+PackedByteArray GaussianSplatAsset::get_streaming_quantization_records() const {
+    MutexLock cache_lock(populate_mutex);
+    return streaming_quantization_records;
+}
+
 void GaussianSplatAsset::set_streaming_chunk_size_used(uint32_t p_size) {
+    MutexLock cache_lock(populate_mutex);
     streaming_chunk_size_used = p_size;
     _invalidate_gaussian_data_cache();
+}
+
+uint32_t GaussianSplatAsset::get_streaming_chunk_size_used() const {
+    MutexLock cache_lock(populate_mutex);
+    return streaming_chunk_size_used;
 }
 
 void GaussianSplatAsset::set_sh_component_terms(uint32_t p_first_order_terms, uint32_t p_high_order_terms) {
@@ -1122,6 +1213,11 @@ void GaussianSplatAsset::set_import_metadata(const Dictionary &p_metadata) {
     emit_changed();
 }
 
+Dictionary GaussianSplatAsset::get_import_metadata() const {
+    MutexLock cache_lock(populate_mutex);
+    return import_metadata;
+}
+
 // Invariant: every bound setter below that mutates `import_metadata` acquires
 // `populate_mutex` on entry. A concurrent prefetch_parallel() worker reads
 // metadata under the same lock in populate_gaussian_data(), so writers must
@@ -1137,6 +1233,11 @@ void GaussianSplatAsset::set_import_quality_preset(const String &p_preset) {
     emit_changed();
 }
 
+String GaussianSplatAsset::get_import_quality_preset() const {
+    MutexLock cache_lock(populate_mutex);
+    return import_quality_preset;
+}
+
 void GaussianSplatAsset::set_compression_flags(uint32_t p_flags) {
     MutexLock cache_lock(populate_mutex);
     if (compression_flags == p_flags) {
@@ -1145,6 +1246,11 @@ void GaussianSplatAsset::set_compression_flags(uint32_t p_flags) {
     compression_flags = p_flags;
     import_metadata[StringName("compression_flags")] = (int)compression_flags;
     emit_changed();
+}
+
+uint32_t GaussianSplatAsset::get_compression_flags() const {
+    MutexLock cache_lock(populate_mutex);
+    return compression_flags;
 }
 
 void GaussianSplatAsset::set_preview_image(const Ref<Image> &p_image) {
@@ -1159,23 +1265,36 @@ void GaussianSplatAsset::set_preview_image(const Ref<Image> &p_image) {
     emit_changed();
 }
 
+Ref<Image> GaussianSplatAsset::get_preview_image() const {
+    MutexLock cache_lock(populate_mutex);
+    return preview_image;
+}
+
 Ref<Texture2D> GaussianSplatAsset::get_preview_texture() const {
-    if (preview_texture_cache.is_valid()) {
-        return preview_texture_cache;
+    ERR_FAIL_COND_V_MSG(!Thread::is_main_thread(), Ref<Texture2D>(),
+            "GaussianSplatAsset::get_preview_texture() creates an ImageTexture and must run on the main thread. Use get_preview_image() or capture_payload_snapshot() from worker threads.");
+
+    Ref<Image> image;
+    {
+        MutexLock cache_lock(populate_mutex);
+        if (preview_texture_cache.is_valid()) {
+            return preview_texture_cache;
+        }
+        image = preview_image;
     }
 
-    if (preview_image.is_null() || preview_image->is_empty()) {
+    if (image.is_null() || image->is_empty()) {
         return Ref<Texture2D>();
     }
 
-    // Safe to call from `EditorResourcePreview`'s worker threads: the main
-    // thread services the RS command queue in editor mode, so the sync RS
-    // chain underneath `create_from_image` completes. The `--headless
-    // --import` deadlock motivating #251 is avoided because the import path
-    // stores `preview_image` directly via `set_preview_image()` and never
-    // invokes this lazy texture-creation accessor.
-    preview_texture_cache = ImageTexture::create_from_image(preview_image);
-    return preview_texture_cache;
+    // Texture creation crosses RenderingServer state. Keep worker/import paths
+    // CPU-only and expose the stored Image through get_preview_image() instead.
+    Ref<ImageTexture> texture = ImageTexture::create_from_image(image);
+    MutexLock cache_lock(populate_mutex);
+    if (preview_texture_cache.is_null() && preview_image == image) {
+        preview_texture_cache = texture;
+    }
+    return preview_texture_cache.is_valid() ? preview_texture_cache : texture;
 }
 
 void GaussianSplatAsset::set_thumbnail(const Ref<Texture2D> &p_thumbnail) {
@@ -1200,6 +1319,7 @@ void GaussianSplatAsset::set_source_path(const String &p_path) {
 }
 
 String GaussianSplatAsset::get_source_path() const {
+    MutexLock cache_lock(populate_mutex);
     if (import_metadata.has(StringName("source_path"))) {
         return (String)import_metadata[StringName("source_path")];
     }

--- a/modules/gaussian_splatting/core/gaussian_splat_asset.h
+++ b/modules/gaussian_splatting/core/gaussian_splat_asset.h
@@ -71,10 +71,10 @@ private:
     mutable Ref<ImageTexture> preview_texture_cache;
     bool has_sh_dc_coefficients = false;
     mutable Ref<::GaussianData> gaussian_data_cache;
-    // Serializes the cache check-and-store in get_gaussian_data() / populate_gaussian_data()
-    // so the O(N) SoA->AoS build can run on a WorkerThreadPool task (one task per asset).
-    // The mutex is NEVER held during the build itself — only around the cache reads/writes —
-    // to avoid serializing parallel workers materializing distinct assets.
+    // Serializes payload snapshots, hot-reload copy_from(), preview image/cache
+    // state, and get_gaussian_data() materialization. Multi-field readers should
+    // use capture_payload_snapshot() to copy a coherent asset generation under
+    // one lock and then release it before doing heavier work.
     mutable Mutex populate_mutex;
     // Once the asset has been "handed out" as runtime authority (via
     // get_gaussian_data() or populate_from_gaussian_data()), the packed
@@ -105,6 +105,36 @@ protected:
     void _get_property_list(List<PropertyInfo> *p_list) const;
 
 public:
+    struct PayloadSnapshot {
+        uint32_t splat_count = 0;
+        uint32_t sh_first_order_terms = 0;
+        uint32_t sh_high_order_terms = 0;
+        uint32_t compression_flags = COMPRESSION_NONE;
+        String import_quality_preset;
+        Dictionary import_metadata;
+        Ref<Image> preview_image;
+        PackedFloat32Array positions;
+        PackedColorArray colors;
+        PackedFloat32Array scales;
+        PackedFloat32Array rotations;
+        PackedFloat32Array sh_dc_coefficients;
+        PackedFloat32Array sh_first_order_coefficients;
+        PackedFloat32Array sh_high_order_coefficients;
+        PackedFloat32Array opacity_logits;
+        PackedInt32Array palette_ids;
+        PackedInt32Array painterly_flags;
+        PackedFloat32Array normals;
+        PackedFloat32Array brush_axes;
+        PackedFloat32Array stroke_ages;
+        PackedByteArray streaming_chunk_records;
+        PackedInt32Array streaming_primary_source_indices;
+        PackedByteArray streaming_quantization_records;
+        uint32_t streaming_chunk_size_used = 0;
+        bool has_sh_dc_coefficients = false;
+
+        bool is_loaded() const { return splat_count > 0; }
+    };
+
     GaussianSplatAsset();
     ~GaussianSplatAsset();
 
@@ -128,6 +158,11 @@ public:
     // read against set_splat_count() / copy_from(). Mutex is recursive, so it
     // is safe to call from within a setter that already holds the lock.
     uint32_t get_splat_count() const;
+
+    // Copies all payload arrays and metadata while holding populate_mutex once.
+    // Use this for node/editor/runtime code that needs more than one field from
+    // an asset; individual getters are for single-field compatibility reads.
+    PayloadSnapshot capture_payload_snapshot() const;
 
     // Getters
     PackedFloat32Array get_positions() const;
@@ -155,8 +190,8 @@ public:
     PackedVector2Array get_brush_axes_vector2() const;
     PackedFloat32Array get_stroke_ages() const;
     PackedFloat32Array get_stroke_ages_buffer() const;
-    uint32_t get_sh_first_order_terms() const { return sh_first_order_terms; }
-    uint32_t get_sh_high_order_terms() const { return sh_high_order_terms; }
+    uint32_t get_sh_first_order_terms() const;
+    uint32_t get_sh_high_order_terms() const;
 
     // Setters - needed for loaders to populate data
     void set_positions(const PackedFloat32Array &p_positions);
@@ -178,16 +213,16 @@ public:
     static uint32_t get_instance_count() { return instance_count.load(); }
 
     void set_import_metadata(const Dictionary &p_metadata);
-    Dictionary get_import_metadata() const { return import_metadata; }
+    Dictionary get_import_metadata() const;
 
     void set_import_quality_preset(const String &p_preset);
-    String get_import_quality_preset() const { return import_quality_preset; }
+    String get_import_quality_preset() const;
 
     void set_compression_flags(uint32_t p_flags);
-    uint32_t get_compression_flags() const { return compression_flags; }
+    uint32_t get_compression_flags() const;
 
     void set_preview_image(const Ref<Image> &p_image);
-    Ref<Image> get_preview_image() const { return preview_image; }
+    Ref<Image> get_preview_image() const;
     Ref<Texture2D> get_preview_texture() const;
 
     void set_thumbnail(const Ref<Texture2D> &p_thumbnail);
@@ -217,15 +252,16 @@ public:
 
     // Streaming-chunk bake accessors (Phase B.1).
     void set_streaming_chunk_records(const PackedByteArray &p_records);
-    PackedByteArray get_streaming_chunk_records() const { return streaming_chunk_records; }
+    PackedByteArray get_streaming_chunk_records() const;
     void set_streaming_primary_source_indices(const PackedInt32Array &p_indices);
-    PackedInt32Array get_streaming_primary_source_indices() const { return streaming_primary_source_indices; }
+    PackedInt32Array get_streaming_primary_source_indices() const;
     void set_streaming_quantization_records(const PackedByteArray &p_records);
-    PackedByteArray get_streaming_quantization_records() const { return streaming_quantization_records; }
+    PackedByteArray get_streaming_quantization_records() const;
     void set_streaming_chunk_size_used(uint32_t p_size);
-    uint32_t get_streaming_chunk_size_used() const { return streaming_chunk_size_used; }
+    uint32_t get_streaming_chunk_size_used() const;
 
     bool has_baked_streaming_chunks() const {
+        MutexLock cache_lock(populate_mutex);
         return streaming_chunk_size_used > 0 && !streaming_chunk_records.is_empty();
     }
 };

--- a/modules/gaussian_splatting/editor/gaussian_resource_preview_generator.cpp
+++ b/modules/gaussian_splatting/editor/gaussian_resource_preview_generator.cpp
@@ -4,13 +4,52 @@
 
 #include "core/io/resource_loader.h"
 #include "core/math/math_funcs.h"
+#include "core/object/message_queue.h"
 #include "core/object/object.h"
+#include "core/os/semaphore.h"
+#include "core/os/thread.h"
+#include "scene/resources/image_texture.h"
 #include "scene/resources/texture.h"
 
 #include "../core/gaussian_splat_asset.h"
 #include "gaussian_thumbnail_generator.h"
 
 void GaussianSplatAssetPreviewGenerator::_bind_methods() {}
+
+class GaussianPreviewTextureCreateRequest : public Object {
+public:
+	Ref<Image> image;
+	Ref<Texture2D> texture;
+	Semaphore done;
+
+	void create_texture() {
+		if (image.is_valid() && !image->is_empty()) {
+			texture = ImageTexture::create_from_image(image);
+		}
+		done.post();
+	}
+};
+
+static Ref<Texture2D> _create_preview_texture_from_image(const Ref<Image> &p_image) {
+	if (p_image.is_null() || p_image->is_empty()) {
+		return Ref<Texture2D>();
+	}
+	if (Thread::is_main_thread()) {
+		return ImageTexture::create_from_image(p_image);
+	}
+
+	CallQueue *main_queue = MessageQueue::get_main_singleton();
+	ERR_FAIL_NULL_V_MSG(main_queue, Ref<Texture2D>(),
+			"Gaussian preview texture creation must run on the main thread, but the main message queue is not available.");
+
+	GaussianPreviewTextureCreateRequest request;
+	request.image = p_image;
+	const Error err = main_queue->push_callable(callable_mp(&request, &GaussianPreviewTextureCreateRequest::create_texture));
+	ERR_FAIL_COND_V_MSG(err != OK, Ref<Texture2D>(), "Failed to queue Gaussian preview texture creation on the main thread.");
+
+	request.done.wait();
+	return request.texture;
+}
 
 bool GaussianSplatAssetPreviewGenerator::handles(const String &p_type) const {
 	return ClassDB::is_parent_class(p_type, "GaussianSplatAsset");
@@ -22,10 +61,18 @@ Ref<Texture2D> GaussianSplatAssetPreviewGenerator::generate(const Ref<Resource> 
 		return Ref<Texture2D>();
 	}
 
-	Ref<Texture2D> existing_thumbnail = asset->get_preview_texture();
-	if (existing_thumbnail.is_valid()) {
-		p_metadata[StringName("gaussian_preview_source")] = String("stored_thumbnail");
-		return existing_thumbnail;
+	if (Thread::is_main_thread()) {
+		Ref<Texture2D> existing_thumbnail = asset->get_preview_texture();
+		if (existing_thumbnail.is_valid()) {
+			p_metadata[StringName("gaussian_preview_source")] = String("stored_thumbnail");
+			return existing_thumbnail;
+		}
+	} else {
+		Ref<Texture2D> existing_thumbnail = _create_preview_texture_from_image(asset->get_preview_image());
+		if (existing_thumbnail.is_valid()) {
+			p_metadata[StringName("gaussian_preview_source")] = String("stored_thumbnail");
+			return existing_thumbnail;
+		}
 	}
 
 	if (thumbnail_generator.is_null()) {
@@ -37,7 +84,11 @@ Ref<Texture2D> GaussianSplatAssetPreviewGenerator::generate(const Ref<Resource> 
 
 	const int thumbnail_size = MAX(64, int(MAX(p_size.x, p_size.y)));
 	p_metadata[StringName("gaussian_preview_source")] = String("generated_thumbnail");
-	return thumbnail_generator->generate_thumbnail(asset, thumbnail_size, GaussianThumbnailGenerator::THUMBNAIL_STYLE_COLOR);
+	if (Thread::is_main_thread()) {
+		return thumbnail_generator->generate_thumbnail(asset, thumbnail_size, GaussianThumbnailGenerator::THUMBNAIL_STYLE_COLOR);
+	}
+	return _create_preview_texture_from_image(
+			thumbnail_generator->generate_thumbnail_image(asset, thumbnail_size, GaussianThumbnailGenerator::THUMBNAIL_STYLE_COLOR));
 }
 
 Ref<Texture2D> GaussianSplatAssetPreviewGenerator::generate_from_path(const String &p_path, const Size2 &p_size, Dictionary &p_metadata) const {

--- a/modules/gaussian_splatting/editor/gaussian_thumbnail_generator.cpp
+++ b/modules/gaussian_splatting/editor/gaussian_thumbnail_generator.cpp
@@ -104,39 +104,41 @@ static void _mix_color_array_samples(uint64_t &r_hash, const PackedColorArray &p
 
 } // namespace
 
-uint64_t GaussianThumbnailGenerator::_compute_asset_fingerprint(const Ref<GaussianSplatAsset> &p_asset) const {
+uint64_t GaussianThumbnailGenerator::_compute_asset_fingerprint(const Ref<GaussianSplatAsset> &p_asset,
+        const GaussianSplatAsset::PayloadSnapshot &p_snapshot) const {
     if (p_asset.is_null()) {
         return 0;
     }
 
     uint64_t hash = 1469598103934665603ULL;
-    hash = _mix_hash64(hash, uint64_t(p_asset->get_splat_count()));
-    hash = _mix_hash64(hash, uint64_t(p_asset->get_compression_flags()));
-    hash = _mix_hash64(hash, uint64_t(p_asset->get_source_path().hash()));
+    hash = _mix_hash64(hash, uint64_t(p_snapshot.splat_count));
+    hash = _mix_hash64(hash, uint64_t(p_snapshot.compression_flags));
+    hash = _mix_hash64(hash, uint64_t(String(p_snapshot.import_metadata.get(StringName("source_path"), String())).hash()));
     hash = _mix_hash64(hash, uint64_t(p_asset->get_path().hash()));
 
-    Dictionary metadata = p_asset->get_import_metadata();
+    const Dictionary &metadata = p_snapshot.import_metadata;
     if (!metadata.is_empty()) {
         hash = _mix_hash64(hash, uint64_t(String(metadata.get(StringName("import_time"), String())).hash()));
         hash = _mix_hash64(hash, uint64_t(String(metadata.get(StringName("source_file"), String())).hash()));
     }
 
-    _mix_float_array_samples(hash, p_asset->get_positions());
-    _mix_color_array_samples(hash, p_asset->get_colors());
-    _mix_float_array_samples(hash, p_asset->get_scales());
-    _mix_float_array_samples(hash, p_asset->get_rotations());
-    _mix_float_array_samples(hash, p_asset->get_opacities());
-    _mix_float_array_samples(hash, p_asset->get_normals());
+    _mix_float_array_samples(hash, p_snapshot.positions);
+    _mix_color_array_samples(hash, p_snapshot.colors);
+    _mix_float_array_samples(hash, p_snapshot.scales);
+    _mix_float_array_samples(hash, p_snapshot.rotations);
+    _mix_float_array_samples(hash, p_snapshot.opacity_logits);
+    _mix_float_array_samples(hash, p_snapshot.normals);
 
     return hash;
 }
 
-String GaussianThumbnailGenerator::_build_cache_key(const Ref<GaussianSplatAsset> &p_asset, int p_size, ThumbnailStyle p_style) const {
+String GaussianThumbnailGenerator::_build_cache_key(const Ref<GaussianSplatAsset> &p_asset,
+        const GaussianSplatAsset::PayloadSnapshot &p_snapshot, int p_size, ThumbnailStyle p_style) const {
     if (p_asset.is_null()) {
         return String();
     }
 
-    String asset_id = p_asset->get_source_path();
+    String asset_id = p_snapshot.import_metadata.get(StringName("source_path"), String());
     if (asset_id.is_empty()) {
         asset_id = p_asset->get_path();
     }
@@ -144,7 +146,7 @@ String GaussianThumbnailGenerator::_build_cache_key(const Ref<GaussianSplatAsset
         asset_id = "<in-memory>";
     }
 
-    const uint64_t fingerprint = _compute_asset_fingerprint(p_asset);
+    const uint64_t fingerprint = _compute_asset_fingerprint(p_asset, p_snapshot);
     return asset_id + "|" + String::num_uint64(fingerprint) + "|" + itos(p_size) + "|" + itos(int(p_style));
 }
 
@@ -211,7 +213,7 @@ void GaussianThumbnailGenerator::_save_to_disk_cache(uint64_t p_fingerprint, int
     p_image->save_png(path);
 }
 
-Dictionary GaussianThumbnailGenerator::_project_to_canvas(const Ref<GaussianSplatAsset> &p_asset, int p_size,
+Dictionary GaussianThumbnailGenerator::_project_to_canvas(const GaussianSplatAsset::PayloadSnapshot &p_snapshot, int p_size,
         Vector<int> &r_hits, Vector<Color> &r_accum) const {
     Dictionary result;
     r_hits.clear();
@@ -227,10 +229,10 @@ Dictionary GaussianThumbnailGenerator::_project_to_canvas(const Ref<GaussianSpla
         accum_ptr[i] = Color();
     }
 
-    PackedFloat32Array positions = p_asset->get_positions();
-    PackedColorArray colors = p_asset->get_colors();
-    PackedFloat32Array scales = p_asset->get_scales();
-    const int splat_count = p_asset->get_splat_count();
+    const PackedFloat32Array &positions = p_snapshot.positions;
+    const PackedColorArray &colors = p_snapshot.colors;
+    const PackedFloat32Array &scales = p_snapshot.scales;
+    const int splat_count = p_snapshot.splat_count;
 
     Vector3 min_pos(FLT_MAX, FLT_MAX, FLT_MAX);
     Vector3 max_pos(-FLT_MAX, -FLT_MAX, -FLT_MAX);
@@ -300,10 +302,10 @@ Dictionary GaussianThumbnailGenerator::_project_to_canvas(const Ref<GaussianSpla
     return result;
 }
 
-Ref<Image> GaussianThumbnailGenerator::_generate_color_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const {
+Ref<Image> GaussianThumbnailGenerator::_generate_color_thumbnail(const GaussianSplatAsset::PayloadSnapshot &p_snapshot, int p_size) const {
     Vector<int> hits;
     Vector<Color> accum;
-    _project_to_canvas(p_asset, p_size, hits, accum);
+    _project_to_canvas(p_snapshot, p_size, hits, accum);
 
     Ref<Image> image = Image::create_empty(p_size, p_size, false, Image::FORMAT_RGBA8);
     image->fill(Color(0.08f, 0.08f, 0.08f, 1.0f));
@@ -323,10 +325,10 @@ Ref<Image> GaussianThumbnailGenerator::_generate_color_thumbnail(const Ref<Gauss
     return image;
 }
 
-Ref<Image> GaussianThumbnailGenerator::_generate_density_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const {
+Ref<Image> GaussianThumbnailGenerator::_generate_density_thumbnail(const GaussianSplatAsset::PayloadSnapshot &p_snapshot, int p_size) const {
     Vector<int> hits;
     Vector<Color> accum;
-    _project_to_canvas(p_asset, p_size, hits, accum);
+    _project_to_canvas(p_snapshot, p_size, hits, accum);
 
     int max_hit = 1;
     const int *hits_ptr = hits.ptr();
@@ -349,18 +351,18 @@ Ref<Image> GaussianThumbnailGenerator::_generate_density_thumbnail(const Ref<Gau
     return image;
 }
 
-Ref<Image> GaussianThumbnailGenerator::_generate_normals_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const {
+Ref<Image> GaussianThumbnailGenerator::_generate_normals_thumbnail(const GaussianSplatAsset::PayloadSnapshot &p_snapshot, int p_size) const {
     Vector<int> hits;
     Vector<Color> accum;
-    Dictionary projection = _project_to_canvas(p_asset, p_size, hits, accum);
+    Dictionary projection = _project_to_canvas(p_snapshot, p_size, hits, accum);
 
     Ref<Image> image = Image::create_empty(p_size, p_size, false, Image::FORMAT_RGBA8);
     image->fill(Color(0.3f, 0.3f, 0.4f, 1.0f));
 
-    PackedFloat32Array positions = p_asset->get_positions();
-    PackedFloat32Array rotations = p_asset->get_rotations();
-    PackedFloat32Array normals_array = p_asset->get_normals();
-    const int splat_count = p_asset->get_splat_count();
+    const PackedFloat32Array &positions = p_snapshot.positions;
+    const PackedFloat32Array &rotations = p_snapshot.rotations;
+    const PackedFloat32Array &normals_array = p_snapshot.normals;
+    const int splat_count = p_snapshot.splat_count;
     const int rot_size = rotations.size();
     const bool has_normals = normals_array.size() >= splat_count * 3;
 
@@ -428,10 +430,10 @@ Ref<Image> GaussianThumbnailGenerator::_generate_normals_thumbnail(const Ref<Gau
     return image;
 }
 
-Ref<Image> GaussianThumbnailGenerator::_generate_heatmap_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const {
+Ref<Image> GaussianThumbnailGenerator::_generate_heatmap_thumbnail(const GaussianSplatAsset::PayloadSnapshot &p_snapshot, int p_size) const {
     Vector<int> hits;
     Vector<Color> accum;
-    _project_to_canvas(p_asset, p_size, hits, accum);
+    _project_to_canvas(p_snapshot, p_size, hits, accum);
 
     int max_hit = 1;
     const int *hits_ptr = hits.ptr();
@@ -462,10 +464,11 @@ Ref<Image> GaussianThumbnailGenerator::generate_thumbnail_image(const Ref<Gaussi
         ThumbnailStyle p_style) const {
     ERR_FAIL_COND_V(p_size <= 0, Ref<Image>());
     ERR_FAIL_COND_V(p_asset.is_null(), Ref<Image>());
-    ERR_FAIL_COND_V(p_asset->get_splat_count() == 0, Ref<Image>());
+    const GaussianSplatAsset::PayloadSnapshot snapshot = p_asset->capture_payload_snapshot();
+    ERR_FAIL_COND_V(snapshot.splat_count == 0, Ref<Image>());
 
-    const String cache_key = _build_cache_key(p_asset, p_size, p_style);
-    const uint64_t fingerprint = _compute_asset_fingerprint(p_asset);
+    const String cache_key = _build_cache_key(p_asset, snapshot, p_size, p_style);
+    const uint64_t fingerprint = _compute_asset_fingerprint(p_asset, snapshot);
 
     // Check in-memory cache first.
     if (!cache_key.is_empty()) {
@@ -497,19 +500,19 @@ Ref<Image> GaussianThumbnailGenerator::generate_thumbnail_image(const Ref<Gaussi
 
     switch (p_style) {
         case THUMBNAIL_STYLE_COLOR:
-            generated = _generate_color_thumbnail(p_asset, p_size);
+            generated = _generate_color_thumbnail(snapshot, p_size);
             break;
         case THUMBNAIL_STYLE_DENSITY:
-            generated = _generate_density_thumbnail(p_asset, p_size);
+            generated = _generate_density_thumbnail(snapshot, p_size);
             break;
         case THUMBNAIL_STYLE_NORMALS:
-            generated = _generate_normals_thumbnail(p_asset, p_size);
+            generated = _generate_normals_thumbnail(snapshot, p_size);
             break;
         case THUMBNAIL_STYLE_HEATMAP:
-            generated = _generate_heatmap_thumbnail(p_asset, p_size);
+            generated = _generate_heatmap_thumbnail(snapshot, p_size);
             break;
         default:
-            generated = _generate_color_thumbnail(p_asset, p_size);
+            generated = _generate_color_thumbnail(snapshot, p_size);
             break;
     }
 
@@ -531,16 +534,15 @@ Ref<Image> GaussianThumbnailGenerator::generate_thumbnail_image(const Ref<Gaussi
 
 Ref<Texture2D> GaussianThumbnailGenerator::generate_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size,
         ThumbnailStyle p_style) const {
+    ERR_FAIL_COND_V_MSG(!Thread::is_main_thread(), Ref<Texture2D>(),
+            "GaussianThumbnailGenerator::generate_thumbnail() creates an ImageTexture and must run on the main thread. Use generate_thumbnail_image() from worker/import paths.");
     Ref<Image> image = generate_thumbnail_image(p_asset, p_size, p_style);
     if (image.is_null() || image->is_empty()) {
         return Ref<Texture2D>();
     }
 
-    // Safe to call from `EditorResourcePreview`'s worker threads in editor
-    // mode: the main thread pumps the RS command queue so the sync RS call
-    // chain underneath `create_from_image` completes. The `--headless
-    // --import` deadlock case that motivated #251 is avoided by having the
-    // importer call `generate_thumbnail_image()` directly (no RS calls).
+    // Texture creation crosses RenderingServer state. Worker/import paths must
+    // remain CPU-only and use generate_thumbnail_image().
     return ImageTexture::create_from_image(image);
 }
 

--- a/modules/gaussian_splatting/editor/gaussian_thumbnail_generator.h
+++ b/modules/gaussian_splatting/editor/gaussian_thumbnail_generator.h
@@ -36,8 +36,10 @@ private:
     mutable uint64_t disk_cache_hit_count = 0;
     mutable uint64_t disk_cache_miss_count = 0;
 
-    String _build_cache_key(const Ref<GaussianSplatAsset> &p_asset, int p_size, ThumbnailStyle p_style) const;
-    uint64_t _compute_asset_fingerprint(const Ref<GaussianSplatAsset> &p_asset) const;
+    String _build_cache_key(const Ref<GaussianSplatAsset> &p_asset, const GaussianSplatAsset::PayloadSnapshot &p_snapshot,
+            int p_size, ThumbnailStyle p_style) const;
+    uint64_t _compute_asset_fingerprint(const Ref<GaussianSplatAsset> &p_asset,
+            const GaussianSplatAsset::PayloadSnapshot &p_snapshot) const;
     void _touch_cache_key(const String &p_key) const;
     void _prune_cache_if_needed() const;
 
@@ -47,12 +49,12 @@ private:
     void _save_to_disk_cache(uint64_t p_fingerprint, int p_size, ThumbnailStyle p_style, const Ref<Image> &p_image) const;
     bool _ensure_disk_cache_dir() const;
 
-    Ref<Image> _generate_color_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const;
-    Ref<Image> _generate_density_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const;
-    Ref<Image> _generate_normals_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const;
-    Ref<Image> _generate_heatmap_thumbnail(const Ref<GaussianSplatAsset> &p_asset, int p_size) const;
+    Ref<Image> _generate_color_thumbnail(const GaussianSplatAsset::PayloadSnapshot &p_snapshot, int p_size) const;
+    Ref<Image> _generate_density_thumbnail(const GaussianSplatAsset::PayloadSnapshot &p_snapshot, int p_size) const;
+    Ref<Image> _generate_normals_thumbnail(const GaussianSplatAsset::PayloadSnapshot &p_snapshot, int p_size) const;
+    Ref<Image> _generate_heatmap_thumbnail(const GaussianSplatAsset::PayloadSnapshot &p_snapshot, int p_size) const;
 
-    Dictionary _project_to_canvas(const Ref<GaussianSplatAsset> &p_asset, int p_size, Vector<int> &r_hits,
+    Dictionary _project_to_canvas(const GaussianSplatAsset::PayloadSnapshot &p_snapshot, int p_size, Vector<int> &r_hits,
             Vector<Color> &r_accum) const;
 
 public:

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -385,10 +385,7 @@ void GaussianSplatNode3D::_notification_enter_world() {
 }
 
 void GaussianSplatNode3D::_notification_exit_tree() {
-    if (debug_hud_control) {
-        debug_hud_control->set_visible(false);
-        debug_hud_control->set_process(false);
-    }
+    _destroy_debug_hud_control();
     visible_in_viewport = false;
     _update_visibility();
     _clear_parent_visibility_tracking();
@@ -2041,16 +2038,36 @@ void GaussianSplatNode3D::_ensure_debug_hud_control() {
     debug_hud_layer->add_child(debug_hud_control);
 }
 
+void GaussianSplatNode3D::_destroy_debug_hud_control() {
+    if (debug_hud_control) {
+        debug_hud_control->set_splat_node(nullptr);
+        debug_hud_control->set_visible(false);
+        debug_hud_control->set_process(false);
+        Node *parent = debug_hud_control->get_parent();
+        if (parent) {
+            parent->remove_child(debug_hud_control);
+        }
+        memdelete(debug_hud_control);
+        debug_hud_control = nullptr;
+    }
+
+    if (debug_hud_layer) {
+        Node *parent = debug_hud_layer->get_parent();
+        if (parent) {
+            parent->remove_child(debug_hud_layer);
+        }
+        memdelete(debug_hud_layer);
+        debug_hud_layer = nullptr;
+    }
+}
+
 void GaussianSplatNode3D::_update_debug_hud_visibility() {
     bool should_show_hud = show_performance_hud || show_residency_hud;
     if (renderer.is_valid()) {
         should_show_hud = renderer->is_debug_show_performance_hud() || renderer->is_debug_show_residency_hud();
     }
     if (!should_show_hud) {
-        if (debug_hud_control) {
-            debug_hud_control->set_visible(false);
-            debug_hud_control->set_process(false);
-        }
+        _destroy_debug_hud_control();
         return;
     }
 

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.h
@@ -316,6 +316,7 @@ private:
             bool adaptive_quality, int effective_stream_budget_ms, bool async_loading, bool compression);
     void _fill_preset_config(QualityPreset p_preset, Dictionary &config) const;
     void _ensure_debug_hud_control();
+    void _destroy_debug_hud_control();
     void _update_debug_hud_visibility();
 
     void _ensure_renderer();

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
@@ -136,10 +136,11 @@ void GaussianSplatNodeAssetHelper::update_asset() {
         return;
     }
 
-    owner.total_splat_count = owner.splat_asset->get_splat_count();
+    const GaussianSplatAsset::PayloadSnapshot asset_snapshot = owner.splat_asset->capture_payload_snapshot();
+    owner.total_splat_count = asset_snapshot.splat_count;
 
     // Read import settings from asset metadata
-    Dictionary import_metadata = owner.splat_asset->get_import_metadata();
+    Dictionary import_metadata = asset_snapshot.import_metadata;
     if (import_metadata.has(StringName("enable_lod"))) {
         owner.asset_lod_enabled = (bool)import_metadata[StringName("enable_lod")];
     } else {
@@ -171,8 +172,8 @@ void GaussianSplatNodeAssetHelper::update_asset() {
         }
     }
 
-    PackedFloat32Array positions = owner.splat_asset->get_positions();
-    PackedFloat32Array scales = owner.splat_asset->get_scales();
+    const PackedFloat32Array &positions = asset_snapshot.positions;
+    const PackedFloat32Array &scales = asset_snapshot.scales;
     bool recomputed_bounds = false;
     if (!used_cached_bounds && positions.size() >= 3) {
         Vector3 min_pos = Vector3(INFINITY, INFINITY, INFINITY);
@@ -220,18 +221,18 @@ void GaussianSplatNodeAssetHelper::update_asset() {
 
     double total_bytes = 0.0;
     total_bytes += double(positions.size()) * sizeof(float);
-    total_bytes += double(owner.splat_asset->get_colors().size()) * sizeof(Color);
-    total_bytes += double(owner.splat_asset->get_scales().size()) * sizeof(float);
-    total_bytes += double(owner.splat_asset->get_rotations().size()) * sizeof(float);
-    total_bytes += double(owner.splat_asset->get_sh_dc_coefficients().size()) * sizeof(float);
-    total_bytes += double(owner.splat_asset->get_sh_first_order_coefficients().size()) * sizeof(float);
-    total_bytes += double(owner.splat_asset->get_sh_high_order_coefficients().size()) * sizeof(float);
-    total_bytes += double(owner.splat_asset->get_opacity_logits().size()) * sizeof(float);
-    total_bytes += double(owner.splat_asset->get_palette_ids().size()) * sizeof(int32_t);
-    total_bytes += double(owner.splat_asset->get_painterly_flags().size()) * sizeof(int32_t);
-    total_bytes += double(owner.splat_asset->get_normals().size()) * sizeof(float);
-    total_bytes += double(owner.splat_asset->get_brush_axes().size()) * sizeof(float);
-    total_bytes += double(owner.splat_asset->get_stroke_ages().size()) * sizeof(float);
+    total_bytes += double(asset_snapshot.colors.size()) * sizeof(Color);
+    total_bytes += double(asset_snapshot.scales.size()) * sizeof(float);
+    total_bytes += double(asset_snapshot.rotations.size()) * sizeof(float);
+    total_bytes += double(asset_snapshot.sh_dc_coefficients.size()) * sizeof(float);
+    total_bytes += double(asset_snapshot.sh_first_order_coefficients.size()) * sizeof(float);
+    total_bytes += double(asset_snapshot.sh_high_order_coefficients.size()) * sizeof(float);
+    total_bytes += double(asset_snapshot.opacity_logits.size()) * sizeof(float);
+    total_bytes += double(asset_snapshot.palette_ids.size()) * sizeof(int32_t);
+    total_bytes += double(asset_snapshot.painterly_flags.size()) * sizeof(int32_t);
+    total_bytes += double(asset_snapshot.normals.size()) * sizeof(float);
+    total_bytes += double(asset_snapshot.brush_axes.size()) * sizeof(float);
+    total_bytes += double(asset_snapshot.stroke_ages.size()) * sizeof(float);
     owner.gpu_memory_mb = total_bytes / (1024.0 * 1024.0);
 
     owner._update_bounds();

--- a/modules/gaussian_splatting/tests/test_data_authority_hardening.h
+++ b/modules/gaussian_splatting/tests/test_data_authority_hardening.h
@@ -22,6 +22,7 @@
 #include "../core/gaussian_data.h"
 #include "../core/gaussian_splat_asset.h"
 #include "core/io/resource.h"
+#include "core/os/semaphore.h"
 #include "core/os/thread.h"
 #include "core/templates/local_vector.h"
 #include "tests/test_macros.h"
@@ -118,6 +119,210 @@ static void _animated_accessor_reader_thread(void *p_userdata) {
         }
 
         Thread::yield();
+    }
+}
+#endif
+
+static Ref<GaussianSplatAsset> _make_asset_snapshot_pattern(float p_marker, const Color &p_color) {
+    Ref<GaussianSplatAsset> asset;
+    asset.instantiate();
+
+    constexpr int splat_count = 8;
+    asset->set_splat_count(splat_count);
+
+    PackedFloat32Array positions;
+    positions.resize(splat_count * 3);
+    PackedColorArray colors;
+    colors.resize(splat_count);
+    PackedFloat32Array scales;
+    scales.resize(splat_count * 3);
+    PackedFloat32Array rotations;
+    rotations.resize(splat_count * 4);
+    PackedFloat32Array opacity_logits;
+    opacity_logits.resize(splat_count);
+    PackedInt32Array palette_ids;
+    palette_ids.resize(splat_count);
+    PackedInt32Array painterly_flags;
+    painterly_flags.resize(splat_count);
+    PackedFloat32Array normals;
+    normals.resize(splat_count * 3);
+    PackedFloat32Array brush_axes;
+    brush_axes.resize(splat_count * 2);
+    PackedFloat32Array stroke_ages;
+    stroke_ages.resize(splat_count);
+
+    for (int i = 0; i < splat_count; i++) {
+        positions.set(i * 3 + 0, p_marker);
+        positions.set(i * 3 + 1, p_marker + float(i));
+        positions.set(i * 3 + 2, -p_marker);
+        colors.set(i, p_color);
+        scales.set(i * 3 + 0, Math::abs(p_marker) + 1.0f);
+        scales.set(i * 3 + 1, Math::abs(p_marker) + 2.0f);
+        scales.set(i * 3 + 2, Math::abs(p_marker) + 3.0f);
+        rotations.set(i * 4 + 0, 1.0f);
+        rotations.set(i * 4 + 1, 0.0f);
+        rotations.set(i * 4 + 2, 0.0f);
+        rotations.set(i * 4 + 3, 0.0f);
+        opacity_logits.set(i, p_marker);
+        palette_ids.set(i, int(p_marker) & 0xffff);
+        painterly_flags.set(i, (int(p_marker) + 7) & 0xffff);
+        normals.set(i * 3 + 0, 0.0f);
+        normals.set(i * 3 + 1, p_marker > 0.0f ? 1.0f : -1.0f);
+        normals.set(i * 3 + 2, 0.0f);
+        brush_axes.set(i * 2 + 0, p_marker);
+        brush_axes.set(i * 2 + 1, p_marker + 0.5f);
+        stroke_ages.set(i, p_marker + float(i) * 0.25f);
+    }
+
+    asset->set_positions(positions);
+    asset->set_colors(colors);
+    asset->set_scales(scales);
+    asset->set_rotations(rotations);
+    asset->set_opacity_logits(opacity_logits);
+    asset->set_palette_ids(palette_ids);
+    asset->set_painterly_flags(painterly_flags);
+    asset->set_normals(normals);
+    asset->set_brush_axes(brush_axes);
+    asset->set_stroke_ages(stroke_ages);
+    asset->set_source_path(vformat("res://snapshot_pattern_%s.ply", p_marker > 0.0f ? "a" : "b"));
+    return asset;
+}
+
+static bool _snapshot_has_expected_core_sizes(const GaussianSplatAsset::PayloadSnapshot &p_snapshot, int p_splat_count) {
+    if (p_snapshot.splat_count != uint32_t(p_splat_count)) {
+        return false;
+    }
+    if (p_snapshot.positions.size() != p_splat_count * 3 || p_snapshot.colors.size() != p_splat_count) {
+        return false;
+    }
+    if (p_snapshot.scales.size() != p_splat_count * 3 || p_snapshot.rotations.size() != p_splat_count * 4) {
+        return false;
+    }
+    return p_snapshot.opacity_logits.size() == p_splat_count;
+}
+
+static bool _snapshot_has_expected_painterly_sizes(const GaussianSplatAsset::PayloadSnapshot &p_snapshot, int p_splat_count) {
+    if (p_snapshot.palette_ids.size() != p_splat_count || p_snapshot.painterly_flags.size() != p_splat_count) {
+        return false;
+    }
+    if (p_snapshot.normals.size() != p_splat_count * 3 || p_snapshot.brush_axes.size() != p_splat_count * 2) {
+        return false;
+    }
+    return p_snapshot.stroke_ages.size() == p_splat_count;
+}
+
+static bool _snapshot_entry_core_matches(const GaussianSplatAsset::PayloadSnapshot &p_snapshot, int p_index, float p_marker, const Color &p_color) {
+    if (!Math::is_equal_approx(p_snapshot.positions[p_index * 3 + 0], p_marker)) {
+        return false;
+    }
+    if (!Math::is_equal_approx(p_snapshot.positions[p_index * 3 + 1], p_marker + float(p_index))) {
+        return false;
+    }
+    if (!Math::is_equal_approx(p_snapshot.positions[p_index * 3 + 2], -p_marker)) {
+        return false;
+    }
+    if (p_snapshot.colors[p_index] != p_color) {
+        return false;
+    }
+    return Math::is_equal_approx(p_snapshot.scales[p_index * 3 + 0], Math::abs(p_marker) + 1.0f);
+}
+
+static bool _snapshot_entry_metadata_matches(const GaussianSplatAsset::PayloadSnapshot &p_snapshot, int p_index, float p_marker) {
+    if (!Math::is_equal_approx(p_snapshot.opacity_logits[p_index], p_marker)) {
+        return false;
+    }
+    if (p_snapshot.palette_ids[p_index] != (int(p_marker) & 0xffff)) {
+        return false;
+    }
+    return p_snapshot.painterly_flags[p_index] == ((int(p_marker) + 7) & 0xffff);
+}
+
+static bool _snapshot_entry_painterly_matches(const GaussianSplatAsset::PayloadSnapshot &p_snapshot, int p_index, float p_marker) {
+    const float expected_normal_y = p_marker > 0.0f ? 1.0f : -1.0f;
+    if (!Math::is_equal_approx(p_snapshot.normals[p_index * 3 + 1], expected_normal_y)) {
+        return false;
+    }
+    if (!Math::is_equal_approx(p_snapshot.brush_axes[p_index * 2 + 0], p_marker)) {
+        return false;
+    }
+    return Math::is_equal_approx(p_snapshot.stroke_ages[p_index], p_marker + float(p_index) * 0.25f);
+}
+
+static bool _snapshot_entry_matches_pattern(const GaussianSplatAsset::PayloadSnapshot &p_snapshot, int p_index, float p_marker, const Color &p_color) {
+    return _snapshot_entry_core_matches(p_snapshot, p_index, p_marker, p_color) &&
+            _snapshot_entry_metadata_matches(p_snapshot, p_index, p_marker) &&
+            _snapshot_entry_painterly_matches(p_snapshot, p_index, p_marker);
+}
+
+static bool _snapshot_matches_pattern(const GaussianSplatAsset::PayloadSnapshot &p_snapshot, float p_marker, const Color &p_color) {
+    constexpr int splat_count = 8;
+    if (!_snapshot_has_expected_core_sizes(p_snapshot, splat_count)) {
+        return false;
+    }
+    if (!_snapshot_has_expected_painterly_sizes(p_snapshot, splat_count)) {
+        return false;
+    }
+
+    for (int i = 0; i < splat_count; i++) {
+        if (!_snapshot_entry_matches_pattern(p_snapshot, i, p_marker, p_color)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+#ifdef THREADS_ENABLED
+struct _AssetSnapshotCopyRaceContext {
+    Ref<GaussianSplatAsset> target;
+    Ref<GaussianSplatAsset> asset_a;
+    Ref<GaussianSplatAsset> asset_b;
+    std::atomic<bool> stop{ false };
+    std::atomic<int> invalid_snapshots{ 0 };
+    Semaphore writer_begin;
+    Semaphore writer_done;
+    Semaphore reader_begin;
+    Semaphore reader_done;
+};
+
+static void _asset_snapshot_writer_thread(void *p_userdata) {
+    _AssetSnapshotCopyRaceContext *ctx = static_cast<_AssetSnapshotCopyRaceContext *>(p_userdata);
+    if (!ctx || ctx->target.is_null() || ctx->asset_a.is_null() || ctx->asset_b.is_null()) {
+        return;
+    }
+
+    int iteration = 0;
+    while (true) {
+        ctx->writer_begin.wait();
+        if (ctx->stop.load(std::memory_order_acquire)) {
+            break;
+        }
+
+        Ref<Resource> source = (iteration % 2) == 0 ? ctx->asset_a : ctx->asset_b;
+        ctx->target->copy_from(source);
+        iteration++;
+        ctx->writer_done.post();
+    }
+}
+
+static void _asset_snapshot_reader_thread(void *p_userdata) {
+    _AssetSnapshotCopyRaceContext *ctx = static_cast<_AssetSnapshotCopyRaceContext *>(p_userdata);
+    if (!ctx || ctx->target.is_null()) {
+        return;
+    }
+
+    while (true) {
+        ctx->reader_begin.wait();
+        if (ctx->stop.load(std::memory_order_acquire)) {
+            break;
+        }
+
+        const GaussianSplatAsset::PayloadSnapshot snapshot = ctx->target->capture_payload_snapshot();
+        const bool matches_a = _snapshot_matches_pattern(snapshot, 11.0f, Color(1, 0, 0, 1));
+        const bool matches_b = _snapshot_matches_pattern(snapshot, -23.0f, Color(0, 1, 0, 1));
+        if (!matches_a && !matches_b) {
+            ctx->invalid_snapshots.fetch_add(1, std::memory_order_relaxed);
+        }
+        ctx->reader_done.post();
     }
 }
 #endif
@@ -396,6 +601,56 @@ TEST_CASE("[GaussianSplatting][DataAuthority] GaussianSplatAsset packed setters 
     rewrite_data.instantiate();
     rewrite_data->set_gaussians(_make_authority_test_cloud());
     REQUIRE(asset->populate_from_gaussian_data(rewrite_data) == OK);
+}
+
+TEST_CASE("[GaussianSplatting][DataAuthority] GaussianSplatAsset payload snapshots stay coherent across copy_from reloads") {
+#ifndef THREADS_ENABLED
+    MESSAGE("Skipping - THREADS_ENABLED is not enabled in this build");
+    return;
+#else
+    Ref<GaussianSplatAsset> asset_a = _make_asset_snapshot_pattern(11.0f, Color(1, 0, 0, 1));
+    Ref<GaussianSplatAsset> asset_b = _make_asset_snapshot_pattern(-23.0f, Color(0, 1, 0, 1));
+    Ref<GaussianSplatAsset> target = _make_asset_snapshot_pattern(11.0f, Color(1, 0, 0, 1));
+
+    // Seal the target first so copy_from() also proves the hot-reload unseal
+    // path is serialized against snapshot reads.
+    Ref<::GaussianData> runtime = target->get_gaussian_data();
+    REQUIRE(runtime.is_valid());
+
+    _AssetSnapshotCopyRaceContext ctx;
+    ctx.target = target;
+    ctx.asset_a = asset_a;
+    ctx.asset_b = asset_b;
+
+    Thread writer_thread;
+    Thread reader_thread;
+    writer_thread.start(_asset_snapshot_writer_thread, &ctx);
+    reader_thread.start(_asset_snapshot_reader_thread, &ctx);
+
+    constexpr uint32_t iterations = 128;
+    for (uint32_t i = 0; i < iterations; i++) {
+        if ((i % 2) == 0) {
+            ctx.writer_begin.post();
+            Thread::yield();
+            ctx.reader_begin.post();
+        } else {
+            ctx.reader_begin.post();
+            Thread::yield();
+            ctx.writer_begin.post();
+        }
+        ctx.writer_done.wait();
+        ctx.reader_done.wait();
+    }
+
+    ctx.stop.store(true, std::memory_order_release);
+    ctx.writer_begin.post();
+    ctx.reader_begin.post();
+    writer_thread.wait_to_finish();
+    reader_thread.wait_to_finish();
+
+    CHECK_MESSAGE(ctx.invalid_snapshots.load(std::memory_order_acquire) == 0,
+            "Payload snapshots must observe one complete asset generation, never mixed arrays/metadata during copy_from().");
+#endif
 }
 
 TEST_CASE("[GaussianSplatting][DataAuthority] Raw storage accessors compile-survivable and main-thread safe") {

--- a/modules/gaussian_splatting/tests/test_debug_hud_lifecycle.h
+++ b/modules/gaussian_splatting/tests/test_debug_hud_lifecycle.h
@@ -71,4 +71,38 @@ TEST_CASE("[GaussianSplatting][SceneTree] Debug HUD preserves owner-controlled p
 	memdelete(hud);
 }
 
+TEST_CASE("[GaussianSplatting][SceneTree] GaussianSplatNode3D destroys owned debug HUD on disable and exit") {
+	SceneTree *tree = SceneTree::get_singleton();
+	REQUIRE_MESSAGE(tree != nullptr, "SceneTree must exist (provided by [SceneTree] tag)");
+
+	Window *root = tree->get_root();
+	REQUIRE_MESSAGE(root != nullptr, "SceneTree root window must exist");
+
+	GaussianSplatNode3D *node = memnew(GaussianSplatNode3D);
+	root->add_child(node);
+	tree->process(0.0);
+
+	node->set_show_performance_hud(true);
+	tree->process(0.0);
+	CHECK(node->find_child("GaussianSplatDebugHUDLayer", true, false) != nullptr);
+	CHECK(node->find_child("GaussianSplatDebugHUD", true, false) != nullptr);
+
+	node->set_show_performance_hud(false);
+	tree->process(0.0);
+	CHECK(node->find_child("GaussianSplatDebugHUDLayer", true, false) == nullptr);
+	CHECK(node->find_child("GaussianSplatDebugHUD", true, false) == nullptr);
+
+	node->set_show_residency_hud(true);
+	tree->process(0.0);
+	CHECK(node->find_child("GaussianSplatDebugHUDLayer", true, false) != nullptr);
+	CHECK(node->find_child("GaussianSplatDebugHUD", true, false) != nullptr);
+
+	root->remove_child(node);
+	tree->process(0.0);
+	CHECK(node->find_child("GaussianSplatDebugHUDLayer", true, false) == nullptr);
+	CHECK(node->find_child("GaussianSplatDebugHUD", true, false) == nullptr);
+
+	memdelete(node);
+}
+
 #endif // TESTS_ENABLED || TOOLS_ENABLED

--- a/modules/gaussian_splatting/tests/test_gaussian_importer.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_importer.h
@@ -12,6 +12,7 @@
 #include "../editor/gaussian_import_dialog.h"
 #include "../editor/gaussian_editor_plugin.h"
 #include "../editor/gaussian_import_settings_dialog.h"
+#include "../editor/gaussian_resource_preview_generator.h"
 #include "../editor/gaussian_thumbnail_generator.h"
 #include "../core/gaussian_splat_asset.h"
 #include "../core/gaussian_splat_world.h"
@@ -27,6 +28,10 @@
 #include "core/config/project_settings.h"
 #include "core/templates/hash_map.h"
 #include "core/math/math_funcs.h"
+#include "core/object/message_queue.h"
+#include "core/os/os.h"
+#include "core/os/semaphore.h"
+#include "core/os/thread.h"
 #include "editor/editor_node.h"
 #include "editor/inspector/editor_inspector.h"
 #include "core/string/ustring.h"
@@ -515,6 +520,24 @@ Ref<GaussianSplatAsset> _make_thumbnail_fixture_asset(int p_splat_count = 6) {
     return asset;
 }
 
+struct _PreviewGeneratorThreadContext {
+    Ref<GaussianSplatAsset> asset;
+    Ref<Texture2D> texture;
+    Dictionary metadata;
+    Semaphore done;
+    bool ran_on_worker = false;
+};
+
+static void _preview_generator_thread(void *p_userdata) {
+    _PreviewGeneratorThreadContext *ctx = static_cast<_PreviewGeneratorThreadContext *>(p_userdata);
+    ctx->ran_on_worker = !Thread::is_main_thread();
+
+    Ref<GaussianSplatAssetPreviewGenerator> generator;
+    generator.instantiate();
+    ctx->texture = generator->generate(ctx->asset, Size2(96, 96), ctx->metadata);
+    ctx->done.post();
+}
+
 } // namespace
 
 TEST_CASE("[GaussianSplatting][Importer] PLY importer produces metadata and preview images") {
@@ -883,6 +906,40 @@ TEST_CASE("[GaussianSplatting][Thumbnail] Generator caches deterministic asset+s
 
     stats = generator->get_cache_statistics();
     CHECK(int(stats.get(StringName("entries"), 0)) == 3);
+}
+
+TEST_CASE("[GaussianSplatting][Thumbnail] Editor preview generator uses stored images on worker threads") {
+#ifndef THREADS_ENABLED
+    MESSAGE("Skipping - THREADS_ENABLED is not enabled in this build");
+    return;
+#else
+    Ref<GaussianSplatAsset> asset;
+    asset.instantiate();
+    asset->set_splat_count(1);
+    asset->set_source_path("res://preview_worker_fixture.ply");
+    asset->set_preview_image(_make_thumbnail_test_image());
+
+    _PreviewGeneratorThreadContext ctx;
+    ctx.asset = asset;
+
+    Thread worker;
+    worker.start(_preview_generator_thread, &ctx);
+    CHECK(worker.is_started());
+    if (worker.is_started()) {
+        while (!ctx.done.try_wait()) {
+            CallQueue *main_queue = MessageQueue::get_main_singleton();
+            if (main_queue) {
+                main_queue->flush();
+            }
+            OS::get_singleton()->delay_usec(1000);
+        }
+        worker.wait_to_finish();
+    }
+
+    CHECK(ctx.ran_on_worker);
+    CHECK(ctx.texture.is_valid());
+    CHECK(String(ctx.metadata.get(StringName("gaussian_preview_source"), String())) == "stored_thumbnail");
+#endif
 }
 
 TEST_CASE("[GaussianSplatting][Importer] GaussianSplatAsset serializes preview images without ImageTexture state") {


### PR DESCRIPTION
## Summary
- Adds `GaussianSplatAsset::PayloadSnapshot` / `capture_payload_snapshot()` so multi-field readers can copy one coherent asset generation under `populate_mutex`.
- Moves thumbnail generation and node asset refresh toward the snapshot contract.
- Makes preview texture creation main-thread-only; worker/import paths keep using stored `Image` data and image thumbnail generation.
- Adds explicit node-owned debug HUD destruction and lifecycle regression coverage.
- Adds a threaded snapshot-vs-copy_from race regression for hot-reload coherence.

Fixes #355.

## Validation
- `python3 tests/ci/run_module_tests.py --guard-only --base-ref origin/master`
- `git diff --cached --check` before commit

## Remaining Risk
- Full SceneTree/GPU execution of the new asset-backed hot-swap/reload path was not run in this WSL finalization pass.
- The broader issue still needs an executing GPU lane for canonical `GaussianSplatNode3D + splat_asset` hot-swap/clear/reassign/shared-asset coverage.
- Editor preview worker behavior is now guarded to fail closed for texture creation; follow-up editor testing should verify callers use image-only paths off-thread.
