### PR TITLE
[codex] Codify public alpha release gates

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -39,7 +39,9 @@ The renderer/public-alpha evidence policy is maintained in
 python tests/ci/check_renderer_release_gates.py --mode contract
 ```
 
-The contract check is deterministic and GPU-free. Public-alpha candidate mode
+The same contract check is part of `tests/ci/run_module_tests.py --guard-only`,
+which is what the Gaussian Production Gates `guards` job runs. The contract check
+is deterministic and GPU-free. Public-alpha candidate mode
 requires the evidence bundle, a public-alpha channel/tag selector, and a live
 issue-label snapshot so P0, P1, and release-blocker issues cannot be bypassed by
 release notes or manual workflow choices. The workflow-policy

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,11 +41,18 @@ python tests/ci/check_renderer_release_gates.py --mode contract
 
 The contract check is deterministic and GPU-free. Public-alpha candidate mode
 requires the evidence bundle, a public-alpha channel/tag selector, and a live
-issue-label snapshot so P0, release-blocker, and alpha-relevant P1 issues cannot
-be bypassed by release notes or manual workflow choices. The workflow-policy
+issue-label snapshot so P0, P1, and release-blocker issues cannot be bypassed by
+release notes or manual workflow choices. The workflow-policy
 portion of the checker validates required workflow files and job markers only;
 the stronger no-downgrade workflow rules remain documented review policy until
 the checker grows a real GitHub Actions behavior parser.
+
+External checks are not automatically renderer release blockers. `qlty check`
+is currently documented in the manifest as a deferred, non-blocking external
+signal because `master` branch protection has no required status checks and the
+repo does not track a qlty configuration/log contract. If branch protection
+later requires qlty, update the manifest before treating a qlty result as part
+of public-alpha signoff.
 
 ## Scheduled Triggers
 

--- a/.github/workflows/gaussian_production_gates.yml
+++ b/.github/workflows/gaussian_production_gates.yml
@@ -18,6 +18,10 @@ on:
       - "SConstruct"
       - "tests/**"
       - ".github/workflows/gaussian_production_gates.yml"
+      - ".github/workflows/README.md"
+      - "docs/reference/renderer-release-gates.md"
+      - "docs/reference/renderer_release_gate_manifest.json"
+      - "docs/development/known-public-alpha-limitations.md"
   push:
     branches: [master, develop]
     paths:
@@ -34,6 +38,10 @@ on:
       - "SConstruct"
       - "tests/**"
       - ".github/workflows/gaussian_production_gates.yml"
+      - ".github/workflows/README.md"
+      - "docs/reference/renderer-release-gates.md"
+      - "docs/reference/renderer_release_gate_manifest.json"
+      - "docs/development/known-public-alpha-limitations.md"
   workflow_dispatch:
     inputs:
       run_gpu_lane:

--- a/docs/reference/build-test-ci.md
+++ b/docs/reference/build-test-ci.md
@@ -50,8 +50,15 @@ Required-batch contract: `REQUIRED_BATCHES = {"CompositorHazard"}` is asserted a
 - [Workflow overview](../../.github/workflows/README.md)
 - [Production gate workflow](../../.github/workflows/gaussian_production_gates.yml)
 - [Baseline QA workflow (gpu-tests + gpu-harness visual gate)](../../.github/workflows/baseline_qa.yml)
+- [Renderer release gate contract](renderer-release-gates.md)
 
 Fork-PR safety gate: the `gpu-tests` and `gpu-harness` jobs in `baseline_qa.yml` both guard on `github.event.pull_request.head.repo.full_name == github.repository`, so untrusted fork-PR code never executes on the self-hosted Windows GPU runner. Same-repo branch PRs and the merge queue still exercise the visual gate.
+
+External advisory checks: `qlty check` is not part of the local renderer
+release gate while `master` branch protection has no required status checks and
+the repo has no tracked qlty configuration. Treat qlty as a non-blocking signal
+unless branch protection or `docs/reference/renderer_release_gate_manifest.json`
+is changed to require it.
 
 ## Common Failure Modes
 

--- a/docs/reference/build-test-ci.md
+++ b/docs/reference/build-test-ci.md
@@ -25,6 +25,7 @@ scons platform=<platform> target=editor dev_build=yes tests=yes -j<jobs>
 - Module checks/tests:
   - `python3 tests/ci/run_module_tests.py --guard-only`
   - `python3 tests/ci/run_module_tests.py --godot-binary <module-built-binary>`
+  - `--guard-only` includes the renderer release-gate contract check.
 - Runtime validation:
   - `python3 tests/runtime/run_runtime_validation.py --godot-binary <module-built-binary> --gd-mode headless`
 - Benchmark suite:

--- a/docs/reference/renderer-release-gates.md
+++ b/docs/reference/renderer-release-gates.md
@@ -14,9 +14,9 @@ matches a `v*-alpha*` release tag, then passes the manifest predicate:
 
 - an issue snapshot is required, either through `--issues-json` or an embedded
   candidate evidence `issue_snapshot`;
-- open `priority:P0`, `release blocker`, and alpha-relevant `priority:P1` issues
-  in that snapshot must be classified as `blocking`,
-  `accepted_alpha_limitation`, or `post_alpha`;
+- open `priority:P0`, `priority:P1`, and `release blocker` issues in that
+  snapshot must be classified as `blocking`, `accepted_alpha_limitation`, or
+  `deferred`;
 - any `accepted_alpha_limitation` must have a user-facing entry in
   `docs/development/known-public-alpha-limitations.md`;
 - Linux and Windows artifacts, runtime validation, GPU harness output,
@@ -24,6 +24,51 @@ matches a `v*-alpha*` release tag, then passes the manifest predicate:
   acceptance, and open-world proof must all be present;
 - missing GPU runner availability, manual inputs, path filters, or advisory
   open-world proof cannot downgrade a public-alpha candidate to pass.
+
+## Public Alpha Checklist
+
+The manifest owns the machine-readable checklist. Public-alpha signoff requires
+all blocking rows below to be closed by code, evidence, or an explicit accepted
+limitation before candidate mode can pass.
+
+| Gate | Classification | Evidence Required |
+| --- | --- | --- |
+| #351 route/fallback/stage contracts | Blocking | #351 closed or split to non-alpha follow-up; resident, streaming, and serial route failure-injection tests; candidate benchmark rows include `route_uid`, `stage_statuses`, and `fallback_counters`. |
+| #352 GPU resource lifetime | Blocking | #352 closed or split to non-alpha follow-up; GPU/RID accounting fails on retained owned resources; required GPU batches report `rid_leak_bytes=0`. |
+| #360 public-alpha acceptance gates | Blocking | Candidate evidence bundle passes `--mode candidate`; issue snapshot classifies every open P0/P1/release-blocker issue; known limitations page contains each accepted alpha limitation. |
+| #369 opaque `qlty check` | Deferred external signal | `master` branch protection has no required status checks; no repo-owned qlty config is tracked; `qlty check` is documented as non-blocking unless branch protection later requires it. |
+
+Closed umbrella issues #350 and #353 stay closed only because their remaining
+release risk is represented by open child blockers and follow-up issues. They
+must not be used as evidence that renderer correctness, GPU lifetime, streaming,
+or public-alpha acceptance is complete.
+
+## Issue Classifications
+
+`blocking` means the public-alpha candidate fails while the issue remains open.
+
+`accepted_alpha_limitation` means the candidate may pass only when the evidence
+bundle points to the canonical known-limitations page and that page explains
+user impact, platform/workflow scope, mitigation, and proof that the limitation
+does not hide renderer correctness failures.
+
+`deferred` means the issue is explicitly outside the public-alpha gate or is an
+external/non-required signal. A deferred issue still needs a rationale and
+evidence requirements in the manifest; an unclassified P0/P1 issue is a gate
+failure, not an implicit deferral.
+
+## External Status Checks
+
+The local renderer release gate only treats repo-owned checks and required
+branch-protection contexts as release blockers. As of 2026-05-21, GitHub branch
+protection for `master` reports `required_status_checks=null`, and the repo does
+not track a qlty configuration file. Therefore `qlty check` is an advisory
+external signal for this gate. A failing, pending, absent, or login-gated qlty
+result must not fail `tests/ci/check_renderer_release_gates.py`.
+
+If qlty later becomes branch-protection-required or gets a repo-owned actionable
+configuration/log contract, update `external_status_check_policy` in the
+manifest and reclassify #369 before cutting a candidate.
 
 ## Workflow Policy Scope
 

--- a/docs/reference/renderer-release-gates.md
+++ b/docs/reference/renderer-release-gates.md
@@ -17,6 +17,8 @@ matches a `v*-alpha*` release tag, then passes the manifest predicate:
 - open `priority:P0`, `priority:P1`, and `release blocker` issues in that
   snapshot must be classified as `blocking`, `accepted_alpha_limitation`, or
   `deferred`;
+- if the snapshot is open-only, omitted manifest-tracked `blocking` issues must
+  be proven closed through candidate evidence `resolved_manifest_issues`;
 - any `accepted_alpha_limitation` must have a user-facing entry in
   `docs/development/known-public-alpha-limitations.md`;
 - Linux and Windows artifacts, runtime validation, GPU harness output,
@@ -138,5 +140,7 @@ python3 tests/ci/check_renderer_release_gates.py \
 ```
 
 The issue JSON is intended to come from `gh issue list` or the GitHub API with
-labels included. This PR does not require live network access for the
-deterministic contract check.
+labels included. When that snapshot is open-only, any manifest-tracked
+`blocking` issue omitted from it needs explicit closure proof in
+`resolved_manifest_issues` inside the evidence bundle. This PR does not require
+live network access for the deterministic contract check.

--- a/docs/reference/renderer-release-gates.md
+++ b/docs/reference/renderer-release-gates.md
@@ -115,10 +115,16 @@ until a complete candidate evidence bundle exists.
 
 ## CI Hook
 
-Run the contract check locally or in CI:
+Run the direct contract check locally:
 
 ```bash
 python3 tests/ci/check_renderer_release_gates.py --mode contract
+```
+
+CI enforces the same contract through the existing module guard entry point:
+
+```bash
+python3 tests/ci/run_module_tests.py --guard-only
 ```
 
 Candidate release validation requires an evidence bundle and an issue snapshot

--- a/docs/reference/renderer_release_gate_manifest.json
+++ b/docs/reference/renderer_release_gate_manifest.json
@@ -92,8 +92,8 @@
   "known_limitations_page": "docs/development/known-public-alpha-limitations.md",
   "requires_gpu_test_snapshot": {
     "source_glob": "modules/gaussian_splatting/tests/**/*.{h,cpp}",
-    "test_count": 96,
-    "sha256": "8932222543ec28d6ee657211fdda09c767b344c8d08bdceca40aa5450a03768e",
+    "test_count": 99,
+    "sha256": "ee61962cc8bb817d66b3cfd4e02679ff6ed321fbf13b52bfc38cf9da37fd59be",
     "deferred_tags_any": ["SceneTree", "Importer"],
     "deferred_count": 29,
     "new_or_missing_test_policy": "fail-contract-check",

--- a/docs/reference/renderer_release_gate_manifest.json
+++ b/docs/reference/renderer_release_gate_manifest.json
@@ -13,17 +13,87 @@
     "disallow_missing_gpu_runner_downgrade": true,
     "disallow_open_world_advisory_only": true,
     "required_issue_query": {
+      "classification_labels_any": ["priority:P0", "priority:P1", "release blocker"],
       "blocking_labels_any": ["priority:P0", "release blocker"],
       "alpha_relevant_p1_labels_all": ["priority:P1", "alpha-relevant"],
-      "allowed_classifications": ["blocking", "accepted_alpha_limitation", "post_alpha"],
+      "allowed_classifications": ["blocking", "accepted_alpha_limitation", "deferred"],
       "accepted_limitation_requires_docs_path": true
     }
+  },
+  "public_alpha_issue_ledger": {
+    "scope": "Every open priority:P0, priority:P1, or release blocker issue in the candidate issue snapshot must resolve to one public-alpha classification.",
+    "allowed_statuses": ["blocking", "accepted_alpha_limitation", "deferred"],
+    "tracked_issues": [
+      {
+        "number": 351,
+        "title": "Audit P0: make render route, fallback, and stage failure contracts explicit",
+        "status": "blocking",
+        "goal": "Public alpha must expose one selected route per frame, typed stage results, visible degradation, and first-failure diagnostics for resident, streaming, and serial paths.",
+        "evidence_required": [
+          "PR closes #351 or splits only non-alpha follow-up work with owner and issue link",
+          "route/stage failure-injection tests cover resident, streaming, and serial paths",
+          "candidate benchmark rows include route_uid, stage_statuses, and fallback_counters for every required lane"
+        ]
+      },
+      {
+        "number": 352,
+        "title": "Audit P0: close GPU resource leaks and shutdown lifetime hazards",
+        "status": "blocking",
+        "goal": "Public alpha must prove renderer shutdown, compositor shutdown, node removal, and failed initialization do not retain owned GPU resources.",
+        "evidence_required": [
+          "PR closes #352 or splits only non-alpha follow-up work with owner and issue link",
+          "GPU/RID accounting tests fail on retained owned resources",
+          "candidate GPU harness report includes zero rid_leak_bytes for required batches"
+        ]
+      },
+      {
+        "number": 360,
+        "title": "Audit P3: define and enforce public alpha release acceptance gates",
+        "status": "blocking",
+        "goal": "Public alpha must be tied to an evidence bundle, issue snapshot, public known-limitations page, and deterministic local contract check.",
+        "evidence_required": [
+          "candidate evidence bundle passes tests/ci/check_renderer_release_gates.py --mode candidate",
+          "candidate issue snapshot classifies every open P0, P1, and release-blocker issue",
+          "docs/development/known-public-alpha-limitations.md contains each accepted public-alpha limitation"
+        ]
+      },
+      {
+        "number": 369,
+        "title": "Audit P0: repair opaque qlty check failures blocking renderer PRs",
+        "status": "deferred",
+        "goal": "Do not let opaque external qlty status block the local renderer release gate when GitHub branch protection does not require it.",
+        "rationale": "As of 2026-05-21, master branch protection reports required_status_checks=null and the repository tracks no qlty configuration; qlty is therefore an advisory external signal, not a public-alpha release blocker.",
+        "evidence_required": [
+          "GitHub branch protection for master has no required status checks",
+          "qlty check is documented as a non-blocking external signal in docs/reference/renderer-release-gates.md and .github/workflows/README.md",
+          "candidate issue validation can resolve #369 through this deferred manifest classification"
+        ]
+      }
+    ]
+  },
+  "external_status_check_policy": {
+    "source": "GitHub branch protection for master checked on 2026-05-21",
+    "branch_protection_required_status_checks": [],
+    "required_for_public_alpha": [],
+    "non_blocking_checks": [
+      {
+        "context": "qlty check",
+        "issue": 369,
+        "classification": "deferred",
+        "reason": "The qlty check is not required by master branch protection and has no repo-owned configuration/log contract in this tree.",
+        "decision_evidence": [
+          "gh api repos/klausi3D/godotGS/branches/master/protection returned required_status_checks=null on 2026-05-21",
+          "repo search found no tracked qlty.toml, .qlty, .codeclimate.yml, or .codefactor.yml policy file"
+        ],
+        "local_gate_behavior": "Do not fail tests/ci/check_renderer_release_gates.py solely because qlty check is failing, pending, absent, or inaccessible."
+      }
+    ]
   },
   "known_limitations_page": "docs/development/known-public-alpha-limitations.md",
   "requires_gpu_test_snapshot": {
     "source_glob": "modules/gaussian_splatting/tests/**/*.{h,cpp}",
-    "test_count": 93,
-    "sha256": "704a15f3989517fe04c16d9c6cae847f97d65db3c26324b851cf58eb2d6b04d0",
+    "test_count": 96,
+    "sha256": "8932222543ec28d6ee657211fdda09c767b344c8d08bdceca40aa5450a03768e",
     "deferred_tags_any": ["SceneTree", "Importer"],
     "deferred_count": 29,
     "new_or_missing_test_policy": "fail-contract-check",

--- a/tests/ci/check_renderer_release_gates.py
+++ b/tests/ci/check_renderer_release_gates.py
@@ -50,6 +50,33 @@ def _repo_path(root: Path, value: str) -> Path:
     return root / value
 
 
+def _repo_relative_path(root: Path, value: Any, label: str) -> tuple[Path | None, list[str]]:
+    if not isinstance(value, str) or not value.strip():
+        return None, [f"{label} must be a non-empty repo-relative path"]
+    path = Path(value)
+    if path.is_absolute():
+        return None, [f"{label} must be repo-relative: {value}"]
+    if ".." in path.parts:
+        return None, [f"{label} must not escape the repository: {value}"]
+
+    candidate = (root / path).resolve()
+    repo_root = root.resolve()
+    try:
+        candidate.relative_to(repo_root)
+    except ValueError:
+        return None, [f"{label} must stay inside the repository: {value}"]
+    return candidate, []
+
+
+def _repo_relative_path_exists(root: Path, value: Any, label: str) -> list[str]:
+    path, failures = _repo_relative_path(root, value, label)
+    if failures:
+        return failures
+    if path is None or not path.exists():
+        return [f"{label} missing: {value}"]
+    return []
+
+
 def _extract_requires_gpu_tests(root: Path) -> list[dict[str, Any]]:
     tests_root = root / "modules" / "gaussian_splatting" / "tests"
     tests: list[dict[str, Any]] = []
@@ -80,7 +107,9 @@ def _requires_gpu_snapshot(tests: Iterable[dict[str, Any]]) -> tuple[int, str]:
 
 
 def _load_gpu_harness_batches(root: Path, script_rel: str) -> dict[str, tuple[str, ...]]:
-    script = _repo_path(root, script_rel)
+    script, failures = _repo_relative_path(root, script_rel, "gpu_harness_policy.script")
+    if failures or script is None:
+        raise RuntimeError("; ".join(failures))
     spec = importlib.util.spec_from_file_location("godotgs_gpu_harness_contract", script)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Unable to import {script_rel}")
@@ -130,12 +159,16 @@ def _validate_manifest_basics(root: Path, manifest: dict[str, Any]) -> list[str]
         failures.append("manifest schema_version must be 1")
 
     for ref in manifest.get("references", []):
-        if not _repo_path(root, ref).exists():
-            failures.append(f"reference path missing: {ref}")
+        failures.extend(_repo_relative_path_exists(root, ref, "reference path"))
 
     known_limitations = manifest.get("known_limitations_page")
-    if not known_limitations or not _repo_path(root, known_limitations).exists():
+    if not known_limitations:
         failures.append("known limitations page is missing")
+    else:
+        known_limitations_failures = _repo_relative_path_exists(root, known_limitations, "known limitations page")
+        if known_limitations_failures:
+            failures.append("known limitations page is missing")
+            failures.extend(known_limitations_failures)
 
     return failures
 
@@ -146,6 +179,12 @@ def _validate_public_alpha_predicate(manifest: dict[str, Any]) -> list[str]:
     for flag in PUBLIC_ALPHA_REQUIRED_FLAGS:
         if predicate.get(flag) is not True:
             failures.append(f"public_alpha_predicate.{flag} must be true")
+    allowed = predicate.get("required_issue_query", {}).get("allowed_classifications", [])
+    if not isinstance(allowed, list) or set(allowed) != set(PREFERRED_ISSUE_CLASSIFICATIONS):
+        failures.append(
+            "public_alpha_predicate.required_issue_query.allowed_classifications must be "
+            f"{list(PREFERRED_ISSUE_CLASSIFICATIONS)!r}"
+        )
     return failures
 
 
@@ -179,7 +218,7 @@ def _validate_public_alpha_issue_ledger(root: Path, manifest: dict[str, Any]) ->
 
     failures: list[str] = []
     allowed = ledger.get("allowed_statuses", [])
-    if set(allowed) != set(PREFERRED_ISSUE_CLASSIFICATIONS):
+    if not isinstance(allowed, list) or set(allowed) != set(PREFERRED_ISSUE_CLASSIFICATIONS):
         failures.append(
             "public_alpha_issue_ledger.allowed_statuses must be "
             f"{list(PREFERRED_ISSUE_CLASSIFICATIONS)!r}"
@@ -294,8 +333,8 @@ def _validate_deferred_requires_gpu_waivers(root: Path, manifest: dict[str, Any]
             if not waiver.get(field):
                 failures.append(f"deferred waiver missing {field}: {waiver!r}")
         docs_path = waiver.get("docs_path")
-        if docs_path and not _repo_path(root, docs_path).exists():
-            failures.append(f"deferred waiver docs_path missing: {docs_path}")
+        if docs_path:
+            failures.extend(_repo_relative_path_exists(root, docs_path, f"deferred waiver docs_path {docs_path}"))
     return failures
 
 
@@ -326,8 +365,12 @@ def _required_gpu_batch_reference_failures(
 ) -> list[str]:
     failures: list[str] = []
     for ref in batch.get("reference_artifacts", []):
-        if not _repo_path(root, ref).exists():
-            failures.append(f"required GPU batch {name} reference missing: {ref}")
+        ref_failures = _repo_relative_path_exists(root, ref, f"required GPU batch {name} reference")
+        for failure in ref_failures:
+            if "missing" in failure:
+                failures.append(f"required GPU batch {name} reference missing: {ref}")
+            else:
+                failures.append(f"required GPU batch {name} reference invalid: {failure}")
     return failures
 
 
@@ -376,8 +419,14 @@ def _validate_visual_acceptance(root: Path, manifest: dict[str, Any]) -> list[st
         if tracked_actual:
             failures.append(f"tracked .actual.png artifacts are forbidden: {tracked_actual}")
     for reference in visual.get("blocking_references", []):
-        if reference.get("required") and not _repo_path(root, reference.get("path", "")).exists():
-            failures.append(f"blocking visual reference missing: {reference.get('path')}")
+        if reference.get("required"):
+            path_value = reference.get("path", "")
+            ref_failures = _repo_relative_path_exists(root, path_value, "blocking visual reference")
+            for failure in ref_failures:
+                if "missing" in failure:
+                    failures.append(f"blocking visual reference missing: {path_value}")
+                else:
+                    failures.append(f"blocking visual reference invalid: {failure}")
     return failures
 
 
@@ -392,7 +441,9 @@ def _workflow_policy_scope_failures(workflow_policy: dict[str, Any]) -> list[str
 def _validate_required_workflow(root: Path, workflow: dict[str, Any]) -> list[str]:
     failures: list[str] = []
     workflow_file = workflow.get("file", "")
-    text_path = _repo_path(root, workflow_file)
+    text_path, path_failures = _repo_relative_path(root, workflow_file, "required workflow")
+    if path_failures:
+        return path_failures
     if not text_path.exists():
         return [f"required workflow missing: {workflow_file}"]
 
@@ -451,7 +502,9 @@ def _rows_from_report(report: Any) -> list[dict[str, Any]]:
 def _load_candidate_json(root: Path, rel_path: Any, label: str) -> tuple[Any | None, list[str]]:
     if not rel_path:
         return None, [f"candidate evidence missing {label}"]
-    path = _repo_path(root, str(rel_path))
+    path, path_failures = _repo_relative_path(root, rel_path, f"candidate {label}")
+    if path_failures or path is None:
+        return None, path_failures
     try:
         return _load_json(path), []
     except OSError as exc:
@@ -609,7 +662,11 @@ def _candidate_artifact_integrity_failures(
     if not raw_path:
         return failures
 
-    artifact_path = _candidate_artifact_path(root, raw_path)
+    artifact_path, path_failures = _candidate_artifact_path(root, raw_path, group)
+    if path_failures:
+        return path_failures
+    if artifact_path is None:
+        return [f"candidate artifact {group} path missing: {raw_path}"]
     if not artifact_path.exists():
         return [f"candidate artifact {group} path missing: {raw_path}"]
     if not artifact_path.is_file():
@@ -630,11 +687,8 @@ def _candidate_artifact_integrity_failures(
     return failures
 
 
-def _candidate_artifact_path(root: Path, raw_path: Any) -> Path:
-    path = Path(str(raw_path))
-    if path.is_absolute():
-        return path
-    return _repo_path(root, path.as_posix())
+def _candidate_artifact_path(root: Path, raw_path: Any, group: Any) -> tuple[Path | None, list[str]]:
+    return _repo_relative_path(root, raw_path, f"candidate artifact {group} path")
 
 
 def _candidate_artifact_commit_failures(
@@ -902,6 +956,10 @@ def _candidate_issue_label_names(issue: dict[str, Any]) -> set[Any]:
     }
 
 
+def _candidate_issue_is_open(issue: dict[str, Any]) -> bool:
+    return str(issue.get("state", "OPEN")).upper() == "OPEN"
+
+
 def _candidate_issue_is_relevant(policy: dict[str, Any], labels: set[Any]) -> bool:
     classification_any = set(policy.get("classification_labels_any", []))
     if classification_any:
@@ -924,7 +982,6 @@ def _validate_candidate_issue_classification(
 
     status = classification.get("status")
     handlers = {
-        "blocker": _candidate_issue_blocking_failures,
         "blocking": _candidate_issue_blocking_failures,
         "accepted_alpha_limitation": _candidate_issue_accepted_limitation_failures,
         "deferred": _candidate_issue_deferred_failures,
@@ -956,14 +1013,20 @@ def _candidate_issue_accepted_limitation_failures(
     if not docs_path:
         failures.append(f"candidate issue #{number} accepted limitation missing docs_path")
         return failures
+    docs_path_failures = _repo_relative_path_exists(
+        root,
+        docs_path,
+        f"candidate issue #{number} accepted limitation docs_path",
+    )
+    if docs_path_failures:
+        failures.extend(docs_path_failures)
+        return failures
     if docs_path != known_limitations:
         failures.append(
             f"candidate issue #{number} accepted limitation must use known_limitations_page "
             f"{known_limitations!r}, got {docs_path!r}"
         )
         return failures
-    if not _repo_path(root, docs_path).exists():
-        failures.append(f"candidate issue #{number} accepted limitation missing docs_path")
     return failures
 
 
@@ -995,8 +1058,18 @@ def _validate_candidate_issues(
     if not isinstance(classifications, dict):
         return ["candidate issue_classifications must be a JSON object"]
     manifest_classifications = _manifest_issue_classifications(manifest)
+    open_issue_numbers: set[str] = set()
     for issue in issue_rows:
-        if issue.get("state", "OPEN").upper() not in {"OPEN", "open".upper()}:
+        if _candidate_issue_is_open(issue):
+            number = issue.get("number")
+            if number is not None:
+                open_issue_numbers.add(str(number))
+    for number in sorted(manifest_classifications):
+        if number not in open_issue_numbers:
+            failures.append(f"candidate issue snapshot missing manifest-tracked issue #{number}")
+
+    for issue in issue_rows:
+        if not _candidate_issue_is_open(issue):
             continue
         number = str(issue.get("number"))
         labels = _candidate_issue_label_names(issue)
@@ -1022,8 +1095,15 @@ def validate_candidate(
     failures.extend(_candidate_commit_metadata_failures(evidence))
 
     known_limitations = manifest.get("known_limitations_page")
-    if known_limitations and not _repo_path(root, known_limitations).exists():
-        failures.append("candidate known limitations page is missing")
+    if known_limitations:
+        known_limitations_failures = _repo_relative_path_exists(
+            root,
+            known_limitations,
+            "candidate known limitations page",
+        )
+        if known_limitations_failures:
+            failures.append("candidate known limitations page is missing")
+            failures.extend(known_limitations_failures)
 
     tests = _extract_requires_gpu_tests(root)
     failures.extend(_validate_candidate_deferred_waivers(manifest, tests))

--- a/tests/ci/check_renderer_release_gates.py
+++ b/tests/ci/check_renderer_release_gates.py
@@ -230,13 +230,20 @@ def _validate_external_status_check_policy(manifest: dict[str, Any]) -> list[str
         return ["external_status_check_policy must be a JSON object"]
 
     failures: list[str] = []
-    required_contexts = set(policy.get("branch_protection_required_status_checks", []))
-    public_alpha_required = set(policy.get("required_for_public_alpha", []))
+    required_status_checks = policy.get("branch_protection_required_status_checks", [])
+    public_alpha_status_checks = policy.get("required_for_public_alpha", [])
+    if not isinstance(required_status_checks, list):
+        return ["external_status_check_policy.branch_protection_required_status_checks must be a list"]
+    if not isinstance(public_alpha_status_checks, list):
+        return ["external_status_check_policy.required_for_public_alpha must be a list"]
+    required_contexts = set(required_status_checks)
+    public_alpha_required = set(public_alpha_status_checks)
     non_blocking = policy.get("non_blocking_checks", [])
     if not isinstance(non_blocking, list):
         return ["external_status_check_policy.non_blocking_checks must be a list"]
 
-    qlty_found = False
+    qlty_non_blocking = False
+    qlty_required = "qlty check" in required_contexts or "qlty check" in public_alpha_required
     for check in non_blocking:
         if not isinstance(check, dict):
             failures.append(f"external non-blocking check must be a JSON object: {check!r}")
@@ -246,7 +253,7 @@ def _validate_external_status_check_policy(manifest: dict[str, Any]) -> list[str
             failures.append(f"external non-blocking check missing context: {check!r}")
             continue
         if context == "qlty check":
-            qlty_found = True
+            qlty_non_blocking = True
         if context in required_contexts or context in public_alpha_required or check.get("required_for_public_alpha") is True:
             failures.append(f"external check {context!r} cannot be both non-blocking and public-alpha required")
         if check.get("classification") != "deferred":
@@ -254,8 +261,8 @@ def _validate_external_status_check_policy(manifest: dict[str, Any]) -> list[str
         for field in ("issue", "reason", "decision_evidence", "local_gate_behavior"):
             if not check.get(field):
                 failures.append(f"external non-blocking check {context!r} missing {field}")
-    if not qlty_found:
-        failures.append("external_status_check_policy must classify qlty check")
+    if not qlty_non_blocking and not qlty_required:
+        failures.append("external_status_check_policy must classify qlty check as required or non-blocking")
     return failures
 
 
@@ -1012,7 +1019,7 @@ def _validate_candidate_issues(
         labels = _candidate_issue_label_names(issue)
         if not _candidate_issue_is_relevant(policy, labels) and number not in manifest_classifications:
             continue
-        classification = classifications.get(number, manifest_classifications.get(number))
+        classification = manifest_classifications.get(number, classifications.get(number))
         failures.extend(_validate_candidate_issue_classification(root, manifest, number, classification))
     return failures
 

--- a/tests/ci/check_renderer_release_gates.py
+++ b/tests/ci/check_renderer_release_gates.py
@@ -26,6 +26,16 @@ PUBLIC_ALPHA_REQUIRED_FLAGS = (
     "disallow_missing_gpu_runner_downgrade",
     "disallow_open_world_advisory_only",
 )
+PREFERRED_ISSUE_CLASSIFICATIONS = (
+    "blocking",
+    "accepted_alpha_limitation",
+    "deferred",
+)
+LEGACY_ISSUE_CLASSIFICATIONS = (
+    "blocker",
+    "post_alpha",
+)
+ISSUE_CLASSIFICATIONS = PREFERRED_ISSUE_CLASSIFICATIONS + LEGACY_ISSUE_CLASSIFICATIONS
 UNSUPPORTED_WORKFLOW_CLAIMS = (
     "must_enforce_readiness",
     "manual_input_may_disable",
@@ -141,6 +151,111 @@ def _validate_public_alpha_predicate(manifest: dict[str, Any]) -> list[str]:
     for flag in PUBLIC_ALPHA_REQUIRED_FLAGS:
         if predicate.get(flag) is not True:
             failures.append(f"public_alpha_predicate.{flag} must be true")
+    return failures
+
+
+def _manifest_issue_classifications(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    ledger = manifest.get("public_alpha_issue_ledger", {})
+    tracked = ledger.get("tracked_issues", []) if isinstance(ledger, dict) else []
+    classifications: dict[str, dict[str, Any]] = {}
+    for issue in tracked:
+        if not isinstance(issue, dict):
+            continue
+        number = issue.get("number")
+        if number is None:
+            continue
+        classifications[str(number)] = issue
+    return classifications
+
+
+def _validate_issue_evidence_requirements(number: Any, classification: dict[str, Any]) -> list[str]:
+    evidence_required = classification.get("evidence_required")
+    if not isinstance(evidence_required, list) or not evidence_required:
+        return [f"candidate issue #{number} classification missing evidence_required"]
+    if any(not isinstance(item, str) or not item.strip() for item in evidence_required):
+        return [f"candidate issue #{number} evidence_required entries must be non-empty strings"]
+    return []
+
+
+def _validate_public_alpha_issue_ledger(root: Path, manifest: dict[str, Any]) -> list[str]:
+    ledger = manifest.get("public_alpha_issue_ledger")
+    if not isinstance(ledger, dict):
+        return ["public_alpha_issue_ledger must be a JSON object"]
+
+    failures: list[str] = []
+    allowed = ledger.get("allowed_statuses", [])
+    if set(allowed) != set(PREFERRED_ISSUE_CLASSIFICATIONS):
+        failures.append(
+            "public_alpha_issue_ledger.allowed_statuses must be "
+            f"{list(PREFERRED_ISSUE_CLASSIFICATIONS)!r}"
+        )
+
+    tracked = ledger.get("tracked_issues", [])
+    if not isinstance(tracked, list) or not tracked:
+        failures.append("public_alpha_issue_ledger.tracked_issues must be a non-empty list")
+        tracked = []
+
+    seen: set[Any] = set()
+    for issue in tracked:
+        if not isinstance(issue, dict):
+            failures.append(f"public_alpha_issue_ledger issue must be a JSON object: {issue!r}")
+            continue
+        number = issue.get("number")
+        if not isinstance(number, int) or number <= 0:
+            failures.append(f"public_alpha_issue_ledger issue number must be positive integer: {issue!r}")
+            continue
+        if number in seen:
+            failures.append(f"public_alpha_issue_ledger duplicate issue #{number}")
+        seen.add(number)
+
+        status = issue.get("status")
+        if status not in PREFERRED_ISSUE_CLASSIFICATIONS:
+            failures.append(f"public_alpha_issue_ledger issue #{number} has invalid status {status!r}")
+            continue
+        for field in ("title", "goal"):
+            if not issue.get(field):
+                failures.append(f"public_alpha_issue_ledger issue #{number} missing {field}")
+        failures.extend(_validate_issue_evidence_requirements(number, issue))
+        if status == "accepted_alpha_limitation":
+            failures.extend(_candidate_issue_accepted_limitation_failures(root, manifest, str(number), issue))
+        if status == "deferred" and not issue.get("rationale"):
+            failures.append(f"public_alpha_issue_ledger issue #{number} deferred classification missing rationale")
+
+    return failures
+
+
+def _validate_external_status_check_policy(manifest: dict[str, Any]) -> list[str]:
+    policy = manifest.get("external_status_check_policy")
+    if not isinstance(policy, dict):
+        return ["external_status_check_policy must be a JSON object"]
+
+    failures: list[str] = []
+    required_contexts = set(policy.get("branch_protection_required_status_checks", []))
+    public_alpha_required = set(policy.get("required_for_public_alpha", []))
+    non_blocking = policy.get("non_blocking_checks", [])
+    if not isinstance(non_blocking, list):
+        return ["external_status_check_policy.non_blocking_checks must be a list"]
+
+    qlty_found = False
+    for check in non_blocking:
+        if not isinstance(check, dict):
+            failures.append(f"external non-blocking check must be a JSON object: {check!r}")
+            continue
+        context = check.get("context")
+        if not context:
+            failures.append(f"external non-blocking check missing context: {check!r}")
+            continue
+        if context == "qlty check":
+            qlty_found = True
+        if context in required_contexts or context in public_alpha_required or check.get("required_for_public_alpha") is True:
+            failures.append(f"external check {context!r} cannot be both non-blocking and public-alpha required")
+        if check.get("classification") != "deferred":
+            failures.append(f"external non-blocking check {context!r} must use deferred classification")
+        for field in ("issue", "reason", "decision_evidence", "local_gate_behavior"):
+            if not check.get(field):
+                failures.append(f"external non-blocking check {context!r} missing {field}")
+    if not qlty_found:
+        failures.append("external_status_check_policy must classify qlty check")
     return failures
 
 
@@ -303,6 +418,8 @@ def validate_contract(root: Path, manifest: dict[str, Any]) -> list[str]:
     failures: list[str] = []
     failures.extend(_validate_manifest_basics(root, manifest))
     failures.extend(_validate_public_alpha_predicate(manifest))
+    failures.extend(_validate_public_alpha_issue_ledger(root, manifest))
+    failures.extend(_validate_external_status_check_policy(manifest))
     failures.extend(_validate_requires_gpu_snapshot(manifest, tests))
     failures.extend(_validate_deferred_requires_gpu_waivers(root, manifest))
     failures.extend(_validate_gpu_harness_policy(root, manifest, tests))
@@ -784,6 +901,9 @@ def _candidate_issue_label_names(issue: dict[str, Any]) -> set[Any]:
 
 
 def _candidate_issue_is_relevant(policy: dict[str, Any], labels: set[Any]) -> bool:
+    classification_any = set(policy.get("classification_labels_any", []))
+    if classification_any:
+        return bool(classification_any.intersection(labels))
     blocking_any = set(policy.get("blocking_labels_any", []))
     alpha_p1_all = set(policy.get("alpha_relevant_p1_labels_all", []))
     return bool(blocking_any.intersection(labels)) or alpha_p1_all.issubset(labels)
@@ -802,8 +922,10 @@ def _validate_candidate_issue_classification(
 
     status = classification.get("status")
     handlers = {
+        "blocker": _candidate_issue_blocking_failures,
         "blocking": _candidate_issue_blocking_failures,
         "accepted_alpha_limitation": _candidate_issue_accepted_limitation_failures,
+        "deferred": _candidate_issue_deferred_failures,
         "post_alpha": _candidate_issue_post_alpha_failures,
     }
     handler = handlers.get(status)
@@ -827,18 +949,33 @@ def _candidate_issue_accepted_limitation_failures(
     number: str,
     classification: dict[str, Any],
 ) -> list[str]:
+    failures = _validate_issue_evidence_requirements(number, classification)
     docs_path = classification.get("docs_path")
     known_limitations = manifest.get("known_limitations_page")
     if not docs_path:
-        return [f"candidate issue #{number} accepted limitation missing docs_path"]
+        failures.append(f"candidate issue #{number} accepted limitation missing docs_path")
+        return failures
     if docs_path != known_limitations:
-        return [
+        failures.append(
             f"candidate issue #{number} accepted limitation must use known_limitations_page "
             f"{known_limitations!r}, got {docs_path!r}"
-        ]
+        )
+        return failures
     if not _repo_path(root, docs_path).exists():
-        return [f"candidate issue #{number} accepted limitation missing docs_path"]
-    return []
+        failures.append(f"candidate issue #{number} accepted limitation missing docs_path")
+    return failures
+
+
+def _candidate_issue_deferred_failures(
+    _root: Path,
+    _manifest: dict[str, Any],
+    number: str,
+    classification: dict[str, Any],
+) -> list[str]:
+    failures = _validate_issue_evidence_requirements(number, classification)
+    if not classification.get("rationale"):
+        failures.append(f"candidate issue #{number} deferred classification missing rationale")
+    return failures
 
 
 def _candidate_issue_post_alpha_failures(
@@ -867,14 +1004,15 @@ def _validate_candidate_issues(
     classifications = evidence.get("issue_classifications", {})
     if not isinstance(classifications, dict):
         return ["candidate issue_classifications must be a JSON object"]
+    manifest_classifications = _manifest_issue_classifications(manifest)
     for issue in issue_rows:
         if issue.get("state", "OPEN").upper() not in {"OPEN", "open".upper()}:
             continue
-        labels = _candidate_issue_label_names(issue)
-        if not _candidate_issue_is_relevant(policy, labels):
-            continue
         number = str(issue.get("number"))
-        classification = classifications.get(number)
+        labels = _candidate_issue_label_names(issue)
+        if not _candidate_issue_is_relevant(policy, labels) and number not in manifest_classifications:
+            continue
+        classification = classifications.get(number, manifest_classifications.get(number))
         failures.extend(_validate_candidate_issue_classification(root, manifest, number, classification))
     return failures
 

--- a/tests/ci/check_renderer_release_gates.py
+++ b/tests/ci/check_renderer_release_gates.py
@@ -31,11 +31,6 @@ PREFERRED_ISSUE_CLASSIFICATIONS = (
     "accepted_alpha_limitation",
     "deferred",
 )
-LEGACY_ISSUE_CLASSIFICATIONS = (
-    "blocker",
-    "post_alpha",
-)
-ISSUE_CLASSIFICATIONS = PREFERRED_ISSUE_CLASSIFICATIONS + LEGACY_ISSUE_CLASSIFICATIONS
 UNSUPPORTED_WORKFLOW_CLAIMS = (
     "must_enforce_readiness",
     "manual_input_may_disable",
@@ -933,7 +928,6 @@ def _validate_candidate_issue_classification(
         "blocking": _candidate_issue_blocking_failures,
         "accepted_alpha_limitation": _candidate_issue_accepted_limitation_failures,
         "deferred": _candidate_issue_deferred_failures,
-        "post_alpha": _candidate_issue_post_alpha_failures,
     }
     handler = handlers.get(status)
     if handler:
@@ -983,17 +977,6 @@ def _candidate_issue_deferred_failures(
     if not classification.get("rationale"):
         failures.append(f"candidate issue #{number} deferred classification missing rationale")
     return failures
-
-
-def _candidate_issue_post_alpha_failures(
-    _root: Path,
-    _manifest: dict[str, Any],
-    number: str,
-    classification: dict[str, Any],
-) -> list[str]:
-    if not classification.get("rationale"):
-        return [f"candidate issue #{number} post_alpha classification missing rationale"]
-    return []
 
 
 def _validate_candidate_issues(

--- a/tests/ci/check_renderer_release_gates.py
+++ b/tests/ci/check_renderer_release_gates.py
@@ -9,6 +9,7 @@ import fnmatch
 import hashlib
 import importlib.util
 import json
+import math
 import re
 import subprocess
 import sys
@@ -538,7 +539,7 @@ def _to_utc_aware(value: _dt.datetime) -> _dt.datetime:
 
 
 def _is_json_number(value: Any) -> bool:
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
 
 
 def _candidate_selector_failures(manifest: dict[str, Any], evidence: dict[str, Any]) -> list[str]:
@@ -887,6 +888,38 @@ def _candidate_lane_visual_failures(
         failures.append(f"candidate benchmark lane {lane_id} has null capture_ssim_min")
     if row.get("capture_psnr_min") is None:
         failures.append(f"candidate benchmark lane {lane_id} has null capture_psnr_min")
+    capture_threshold_pass_count = row.get("capture_threshold_pass_count")
+    if capture_count_valid and capture_threshold_pass_count is not None:
+        if not _is_json_number(capture_threshold_pass_count):
+            failures.append(f"candidate benchmark lane {lane_id} capture_threshold_pass_count must be numeric")
+        elif capture_threshold_pass_count != capture_count:
+            failures.append(f"candidate benchmark lane {lane_id} did not pass all visual thresholds")
+    if row.get("visual_reference_match") is False:
+        failures.append(f"candidate benchmark lane {lane_id} failed visual reference match")
+    return failures
+
+
+def _candidate_lane_identity_failures(lane_id: str, row: dict[str, Any], commit: Any) -> list[str]:
+    failures: list[str] = []
+    if commit:
+        if row.get("commit_sha") != commit:
+            failures.append(f"candidate benchmark lane {lane_id} commit_sha does not match candidate commit")
+        if row.get("godot_binary_commit") != commit:
+            failures.append(f"candidate benchmark lane {lane_id} godot_binary_commit does not match candidate commit")
+    return failures
+
+
+def _candidate_lane_execution_status_failures(lane_id: str, row: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    exit_code = row.get("exit_code")
+    if exit_code is not None:
+        if not _is_json_number(exit_code):
+            failures.append(f"candidate benchmark lane {lane_id} exit_code must be numeric")
+        elif exit_code != 0:
+            failures.append(f"candidate benchmark lane {lane_id} exited with {exit_code}")
+    for field in ("report_valid", "visible_output_valid", "proof_valid", "lane_valid"):
+        if row.get(field) is False:
+            failures.append(f"candidate benchmark lane {lane_id} has {field}=false")
     return failures
 
 
@@ -903,9 +936,19 @@ def _candidate_lane_gpu_timing_failures(lane_id: str, row: dict[str, Any]) -> li
 
 
 def _candidate_lane_route_failures(lane_id: str, row: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
     if row.get("cpu_fallback_route") and not row.get("fallback_route_allowed"):
-        return [f"candidate benchmark lane {lane_id} used unallowed CPU/fallback route"]
-    return []
+        failures.append(f"candidate benchmark lane {lane_id} used unallowed CPU/fallback route")
+    if row.get("cpu_sort_route_detected") and not row.get("fallback_route_allowed"):
+        route_uid = row.get("cpu_sort_route_uid")
+        failures.append(f"candidate benchmark lane {lane_id} used forbidden CPU sort route {route_uid!r}")
+    fallback_count = row.get("sort_total_route_fallback_count")
+    if fallback_count is not None:
+        if not _is_json_number(fallback_count):
+            failures.append(f"candidate benchmark lane {lane_id} sort_total_route_fallback_count must be numeric")
+        elif fallback_count > 0 and not row.get("fallback_route_allowed"):
+            failures.append(f"candidate benchmark lane {lane_id} used unallowed sort fallback routes")
+    return failures
 
 
 def _validate_candidate_benchmark_lane(
@@ -913,9 +956,12 @@ def _validate_candidate_benchmark_lane(
     row: dict[str, Any],
     required_non_null: Iterable[str],
     visual_rules: dict[str, Any],
+    commit: Any,
 ) -> list[str]:
     failures: list[str] = []
     failures.extend(_candidate_lane_timeout_failures(lane_id, row))
+    failures.extend(_candidate_lane_identity_failures(lane_id, row, commit))
+    failures.extend(_candidate_lane_execution_status_failures(lane_id, row))
     failures.extend(_candidate_lane_required_field_failures(lane_id, row, required_non_null))
     failures.extend(_candidate_lane_visual_failures(lane_id, row, visual_rules))
     failures.extend(_candidate_lane_gpu_timing_failures(lane_id, row))
@@ -933,12 +979,13 @@ def _validate_candidate_benchmark_report(root: Path, manifest: dict[str, Any], e
     rows = _rows_from_report(report)
     required_non_null = manifest.get("benchmark_acceptance", {}).get("required_fields_non_null", [])
     visual_rules = manifest.get("visual_acceptance", {}).get("candidate_rules", {})
+    commit = evidence.get("commit")
     for lane_id in manifest.get("benchmark_acceptance", {}).get("candidate_required_lanes", []):
         row = _find_lane(rows, lane_id)
         if row is None:
             failures.append(f"candidate benchmark lane missing: {lane_id}")
             continue
-        failures.extend(_validate_candidate_benchmark_lane(lane_id, row, required_non_null, visual_rules))
+        failures.extend(_validate_candidate_benchmark_lane(lane_id, row, required_non_null, visual_rules, commit))
     return failures
 
 
@@ -1042,6 +1089,14 @@ def _candidate_issue_deferred_failures(
     return failures
 
 
+def _candidate_issue_is_manifest_resolved(
+    number: str,
+    issue: dict[str, Any],
+    classification: dict[str, Any],
+) -> bool:
+    return str(issue.get("number")) == number and not _candidate_issue_is_open(issue) and classification.get("status") == "blocking"
+
+
 def _validate_candidate_issues(
     root: Path,
     manifest: dict[str, Any],
@@ -1058,24 +1113,33 @@ def _validate_candidate_issues(
     if not isinstance(classifications, dict):
         return ["candidate issue_classifications must be a JSON object"]
     manifest_classifications = _manifest_issue_classifications(manifest)
-    open_issue_numbers: set[str] = set()
+    snapshot_issue_numbers: set[str] = set()
     for issue in issue_rows:
-        if _candidate_issue_is_open(issue):
-            number = issue.get("number")
-            if number is not None:
-                open_issue_numbers.add(str(number))
+        number = issue.get("number")
+        if number is not None:
+            snapshot_issue_numbers.add(str(number))
     for number in sorted(manifest_classifications):
-        if number not in open_issue_numbers:
+        if number not in snapshot_issue_numbers:
             failures.append(f"candidate issue snapshot missing manifest-tracked issue #{number}")
 
     for issue in issue_rows:
+        number = str(issue.get("number"))
+        manifest_classification = manifest_classifications.get(number)
+        if manifest_classification and _candidate_issue_is_manifest_resolved(number, issue, manifest_classification):
+            continue
         if not _candidate_issue_is_open(issue):
             continue
-        number = str(issue.get("number"))
         labels = _candidate_issue_label_names(issue)
-        if not _candidate_issue_is_relevant(policy, labels) and number not in manifest_classifications:
+        if not _candidate_issue_is_relevant(policy, labels) and manifest_classification is None:
             continue
-        classification = manifest_classifications.get(number, classifications.get(number))
+        classification = manifest_classification or classifications.get(number)
+        if isinstance(classification, dict):
+            status = classification.get("status")
+            if status in {"accepted_alpha_limitation", "deferred"} and number not in manifest_classifications:
+                failures.append(
+                    f"candidate issue #{number} {status} classification must be tracked in public_alpha_issue_ledger"
+                )
+                continue
         failures.extend(_validate_candidate_issue_classification(root, manifest, number, classification))
     return failures
 

--- a/tests/ci/check_renderer_release_gates.py
+++ b/tests/ci/check_renderer_release_gates.py
@@ -271,8 +271,15 @@ def _validate_external_status_check_policy(manifest: dict[str, Any]) -> list[str
         return ["external_status_check_policy.branch_protection_required_status_checks must be a list"]
     if not isinstance(public_alpha_status_checks, list):
         return ["external_status_check_policy.required_for_public_alpha must be a list"]
-    required_contexts = set(required_status_checks)
-    public_alpha_required = set(public_alpha_status_checks)
+    for field, checks in (
+        ("branch_protection_required_status_checks", required_status_checks),
+        ("required_for_public_alpha", public_alpha_status_checks),
+    ):
+        for index, check in enumerate(checks):
+            if not isinstance(check, str) or not check:
+                failures.append(f"external_status_check_policy.{field}[{index}] must be a non-empty string")
+    required_contexts = {check for check in required_status_checks if isinstance(check, str)}
+    public_alpha_required = {check for check in public_alpha_status_checks if isinstance(check, str)}
     non_blocking = policy.get("non_blocking_checks", [])
     if not isinstance(non_blocking, list):
         return ["external_status_check_policy.non_blocking_checks must be a list"]
@@ -284,8 +291,8 @@ def _validate_external_status_check_policy(manifest: dict[str, Any]) -> list[str
             failures.append(f"external non-blocking check must be a JSON object: {check!r}")
             continue
         context = check.get("context")
-        if not context:
-            failures.append(f"external non-blocking check missing context: {check!r}")
+        if not isinstance(context, str) or not context:
+            failures.append(f"external non-blocking check context must be a non-empty string: {check!r}")
             continue
         if context == "qlty check":
             qlty_non_blocking = True
@@ -996,6 +1003,12 @@ def _candidate_issue_rows(evidence: dict[str, Any], issues: Any | None) -> list[
     return _issue_rows_from_snapshot(evidence.get("issue_snapshot", evidence.get("issues", evidence.get("open_issues"))))
 
 
+def _candidate_resolved_manifest_issue_rows(evidence: dict[str, Any]) -> list[dict[str, Any]] | None:
+    if "resolved_manifest_issues" not in evidence:
+        return []
+    return _issue_rows_from_snapshot(evidence.get("resolved_manifest_issues"))
+
+
 def _candidate_issue_label_names(issue: dict[str, Any]) -> set[Any]:
     return {
         label.get("name", label) if isinstance(label, dict) else label
@@ -1005,6 +1018,10 @@ def _candidate_issue_label_names(issue: dict[str, Any]) -> set[Any]:
 
 def _candidate_issue_is_open(issue: dict[str, Any]) -> bool:
     return str(issue.get("state", "OPEN")).upper() == "OPEN"
+
+
+def _candidate_issue_is_closed(issue: dict[str, Any]) -> bool:
+    return str(issue.get("state", "")).upper() == "CLOSED"
 
 
 def _candidate_issue_is_relevant(policy: dict[str, Any], labels: set[Any]) -> bool:
@@ -1094,7 +1111,39 @@ def _candidate_issue_is_manifest_resolved(
     issue: dict[str, Any],
     classification: dict[str, Any],
 ) -> bool:
-    return str(issue.get("number")) == number and not _candidate_issue_is_open(issue) and classification.get("status") == "blocking"
+    return str(issue.get("number")) == number and _candidate_issue_is_closed(issue) and classification.get("status") == "blocking"
+
+
+def _validate_omitted_manifest_blockers(
+    manifest_classifications: dict[str, dict[str, Any]],
+    issue_rows: list[dict[str, Any]],
+    resolved_rows: list[dict[str, Any]],
+) -> list[str]:
+    snapshot_issue_numbers = {
+        str(issue.get("number"))
+        for issue in issue_rows
+        if issue.get("number") is not None
+    }
+    resolved_by_number = {
+        str(issue.get("number")): issue
+        for issue in resolved_rows
+        if issue.get("number") is not None
+    }
+
+    failures: list[str] = []
+    for number, classification in sorted(manifest_classifications.items()):
+        if number in snapshot_issue_numbers or classification.get("status") != "blocking":
+            continue
+        proof = resolved_by_number.get(number)
+        if proof is None:
+            failures.append(
+                f"candidate issue snapshot missing manifest-tracked blocking issue #{number}; "
+                "include it in issue_snapshot or resolved_manifest_issues"
+            )
+            continue
+        if not _candidate_issue_is_closed(proof):
+            failures.append(f"candidate resolved_manifest_issues issue #{number} must have state CLOSED")
+    return failures
 
 
 def _validate_candidate_issues(
@@ -1113,14 +1162,11 @@ def _validate_candidate_issues(
     if not isinstance(classifications, dict):
         return ["candidate issue_classifications must be a JSON object"]
     manifest_classifications = _manifest_issue_classifications(manifest)
-    snapshot_issue_numbers: set[str] = set()
-    for issue in issue_rows:
-        number = issue.get("number")
-        if number is not None:
-            snapshot_issue_numbers.add(str(number))
-    for number in sorted(manifest_classifications):
-        if number not in snapshot_issue_numbers:
-            failures.append(f"candidate issue snapshot missing manifest-tracked issue #{number}")
+    resolved_rows = _candidate_resolved_manifest_issue_rows(evidence)
+    if resolved_rows is None:
+        failures.append("candidate resolved_manifest_issues must be an issue snapshot object or list")
+        resolved_rows = []
+    failures.extend(_validate_omitted_manifest_blockers(manifest_classifications, issue_rows, resolved_rows))
 
     for issue in issue_rows:
         number = str(issue.get("number"))

--- a/tests/ci/run_module_tests.py
+++ b/tests/ci/run_module_tests.py
@@ -25,6 +25,8 @@ BUILD_METADATA_GUARD_SCRIPT = MODULE_SOURCE_DIR / "tests" / "check_build_metadat
 SHADER_DEPENDENCY_GUARD_SCRIPT = MODULE_SOURCE_DIR / "tests" / "check_shader_dependency_contract.py"
 PROJECT_SETTINGS_MANIFEST_GUARD_SCRIPT = MODULE_SOURCE_DIR / "tests" / "check_project_settings_manifest.py"
 GAUSSIAN_LAYOUT_GUARD_SCRIPT = ROOT / "tests" / "ci" / "check_gaussian_layout_sync.py"
+RENDERER_RELEASE_GATE_SCRIPT = ROOT / "tests" / "ci" / "check_renderer_release_gates.py"
+RENDERER_RELEASE_GATE_TEST_SCRIPT = ROOT / "tests" / "ci" / "test_renderer_release_gates.py"
 HISTORY_ARTIFACT_AUDIT_SCRIPT = ROOT / "scripts" / "repo" / "history_artifact_audit.py"
 SYNTHETIC_ASSET_PREP_SCRIPT = ROOT / "tests" / "runtime" / "prepare_synthetic_assets.py"
 BENCHMARK_ASSET_GUARD_SCRIPT = ROOT / "tests" / "runtime" / "check_benchmark_asset_paths.py"
@@ -539,6 +541,31 @@ def _run_gaussian_layout_guard() -> tuple[bool, list[str]]:
     return True, output_lines
 
 
+def _run_renderer_release_gate_guard() -> tuple[bool, list[str]]:
+    missing = [
+        path.relative_to(ROOT)
+        for path in (RENDERER_RELEASE_GATE_SCRIPT, RENDERER_RELEASE_GATE_TEST_SCRIPT)
+        if not path.is_file()
+    ]
+    if missing:
+        return False, [f"Missing renderer release gate guard file: {path}" for path in missing]
+
+    output_lines: list[str] = []
+    commands = (
+        [sys.executable, str(RENDERER_RELEASE_GATE_SCRIPT), "--mode", "contract"],
+        [sys.executable, str(RENDERER_RELEASE_GATE_TEST_SCRIPT)],
+    )
+    for args in commands:
+        code, out, err = _run_command(args)
+        output_lines.extend(line for line in (out + err).splitlines() if line.strip())
+        if code != 0:
+            if not output_lines:
+                output_lines = [f"Renderer release gate guard failed with exit code {code}."]
+            return False, output_lines
+
+    return True, output_lines
+
+
 def _tests_unavailable(output: str) -> bool:
     normalized_output = " ".join(output.lower().split())
     markers = (
@@ -870,6 +897,12 @@ def _run_optional_message_guards(cli_args: argparse.Namespace) -> int | None:
             _run_gaussian_layout_guard,
             "Gaussian layout guard failed.",
             "Gaussian layout guard passed.",
+        ),
+        (
+            True,
+            _run_renderer_release_gate_guard,
+            "Renderer release gate guard failed.",
+            "Renderer release gate guard passed.",
         ),
         (
             True,

--- a/tests/ci/test_renderer_release_gates.py
+++ b/tests/ci/test_renderer_release_gates.py
@@ -81,9 +81,44 @@ def _base_manifest(root: Path) -> dict[str, Any]:
             "disallow_missing_gpu_runner_downgrade": True,
             "disallow_open_world_advisory_only": True,
             "required_issue_query": {
+                "classification_labels_any": ["priority:P0", "priority:P1", "release blocker"],
                 "blocking_labels_any": ["priority:P0", "release blocker"],
                 "alpha_relevant_p1_labels_all": ["priority:P1", "alpha-relevant"],
             },
+        },
+        "public_alpha_issue_ledger": {
+            "scope": "open P0, P1, and release-blocker issues from the candidate issue snapshot",
+            "allowed_statuses": ["blocking", "accepted_alpha_limitation", "deferred"],
+            "tracked_issues": [
+                {
+                    "number": 369,
+                    "title": "Audit P0: repair opaque qlty check failures blocking renderer PRs",
+                    "status": "deferred",
+                    "goal": "Keep opaque external quality checks out of the local public-alpha gate unless branch protection makes them required.",
+                    "rationale": "The qlty check is an external advisory signal in this repository policy.",
+                    "evidence_required": [
+                        "GitHub branch protection required_status_checks is empty or absent",
+                        "qlty check remains documented as non-blocking external signal",
+                    ],
+                }
+            ],
+        },
+        "external_status_check_policy": {
+            "branch_protection_required_status_checks": [],
+            "required_for_public_alpha": [],
+            "non_blocking_checks": [
+                {
+                    "context": "qlty check",
+                    "issue": 369,
+                    "classification": "deferred",
+                    "reason": "External qlty check is not required by branch protection in the current repo policy.",
+                    "decision_evidence": [
+                        "master branch protection required_status_checks is null",
+                        "No qlty configuration is tracked in the repo",
+                    ],
+                    "local_gate_behavior": "Do not fail the local renderer release gate solely on qlty check status.",
+                }
+            ],
         },
         "known_limitations_page": "docs/development/known-public-alpha-limitations.md",
         "references": [
@@ -290,6 +325,30 @@ class RendererReleaseGateTests(unittest.TestCase):
             manifest["workflow_policy"]["required_workflows"][0]["manual_input_may_disable"] = False
             failures = checker.validate_contract(root, manifest)
             self.assertTrue(any("not machine-enforced" in item for item in failures))
+
+    def test_issue_ledger_rejects_missing_evidence_requirements(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            manifest["public_alpha_issue_ledger"]["tracked_issues"][0].pop("evidence_required")
+            failures = checker.validate_contract(root, manifest)
+            self.assertTrue(any("classification missing evidence_required" in item for item in failures))
+
+    def test_external_status_policy_keeps_qlty_non_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            manifest["external_status_check_policy"]["non_blocking_checks"][0]["required_for_public_alpha"] = True
+            failures = checker.validate_contract(root, manifest)
+            self.assertTrue(any("cannot be both non-blocking and public-alpha required" in item for item in failures))
+
+    def test_external_status_policy_requires_qlty_entry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            manifest["external_status_check_policy"]["non_blocking_checks"] = []
+            failures = checker.validate_contract(root, manifest)
+            self.assertTrue(any("must classify qlty check" in item for item in failures))
 
     def test_candidate_requires_issue_snapshot(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -732,6 +791,7 @@ class RendererReleaseGateTests(unittest.TestCase):
                     "350": {
                         "status": "accepted_alpha_limitation",
                         "docs_path": "README.md",
+                        "evidence_required": ["published known limitation entry"],
                     }
                 }
             }
@@ -748,12 +808,58 @@ class RendererReleaseGateTests(unittest.TestCase):
                     "350": {
                         "status": "accepted_alpha_limitation",
                         "docs_path": "docs/development/known-public-alpha-limitations.md",
+                        "evidence_required": ["published known limitation entry"],
                     }
                 }
             }
             issues = [{"number": 350, "state": "OPEN", "labels": [{"name": "release blocker"}]}]
             failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
             self.assertEqual([], failures)
+
+    def test_candidate_relevant_p1_requires_classification(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = {"issue_classifications": {}}
+            issues = [{"number": 222, "state": "OPEN", "labels": [{"name": "priority:P1"}]}]
+            failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
+            self.assertTrue(any("issue #222 missing alpha classification" in item for item in failures))
+
+    def test_candidate_uses_manifest_deferred_issue_classification(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = {"issue_classifications": {}}
+            issues = [{"number": 369, "state": "OPEN", "labels": [{"name": "priority:P0"}]}]
+            failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
+            self.assertEqual([], failures)
+
+    def test_candidate_uses_manifest_tracked_issue_even_without_relevant_label(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            manifest["public_alpha_issue_ledger"]["tracked_issues"].append(
+                {
+                    "number": 360,
+                    "title": "Public alpha gate",
+                    "status": "blocking",
+                    "goal": "Keep public alpha evidence explicit.",
+                    "evidence_required": ["candidate mode passes"],
+                }
+            )
+            evidence = {"issue_classifications": {}}
+            issues = [{"number": 360, "state": "OPEN", "labels": [{"name": "priority:P3"}]}]
+            failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
+            self.assertTrue(any("issue #360 is still blocking" in item for item in failures))
+
+    def test_deferred_candidate_classification_requires_evidence_requirements(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = {"issue_classifications": {"222": {"status": "deferred", "rationale": "post-alpha refactor"}}}
+            issues = [{"number": 222, "state": "OPEN", "labels": [{"name": "priority:P1"}]}]
+            failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
+            self.assertTrue(any("classification missing evidence_required" in item for item in failures))
 
     def test_candidate_issue_classification_must_be_object(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/ci/test_renderer_release_gates.py
+++ b/tests/ci/test_renderer_release_gates.py
@@ -379,6 +379,20 @@ class RendererReleaseGateTests(unittest.TestCase):
             failures = checker.validate_contract(root, manifest)
             self.assertEqual([], [failure for failure in failures if "qlty check" in failure])
 
+    def test_external_status_policy_rejects_non_string_status_contexts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            manifest["external_status_check_policy"]["branch_protection_required_status_checks"] = [{"context": "bad"}]
+            manifest["external_status_check_policy"]["required_for_public_alpha"] = [42]
+            manifest["external_status_check_policy"]["non_blocking_checks"][0]["context"] = {"context": "bad"}
+            failures = checker.validate_contract(root, manifest)
+            self.assertTrue(
+                any("branch_protection_required_status_checks[0] must be a non-empty string" in item for item in failures)
+            )
+            self.assertTrue(any("required_for_public_alpha[0] must be a non-empty string" in item for item in failures))
+            self.assertTrue(any("context must be a non-empty string" in item for item in failures))
+
     def test_candidate_requires_issue_snapshot(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -387,15 +401,85 @@ class RendererReleaseGateTests(unittest.TestCase):
             failures = checker.validate_candidate(root, manifest, evidence)
             self.assertTrue(any("issue snapshot missing" in item for item in failures))
 
-    def test_candidate_issue_snapshot_must_include_manifest_tracked_issues(self) -> None:
+    def test_candidate_open_issue_snapshot_may_omit_resolved_manifest_tracked_issues(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             manifest = _base_manifest(root)
             evidence = _valid_candidate_evidence(root)
-            failures = checker.validate_candidate(root, manifest, evidence, [])
-            self.assertTrue(
-                any("issue snapshot missing manifest-tracked issue #369" in item for item in failures)
+            manifest["public_alpha_issue_ledger"]["tracked_issues"].append(
+                {
+                    "number": 360,
+                    "title": "Public alpha gate",
+                    "status": "blocking",
+                    "goal": "Keep public alpha evidence explicit.",
+                    "evidence_required": ["candidate mode passes"],
+                }
             )
+            evidence["resolved_manifest_issues"] = [_issue(360, ["priority:P0"], state="CLOSED")]
+            failures = checker.validate_candidate(root, manifest, evidence, [])
+            self.assertEqual([], failures)
+
+    def test_candidate_rejects_omitted_manifest_blocker_without_closure_proof(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            manifest["public_alpha_issue_ledger"]["tracked_issues"].append(
+                {
+                    "number": 360,
+                    "title": "Public alpha gate",
+                    "status": "blocking",
+                    "goal": "Keep public alpha evidence explicit.",
+                    "evidence_required": ["candidate mode passes"],
+                }
+            )
+            failures = checker.validate_candidate(root, manifest, evidence, [])
+            self.assertTrue(any("missing manifest-tracked blocking issue #360" in item for item in failures))
+
+    def test_candidate_rejects_open_closure_proof_for_omitted_manifest_blocker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            manifest["public_alpha_issue_ledger"]["tracked_issues"].append(
+                {
+                    "number": 360,
+                    "title": "Public alpha gate",
+                    "status": "blocking",
+                    "goal": "Keep public alpha evidence explicit.",
+                    "evidence_required": ["candidate mode passes"],
+                }
+            )
+            evidence["resolved_manifest_issues"] = [_issue(360, ["priority:P0"], state="OPEN")]
+            failures = checker.validate_candidate(root, manifest, evidence, [])
+            self.assertTrue(any("resolved_manifest_issues issue #360 must have state CLOSED" in item for item in failures))
+
+    def test_candidate_rejects_malformed_closure_state_for_omitted_manifest_blocker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            manifest["public_alpha_issue_ledger"]["tracked_issues"].append(
+                {
+                    "number": 360,
+                    "title": "Public alpha gate",
+                    "status": "blocking",
+                    "goal": "Keep public alpha evidence explicit.",
+                    "evidence_required": ["candidate mode passes"],
+                }
+            )
+            evidence["resolved_manifest_issues"] = [_issue(360, ["priority:P0"], state="NOT_A_GITHUB_STATE")]
+            failures = checker.validate_candidate(root, manifest, evidence, [])
+            self.assertTrue(any("resolved_manifest_issues issue #360 must have state CLOSED" in item for item in failures))
+
+    def test_candidate_rejects_malformed_resolved_manifest_issues(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            evidence["resolved_manifest_issues"] = "closed"
+            failures = checker.validate_candidate(root, manifest, evidence, _base_issue_snapshot())
+            self.assertTrue(any("resolved_manifest_issues must be an issue snapshot object or list" in item for item in failures))
 
     def test_candidate_accepts_embedded_issue_snapshot(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/ci/test_renderer_release_gates.py
+++ b/tests/ci/test_renderer_release_gates.py
@@ -896,6 +896,22 @@ class RendererReleaseGateTests(unittest.TestCase):
             failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
             self.assertTrue(any("classification missing evidence_required" in item for item in failures))
 
+    def test_candidate_rejects_legacy_post_alpha_classification(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = {
+                "issue_classifications": {
+                    "222": {
+                        "status": "post_alpha",
+                        "rationale": "legacy release evidence should not bypass current public-alpha policy",
+                    }
+                }
+            }
+            issues = [{"number": 222, "state": "OPEN", "labels": [{"name": "priority:P1"}]}]
+            failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
+            self.assertTrue(any("invalid classification 'post_alpha'" in item for item in failures))
+
     def test_candidate_issue_classification_must_be_object(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/ci/test_renderer_release_gates.py
+++ b/tests/ci/test_renderer_release_gates.py
@@ -892,7 +892,7 @@ class RendererReleaseGateTests(unittest.TestCase):
             root = Path(tmp)
             manifest = _base_manifest(root)
             evidence = _valid_candidate_evidence(root)
-            evidence["artifacts"]["linux_release_archive"]["path"] = "/tmp/release.tar.xz"
+            evidence["artifacts"]["linux_release_archive"]["path"] = str((root.parent / "release.tar.xz").resolve())
             failures = checker._validate_candidate_artifacts(root, manifest, evidence)
             self.assertTrue(any("must be repo-relative" in item for item in failures))
 
@@ -918,7 +918,7 @@ class RendererReleaseGateTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             manifest = _base_manifest(root)
-            manifest["references"].append("/tmp/not-a-repo-reference.md")
+            manifest["references"].append(str((root.parent / "not-a-repo-reference.md").resolve()))
             failures = checker.validate_contract(root, manifest)
             self.assertTrue(any("reference path must be repo-relative" in item for item in failures))
 

--- a/tests/ci/test_renderer_release_gates.py
+++ b/tests/ci/test_renderer_release_gates.py
@@ -241,10 +241,17 @@ def _valid_candidate_evidence(root: Path) -> dict[str, Any]:
                     "godot_binary_mtime_utc": "2026-05-19T10:01:00Z",
                     "capture_count": 1,
                     "capture_reference_match_count": 1,
+                    "capture_threshold_pass_count": 1,
                     "capture_ssim_min": 0.99,
                     "capture_psnr_min": 40.0,
                     "gpu_timing_available": False,
                     "gpu_timing_source": "unavailable",
+                    "exit_code": 0,
+                    "report_valid": True,
+                    "visible_output_valid": True,
+                    "visual_reference_match": True,
+                    "proof_valid": True,
+                    "lane_valid": True,
                 }
             ]
         ),
@@ -728,6 +735,79 @@ class RendererReleaseGateTests(unittest.TestCase):
             failures = checker._validate_candidate_benchmark_report(root, manifest, evidence)
             self.assertTrue(any("capture_count must be numeric" in item for item in failures))
 
+    def test_candidate_benchmark_commit_must_match_candidate_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            _write(
+                root / "bench.json",
+                json.dumps(
+                    [
+                        {
+                            "lane_id": "static_baseline",
+                            "commit_sha": "old",
+                            "godot_binary_commit": "old",
+                            "godot_binary_mtime_utc": "2026-05-19T10:01:00Z",
+                            "capture_count": 1,
+                            "capture_reference_match_count": 1,
+                            "capture_threshold_pass_count": 1,
+                            "capture_ssim_min": 0.99,
+                            "capture_psnr_min": 40.0,
+                            "gpu_timing_available": False,
+                            "gpu_timing_source": "unavailable",
+                        }
+                    ]
+                ),
+            )
+            failures = checker._validate_candidate_benchmark_report(root, manifest, evidence)
+            self.assertTrue(any("commit_sha does not match candidate commit" in item for item in failures))
+            self.assertTrue(any("godot_binary_commit does not match candidate commit" in item for item in failures))
+
+    def test_candidate_benchmark_exit_code_must_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            lane = json.loads((root / "bench.json").read_text(encoding="utf-8"))[0]
+            lane["exit_code"] = 7
+            lane["lane_valid"] = False
+            _write(root / "bench.json", json.dumps([lane]))
+            failures = checker._validate_candidate_benchmark_report(root, manifest, evidence)
+            self.assertTrue(any("exited with 7" in item for item in failures))
+            self.assertTrue(any("lane_valid=false" in item for item in failures))
+
+    def test_candidate_benchmark_visual_thresholds_must_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            lane = json.loads((root / "bench.json").read_text(encoding="utf-8"))[0]
+            lane["capture_threshold_pass_count"] = 0
+            lane["visual_reference_match"] = False
+            _write(root / "bench.json", json.dumps([lane]))
+            failures = checker._validate_candidate_benchmark_report(root, manifest, evidence)
+            self.assertTrue(any("did not pass all visual thresholds" in item for item in failures))
+            self.assertTrue(any("failed visual reference match" in item for item in failures))
+
+    def test_candidate_benchmark_rejects_cpu_sort_route_and_fallback_counters(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            lane = json.loads((root / "bench.json").read_text(encoding="utf-8"))[0]
+            lane["cpu_sort_route_detected"] = True
+            lane["cpu_sort_route_uid"] = "INSTANCE_SORT_CPU_FALLBACK"
+            lane["sort_total_route_fallback_count"] = 2
+            _write(root / "bench.json", json.dumps([lane]))
+            failures = checker._validate_candidate_benchmark_report(root, manifest, evidence)
+            self.assertTrue(any("forbidden CPU sort route" in item for item in failures))
+            self.assertTrue(any("unallowed sort fallback routes" in item for item in failures))
+
+    def test_candidate_json_numbers_must_be_finite(self) -> None:
+        self.assertFalse(checker._is_json_number(float("nan")))
+        self.assertFalse(checker._is_json_number(float("inf")))
+
     def test_candidate_fails_stale_and_incomplete_artifacts(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -864,16 +944,18 @@ class RendererReleaseGateTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             manifest = _base_manifest(root)
-            _write(root / "README.md", "not the known limitations page\n")
-            evidence = {
-                "issue_classifications": {
-                    "350": {
-                        "status": "accepted_alpha_limitation",
-                        "docs_path": "README.md",
-                        "evidence_required": ["published known limitation entry"],
-                    }
+            manifest["public_alpha_issue_ledger"]["tracked_issues"].append(
+                {
+                    "number": 350,
+                    "title": "Known limitation",
+                    "status": "accepted_alpha_limitation",
+                    "goal": "Document the public alpha limitation.",
+                    "docs_path": "README.md",
+                    "evidence_required": ["published known limitation entry"],
                 }
-            }
+            )
+            _write(root / "README.md", "not the known limitations page\n")
+            evidence = {"issue_classifications": {}}
             issues = _base_issue_snapshot(_issue(350, ["release blocker"]))
             failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
             self.assertTrue(any("accepted limitation must use known_limitations_page" in item for item in failures))
@@ -882,15 +964,17 @@ class RendererReleaseGateTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             manifest = _base_manifest(root)
-            evidence = {
-                "issue_classifications": {
-                    "350": {
-                        "status": "accepted_alpha_limitation",
-                        "docs_path": "docs/development/known-public-alpha-limitations.md",
-                        "evidence_required": ["published known limitation entry"],
-                    }
+            manifest["public_alpha_issue_ledger"]["tracked_issues"].append(
+                {
+                    "number": 350,
+                    "title": "Known limitation",
+                    "status": "accepted_alpha_limitation",
+                    "goal": "Document the public alpha limitation.",
+                    "docs_path": "docs/development/known-public-alpha-limitations.md",
+                    "evidence_required": ["published known limitation entry"],
                 }
-            }
+            )
+            evidence = {"issue_classifications": {}}
             issues = _base_issue_snapshot(_issue(350, ["release blocker"]))
             failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
             self.assertEqual([], failures)
@@ -964,7 +1048,43 @@ class RendererReleaseGateTests(unittest.TestCase):
             evidence = {"issue_classifications": {"222": {"status": "deferred", "rationale": "post-alpha refactor"}}}
             issues = [{"number": 222, "state": "OPEN", "labels": [{"name": "priority:P1"}]}]
             failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
-            self.assertTrue(any("classification missing evidence_required" in item for item in failures))
+            self.assertTrue(any("classification must be tracked in public_alpha_issue_ledger" in item for item in failures))
+
+    def test_candidate_rejects_untracked_accepted_limitation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = {
+                "issue_classifications": {
+                    "222": {
+                        "status": "accepted_alpha_limitation",
+                        "docs_path": "docs/development/known-public-alpha-limitations.md",
+                        "evidence_required": ["published known limitation entry"],
+                    }
+                }
+            }
+            issues = [{"number": 222, "state": "OPEN", "labels": [{"name": "priority:P1"}]}]
+            failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
+            self.assertTrue(any("classification must be tracked in public_alpha_issue_ledger" in item for item in failures))
+
+    def test_candidate_closed_manifest_blocker_does_not_require_open_issue(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            manifest["public_alpha_issue_ledger"]["tracked_issues"].append(
+                {
+                    "number": 360,
+                    "title": "Public alpha gate",
+                    "status": "blocking",
+                    "goal": "Keep public alpha evidence explicit.",
+                    "evidence_required": ["candidate mode passes"],
+                }
+            )
+            evidence = {"issue_classifications": {}}
+            issues = _base_issue_snapshot(_issue(360, ["priority:P0"], state="CLOSED"))
+            failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
+            self.assertFalse(any("manifest-tracked issue #360" in item for item in failures))
+            self.assertFalse(any("issue #360 is still blocking" in item for item in failures))
 
     def test_candidate_rejects_legacy_post_alpha_classification(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/ci/test_renderer_release_gates.py
+++ b/tests/ci/test_renderer_release_gates.py
@@ -84,6 +84,7 @@ def _base_manifest(root: Path) -> dict[str, Any]:
                 "classification_labels_any": ["priority:P0", "priority:P1", "release blocker"],
                 "blocking_labels_any": ["priority:P0", "release blocker"],
                 "alpha_relevant_p1_labels_all": ["priority:P1", "alpha-relevant"],
+                "allowed_classifications": ["blocking", "accepted_alpha_limitation", "deferred"],
             },
         },
         "public_alpha_issue_ledger": {
@@ -196,6 +197,18 @@ def _base_manifest(root: Path) -> dict[str, Any]:
             "each_artifact_requires": ["path", "sha256", "godot_binary_commit", "godot_binary_mtime_utc"],
         },
     }
+
+
+def _issue(number: int, labels: list[str], state: str = "OPEN") -> dict[str, Any]:
+    return {
+        "number": number,
+        "state": state,
+        "labels": [{"name": label} for label in labels],
+    }
+
+
+def _base_issue_snapshot(*extra: dict[str, Any]) -> list[dict[str, Any]]:
+    return [_issue(369, ["priority:P0"])] + list(extra)
 
 
 def _valid_candidate_evidence(root: Path) -> dict[str, Any]:
@@ -367,12 +380,22 @@ class RendererReleaseGateTests(unittest.TestCase):
             failures = checker.validate_candidate(root, manifest, evidence)
             self.assertTrue(any("issue snapshot missing" in item for item in failures))
 
+    def test_candidate_issue_snapshot_must_include_manifest_tracked_issues(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            failures = checker.validate_candidate(root, manifest, evidence, [])
+            self.assertTrue(
+                any("issue snapshot missing manifest-tracked issue #369" in item for item in failures)
+            )
+
     def test_candidate_accepts_embedded_issue_snapshot(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             manifest = _base_manifest(root)
             evidence = _valid_candidate_evidence(root)
-            evidence["issue_snapshot"] = []
+            evidence["issue_snapshot"] = _base_issue_snapshot()
             failures = checker.validate_candidate(root, manifest, evidence)
             self.assertEqual([], failures)
 
@@ -393,8 +416,20 @@ class RendererReleaseGateTests(unittest.TestCase):
             evidence = _valid_candidate_evidence(root)
             evidence["release_channel"] = "nightly"
             evidence["release_tag"] = "v1.0.0-alpha.1"
-            failures = checker.validate_candidate(root, manifest, evidence, [])
+            failures = checker.validate_candidate(root, manifest, evidence, _base_issue_snapshot())
             self.assertEqual([], failures)
+
+    def test_issue_status_policy_must_match_manifest_ledger(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            manifest["public_alpha_predicate"]["required_issue_query"]["allowed_classifications"] = [
+                "blocking",
+                "accepted_alpha_limitation",
+                "post_alpha",
+            ]
+            failures = checker.validate_contract(root, manifest)
+            self.assertTrue(any("allowed_classifications must be" in item for item in failures))
 
     def test_candidate_requires_commit_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -772,6 +807,41 @@ class RendererReleaseGateTests(unittest.TestCase):
             failures = checker._validate_candidate_artifacts(root, manifest, evidence)
             self.assertTrue(any("artifact linux_release_archive path missing" in item for item in failures))
 
+    def test_candidate_artifact_paths_must_be_repo_relative(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            evidence["artifacts"]["linux_release_archive"]["path"] = "/tmp/release.tar.xz"
+            failures = checker._validate_candidate_artifacts(root, manifest, evidence)
+            self.assertTrue(any("must be repo-relative" in item for item in failures))
+
+    def test_candidate_artifact_paths_must_not_escape_repo(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            evidence["artifacts"]["linux_release_archive"]["path"] = "../release.tar.xz"
+            failures = checker._validate_candidate_artifacts(root, manifest, evidence)
+            self.assertTrue(any("must not escape the repository" in item for item in failures))
+
+    def test_candidate_report_paths_must_not_escape_repo(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = _valid_candidate_evidence(root)
+            evidence["gpu_harness_report"] = "../gpu_report.json"
+            failures = checker._validate_candidate_gpu_report(root, manifest, evidence)
+            self.assertTrue(any("must not escape the repository" in item for item in failures))
+
+    def test_manifest_references_must_be_repo_relative(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            manifest["references"].append("/tmp/not-a-repo-reference.md")
+            failures = checker.validate_contract(root, manifest)
+            self.assertTrue(any("reference path must be repo-relative" in item for item in failures))
+
     def test_candidate_artifact_sha256_must_match_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -804,7 +874,7 @@ class RendererReleaseGateTests(unittest.TestCase):
                     }
                 }
             }
-            issues = [{"number": 350, "state": "OPEN", "labels": [{"name": "release blocker"}]}]
+            issues = _base_issue_snapshot(_issue(350, ["release blocker"]))
             failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
             self.assertTrue(any("accepted limitation must use known_limitations_page" in item for item in failures))
 
@@ -821,7 +891,7 @@ class RendererReleaseGateTests(unittest.TestCase):
                     }
                 }
             }
-            issues = [{"number": 350, "state": "OPEN", "labels": [{"name": "release blocker"}]}]
+            issues = _base_issue_snapshot(_issue(350, ["release blocker"]))
             failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
             self.assertEqual([], failures)
 
@@ -911,6 +981,22 @@ class RendererReleaseGateTests(unittest.TestCase):
             issues = [{"number": 222, "state": "OPEN", "labels": [{"name": "priority:P1"}]}]
             failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
             self.assertTrue(any("invalid classification 'post_alpha'" in item for item in failures))
+
+    def test_candidate_rejects_unlisted_blocker_alias(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            evidence = {
+                "issue_classifications": {
+                    "222": {
+                        "status": "blocker",
+                        "evidence_required": ["legacy alias should not be accepted"],
+                    }
+                }
+            }
+            issues = [{"number": 222, "state": "OPEN", "labels": [{"name": "priority:P1"}]}]
+            failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
+            self.assertTrue(any("invalid classification 'blocker'" in item for item in failures))
 
     def test_candidate_issue_classification_must_be_object(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/ci/test_renderer_release_gates.py
+++ b/tests/ci/test_renderer_release_gates.py
@@ -348,7 +348,16 @@ class RendererReleaseGateTests(unittest.TestCase):
             manifest = _base_manifest(root)
             manifest["external_status_check_policy"]["non_blocking_checks"] = []
             failures = checker.validate_contract(root, manifest)
-            self.assertTrue(any("must classify qlty check" in item for item in failures))
+            self.assertTrue(any("must classify qlty check as required or non-blocking" in item for item in failures))
+
+    def test_external_status_policy_allows_qlty_to_be_required(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            manifest["external_status_check_policy"]["required_for_public_alpha"] = ["qlty check"]
+            manifest["external_status_check_policy"]["non_blocking_checks"] = []
+            failures = checker.validate_contract(root, manifest)
+            self.assertEqual([], [failure for failure in failures if "qlty check" in failure])
 
     def test_candidate_requires_issue_snapshot(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -849,6 +858,32 @@ class RendererReleaseGateTests(unittest.TestCase):
             )
             evidence = {"issue_classifications": {}}
             issues = [{"number": 360, "state": "OPEN", "labels": [{"name": "priority:P3"}]}]
+            failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
+            self.assertTrue(any("issue #360 is still blocking" in item for item in failures))
+
+    def test_candidate_cannot_downgrade_manifest_blocker_with_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            manifest["public_alpha_issue_ledger"]["tracked_issues"].append(
+                {
+                    "number": 360,
+                    "title": "Public alpha gate",
+                    "status": "blocking",
+                    "goal": "Keep public alpha evidence explicit.",
+                    "evidence_required": ["candidate mode passes"],
+                }
+            )
+            evidence = {
+                "issue_classifications": {
+                    "360": {
+                        "status": "deferred",
+                        "rationale": "claimed downstream follow-up",
+                        "evidence_required": ["release owner approval"],
+                    }
+                }
+            }
+            issues = [{"number": 360, "state": "OPEN", "labels": [{"name": "priority:P0"}]}]
             failures = checker._validate_candidate_issues(root, manifest, evidence, issues)
             self.assertTrue(any("issue #360 is still blocking" in item for item in failures))
 


### PR DESCRIPTION
## Goal

Make the public-alpha milestone enforceable instead of relying on chat state or stale issue memory. The renderer goal is a production-ready Gaussian splat render engine where release decisions are backed by explicit evidence, issue classifications, known limitations, and reproducible local gates.

## What changed

- Adds a manifest-backed public-alpha issue ledger for #351, #352, #360, and #369.
- Requires open `priority:P0`, `priority:P1`, and `release blocker` issues to be classified for candidate mode.
- Adds `deferred` as an explicit classification with rationale and evidence requirements.
- Documents `qlty check` as a deferred, non-blocking external signal while branch protection has no required status checks and no repo-owned qlty config/log contract exists.
- Refreshes the module `RequiresGPU` snapshot from 93 to 96 tests.

## Validation

- `python3 -m unittest tests.ci.test_renderer_release_gates`
- `python3 tests/ci/check_renderer_release_gates.py --mode contract`
- `git diff --check`

Refs #351
Refs #352
Refs #360
Refs #369