### PR TITLE
[codex] Preserve selected route and downstream skip contracts

### DIFF
--- a/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.cpp
@@ -190,6 +190,8 @@ static Array _production_metrics_contract() {
 	keys.push_back("stage_skip_cause");
 	keys.push_back("stage_has_degradation");
 	keys.push_back("stage_composite_depth_test_honored");
+	keys.push_back("selected_route_uid");
+	keys.push_back("selected_route_backend");
 	keys.push_back("route_uid");
 	keys.push_back("sort_route_uid");
 	keys.push_back("cull_route_uid");
@@ -367,6 +369,8 @@ static void _append_production_stage_contract_metrics(Dictionary &r_metrics,
 	r_metrics["stage_skip_cause"] = p_stage_valid ? p_stage_metrics.skip_cause_stage : String();
 	r_metrics["stage_has_degradation"] = p_stage_valid ? p_stage_metrics.has_degradation : false;
 	r_metrics["stage_composite_depth_test_honored"] = p_stage_valid ? p_stage_metrics.composite_depth_test_honored : true;
+	r_metrics["selected_route_uid"] = p_stage_valid ? p_stage_metrics.route_uid : String();
+	r_metrics["selected_route_backend"] = p_stage_valid ? p_stage_metrics.selected_route_backend : String();
 }
 
 static Dictionary _build_production_metrics_snapshot(GaussianSplatRenderer &p_renderer,
@@ -533,6 +537,8 @@ static void _append_telemetry_extras(const GaussianSplatRenderer &p_renderer,
 	r_metrics["stage_composite_depth_test_honored"] = p_stage_metrics.composite_depth_test_honored;
 	r_metrics["stage_composite_degraded"] = p_stage_metrics.composite_result.degraded;
 	r_metrics["stage_composite_strict_contract_violation"] = p_stage_metrics.composite_result.strict_contract_violation;
+	r_metrics["selected_route_uid"] = p_stage_valid ? p_stage_metrics.route_uid : String();
+	r_metrics["selected_route_backend"] = p_stage_valid ? p_stage_metrics.selected_route_backend : String();
 	r_metrics["route_uid"] = debug_state.route_uid;
 	r_metrics["sort_route_uid"] = debug_state.sort_route_uid;
 	_append_raster_specialization_metrics(perf, r_metrics);
@@ -829,12 +835,23 @@ static Dictionary _validate_production_metrics(const Dictionary &p_metrics) {
 		issues.push_back("stage_metrics_invalid");
 	}
 	const String route_uid = p_metrics.get("route_uid", String());
+	const String selected_route_uid = p_metrics.get("selected_route_uid", String());
+	const String selected_route_backend = p_metrics.get("selected_route_backend", String());
 	const String sort_route_uid = p_metrics.get("sort_route_uid", String());
 	const String cull_route_uid = p_metrics.get("cull_route_uid", String());
 	const String cull_route_reason = p_metrics.get("cull_route_reason", String());
 	const bool route_no_device = route_uid == String(RenderRouteUID::COMMON_FAIL_NO_DEVICE);
 	if (stage_valid && route_uid.is_empty()) {
 		issues.push_back("route_uid_empty");
+	}
+	if (stage_valid && selected_route_uid.is_empty()) {
+		issues.push_back("selected_route_uid_empty");
+	}
+	if (stage_valid && RenderRouteUID::is_route_uid_missing(selected_route_uid)) {
+		issues.push_back("selected_route_uid_missing");
+	}
+	if (stage_valid && selected_route_backend.is_empty()) {
+		issues.push_back("selected_route_backend_empty");
 	}
 	// No-device fallback can legitimately skip sort-route assignment.
 	if (stage_valid && !route_no_device && sort_route_uid.is_empty()) {
@@ -1475,6 +1492,8 @@ Dictionary RenderDiagnosticsOrchestrator::build_render_stats() const {
 			GaussianRenderRouteLabels::describe_cull_route_reason(perf.cull_route_reason);
 	if (debug_state.last_stage_metrics_valid) {
 		const GaussianSplatRenderer::StageMetrics &stage_metrics = debug_state.last_stage_metrics;
+		stats["selected_route_uid"] = stage_metrics.route_uid;
+		stats["selected_route_backend"] = stage_metrics.selected_route_backend;
 		stats["stage_first_failure"] = stage_metrics.first_failure_stage;
 		stats["stage_skip_cause"] = stage_metrics.skip_cause_stage;
 		stats["stage_first_failure_instance_index"] = static_cast<int64_t>(stage_metrics.first_failure_instance_index);

--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -1158,10 +1158,11 @@ void RenderPipelineStages::execute_frame_entry(const RenderFrameContext &p_frame
 					frame_plan.cull_skip_reason_code);
 			stamp_stage_result_contract(frame_context.metrics->cull_result, "cull", frame_plan.route_decision.route_uid,
 					GaussianSplatRenderer::IndexDomain::UNKNOWN, GaussianSplatRenderer::IndexDomain::UNKNOWN, 0, 0);
-			frame_context.metrics->sort_result = _make_stage_result(
-					StageResult::StageStatus::SKIPPED,
-					frame_plan.sort_skip_reason,
-					false,
+			const String sort_reason = frame_plan.sort_skip_reason.is_empty()
+					? String("Sort skipped: cull skipped")
+					: frame_plan.sort_skip_reason;
+			frame_context.metrics->sort_result = make_downstream_skip_result(
+					"sort", frame_context.metrics->cull_result, sort_reason,
 					frame_plan.sort_skip_reason_code);
 			stamp_stage_result_contract(frame_context.metrics->sort_result, "sort", frame_plan.route_decision.route_uid,
 					GaussianSplatRenderer::IndexDomain::UNKNOWN, GaussianSplatRenderer::IndexDomain::UNKNOWN, 0, 0);

--- a/modules/gaussian_splatting/tests/test_diagnostics.h
+++ b/modules/gaussian_splatting/tests/test_diagnostics.h
@@ -212,6 +212,8 @@ TEST_CASE("[Gaussian Diagnostics] Production metrics preserve GPU timing capture
     debug_state.sort_route_uid = RenderRouteUID::INSTANCE_SORT_GPU;
     debug_state.last_stage_metrics_valid = true;
     GaussianSplatRenderer::StageMetrics &stage_metrics = debug_state.last_stage_metrics;
+    stage_metrics.route_uid = RenderRouteUID::INSTANCE_STREAMING;
+    stage_metrics.selected_route_backend = "streaming";
     stage_metrics.cull.has_visible = true;
     stage_metrics.cull.visible_count = 2048;
     stage_metrics.cull.candidate_count = 4096;
@@ -261,6 +263,8 @@ TEST_CASE("[Gaussian Diagnostics] Production metrics preserve GPU timing capture
     diagnostics_require_key(production_metrics, "raster_overlap_thinning_keep_ratio");
     diagnostics_require_key(production_metrics, "raster_feature_tighter_bounds");
     diagnostics_require_key(production_metrics, "raster_shader_defines_hash");
+    diagnostics_require_key(production_metrics, "selected_route_uid");
+    diagnostics_require_key(production_metrics, "selected_route_backend");
 
     CHECK(float(production_metrics.get("gpu_frame_ms", 0.0f)) == doctest::Approx(3.50f));
     CHECK(float(production_metrics.get("gpu_binning_ms", 0.0f)) == doctest::Approx(0.40f));
@@ -275,6 +279,8 @@ TEST_CASE("[Gaussian Diagnostics] Production metrics preserve GPU timing capture
     CHECK(float(production_metrics.get("raster_overlap_thinning_keep_ratio", 0.0f)) == doctest::Approx(0.875f));
     CHECK(bool(production_metrics.get("raster_feature_tighter_bounds", false)));
     CHECK(String(production_metrics.get("raster_shader_defines_hash", String())) == "12345");
+    CHECK(String(production_metrics.get("selected_route_uid", String())) == String(RenderRouteUID::INSTANCE_STREAMING));
+    CHECK(String(production_metrics.get("selected_route_backend", String())) == String("streaming"));
     CHECK(bool(validation.get("valid", false)));
 
     CHECK(float(telemetry.get("gpu_frame_time_ms", 0.0f)) == doctest::Approx(3.50f));
@@ -286,6 +292,8 @@ TEST_CASE("[Gaussian Diagnostics] Production metrics preserve GPU timing capture
     CHECK(int64_t(telemetry.get("gpu_timing_frames_behind", int64_t(-1))) == 2);
     CHECK(int64_t(telemetry.get("raster_overlap_records", int64_t(0))) == 300000);
     CHECK(bool(telemetry.get("raster_feature_quantized_storage", false)));
+    CHECK(String(telemetry.get("selected_route_uid", String())) == String(RenderRouteUID::INSTANCE_STREAMING));
+    CHECK(String(telemetry.get("selected_route_backend", String())) == String("streaming"));
 
     Array summaries = snapshot.get("production_metrics_summaries", Array());
     REQUIRE(summaries.size() == 1);

--- a/modules/gaussian_splatting/tests/test_renderer_pipeline.h
+++ b/modules/gaussian_splatting/tests/test_renderer_pipeline.h
@@ -134,6 +134,35 @@ TEST_CASE("[GaussianSplatting] Downstream skip contract does not invent first fa
 	CHECK(metrics.skip_cause_stage == String("sort"));
 }
 
+TEST_CASE("[GaussianSplatting] Route-not-ready sort skip blocks raster before no-visible fallback") {
+	GaussianSplatRenderer::StageResult cull_skip;
+	cull_skip.status = GaussianSplatRenderer::StageResult::StageStatus::SKIPPED;
+	cull_skip.reason = "Cull skipped: streaming data unavailable";
+	cull_skip.fallback_reason = GaussianSplatRenderer::RenderFallbackReason::STREAMING_DATA_UNAVAILABLE;
+	RenderPipelineStages::stamp_stage_result_contract(cull_skip, "cull",
+			RenderRouteUID::COMMON_SKIP_STREAMING_NOT_READY,
+			GaussianSplatRenderer::IndexDomain::UNKNOWN,
+			GaussianSplatRenderer::IndexDomain::UNKNOWN, 0, 0);
+
+	GaussianSplatRenderer::StageResult sort_skip =
+			RenderPipelineStages::make_downstream_skip_result("sort", cull_skip,
+					"Sort skipped: streaming data unavailable",
+					GaussianSplatRenderer::RenderFallbackReason::STREAMING_DATA_UNAVAILABLE);
+	RenderPipelineStages::stamp_stage_result_contract(sort_skip, "sort", cull_skip.route_uid,
+			GaussianSplatRenderer::IndexDomain::UNKNOWN,
+			GaussianSplatRenderer::IndexDomain::UNKNOWN, 0, 0);
+
+	CHECK(sort_skip.status == GaussianSplatRenderer::StageResult::StageStatus::SKIPPED);
+	CHECK(sort_skip.first_failure_stage.is_empty());
+	CHECK(sort_skip.skip_cause_stage == String("cull"));
+	CHECK(sort_skip.route_uid == String(RenderRouteUID::COMMON_SKIP_STREAMING_NOT_READY));
+
+	const bool upstream_blocks_raster =
+			sort_skip.status == GaussianSplatRenderer::StageResult::StageStatus::SKIPPED &&
+			!sort_skip.skip_cause_stage.is_empty();
+	CHECK(upstream_blocks_raster);
+}
+
 TEST_CASE("[GaussianSplatting] Composite copy failure becomes a failed stage result") {
 	GaussianSplatRenderer::StageResult result = RenderPipelineStages::make_composite_copy_result(
 			true, false, "framebuffer copy failed", false, String(), true, false, false);


### PR DESCRIPTION
## Goal

Close the highest-risk gap in the route/stage contract work: every production frame needs an explicit selected route and downstream stages must preserve the upstream skip cause. The broader renderer goal is a pipeline that can be debugged under pressure without guessing whether no-output came from route selection, cull, sort, raster, or composite.

## What changed

- Exposes `selected_route_uid` and `selected_route_backend` in production metrics, telemetry, validation, and render stats.
- Treats no-render-data sort skip as a downstream skip caused by cull, instead of letting later logic collapse into a generic no-visible fallback.
- Adds focused tests for route-not-ready skip behavior and diagnostics selected-route preservation.

## Validation

- `python3 tests/ci/run_module_tests.py --guard-only --base-ref origin/master`
- `scons platform=linuxbsd target=editor dev_build=yes tests=yes module_gaussian_splatting_enabled=yes progress=no -j2 bin/obj/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.linuxbsd.editor.dev.x86_64.o bin/obj/modules/gaussian_splatting/renderer/render_pipeline_stages.linuxbsd.editor.dev.x86_64.o bin/obj/modules/gaussian_splatting/tests/test_gaussian_splatting.linuxbsd.editor.dev.x86_64.o`
- `git diff --check`

Refs #351