### PR TITLE
[codex] Prove compositor GPU lifetime cleanup

### DIFF
--- a/modules/gaussian_splatting/interfaces/output_compositor.cpp
+++ b/modules/gaussian_splatting/interfaces/output_compositor.cpp
@@ -286,6 +286,24 @@ void OutputCompositor::_forget_resource(const RID &p_rid) {
     }
 }
 
+void OutputCompositor::_free_tracked_resource(RenderingDevice *p_fallback_device, RID &r_rid) {
+    if (!r_rid.is_valid()) {
+        return;
+    }
+
+    if (device_manager.is_valid()) {
+        if (device_manager->has_tracked_resource(r_rid)) {
+            device_manager->free_owned_resource(p_fallback_device, r_rid);
+            return;
+        }
+    }
+
+    if (p_fallback_device) {
+        p_fallback_device->free(r_rid);
+    }
+    r_rid = RID();
+}
+
 // Static helper methods
 bool OutputCompositor::_is_depth_attachment_format(RD::DataFormat p_format) {
     switch (p_format) {
@@ -418,10 +436,7 @@ RID OutputCompositor::_ensure_viewport_blit_sampler(RenderingDevice *p_device) {
         }
 
         RenderingDevice *owner_device = existing->owner_device ? existing->owner_device : p_device;
-        if (existing->sampler.is_valid() && owner_device) {
-            owner_device->free(existing->sampler);
-        }
-        _forget_resource(existing->sampler);
+        _free_tracked_resource(owner_device, existing->sampler);
         viewport_blit_samplers.erase(device_key);
     }
 
@@ -477,10 +492,7 @@ RID OutputCompositor::_ensure_viewport_blit_scratch(RenderingDevice *p_device, c
             return existing->texture;
         }
         RenderingDevice *owner_device = existing->owner_device ? existing->owner_device : p_device;
-        if (existing->texture.is_valid() && owner_device) {
-            owner_device->free(existing->texture);
-        }
-        _forget_resource(existing->texture);
+        _free_tracked_resource(owner_device, existing->texture);
         viewport_blit_scratch.erase(key);
     }
 
@@ -504,11 +516,7 @@ RID OutputCompositor::_ensure_viewport_blit_scratch(RenderingDevice *p_device, c
             ViewportBlitScratch *victim = viewport_blit_scratch.getptr(oldest_key);
             if (victim) {
                 RenderingDevice *owner_device = victim->owner_device ? victim->owner_device : p_device;
-                if (victim->texture.is_valid() && owner_device &&
-                        owner_device->texture_is_valid(victim->texture)) {
-                    owner_device->free(victim->texture);
-                }
-                _forget_resource(victim->texture);
+                _free_tracked_resource(owner_device, victim->texture);
                 viewport_blit_scratch.erase(oldest_key);
             }
         }
@@ -572,16 +580,8 @@ bool OutputCompositor::_ensure_viewport_blit_pipeline(RenderingDevice *p_device,
         }
 
         RenderingDevice *owner_device = variant->owner_device ? variant->owner_device : p_device;
-        if (owner_device) {
-            if (variant->pipeline.is_valid() && owner_device->compute_pipeline_is_valid(variant->pipeline)) {
-                owner_device->free(variant->pipeline);
-            }
-            if (variant->shader.is_valid()) {
-                owner_device->free(variant->shader);
-            }
-        }
-        _forget_resource(variant->pipeline);
-        _forget_resource(variant->shader);
+        _free_tracked_resource(owner_device, variant->pipeline);
+        _free_tracked_resource(owner_device, variant->shader);
         viewport_blit_variants.erase(key);
     }
 
@@ -647,10 +647,7 @@ void OutputCompositor::clear_cached_framebuffers() {
     for (KeyValue<uint64_t, CachedFramebuffer> &E : output_cache.cached_framebuffers) {
         CachedFramebuffer &entry = E.value;
         RenderingDevice *fb_device = entry.device ? entry.device : rd;
-        if (entry.framebuffer.is_valid() && fb_device && fb_device->framebuffer_is_valid(entry.framebuffer)) {
-            fb_device->free(entry.framebuffer);
-        }
-        _forget_resource(entry.framebuffer);
+        _free_tracked_resource(fb_device, entry.framebuffer);
     }
 
     output_cache.cached_framebuffers.clear();
@@ -662,34 +659,20 @@ void OutputCompositor::clear_viewport_blit_resources() {
     for (KeyValue<uint64_t, ViewportBlitVariant> &E : viewport_blit_variants) {
         ViewportBlitVariant &variant = E.value;
         RenderingDevice *owner_device = variant.owner_device ? variant.owner_device : rd;
-        if (owner_device) {
-            if (variant.pipeline.is_valid() && owner_device->compute_pipeline_is_valid(variant.pipeline)) {
-                owner_device->free(variant.pipeline);
-            }
-            if (variant.shader.is_valid()) {
-                owner_device->free(variant.shader);
-            }
-        }
-        _forget_resource(variant.pipeline);
-        _forget_resource(variant.shader);
+        _free_tracked_resource(owner_device, variant.pipeline);
+        _free_tracked_resource(owner_device, variant.shader);
     }
 
     for (KeyValue<uint64_t, ViewportBlitSampler> &E : viewport_blit_samplers) {
         ViewportBlitSampler &sampler_entry = E.value;
         RenderingDevice *owner_device = sampler_entry.owner_device ? sampler_entry.owner_device : rd;
-        if (sampler_entry.sampler.is_valid() && owner_device) {
-            owner_device->free(sampler_entry.sampler);
-        }
-        _forget_resource(sampler_entry.sampler);
+        _free_tracked_resource(owner_device, sampler_entry.sampler);
     }
 
     for (KeyValue<uint64_t, ViewportBlitScratch> &E : viewport_blit_scratch) {
         ViewportBlitScratch &scratch_entry = E.value;
         RenderingDevice *owner_device = scratch_entry.owner_device ? scratch_entry.owner_device : rd;
-        if (scratch_entry.texture.is_valid() && owner_device && owner_device->texture_is_valid(scratch_entry.texture)) {
-            owner_device->free(scratch_entry.texture);
-        }
-        _forget_resource(scratch_entry.texture);
+        _free_tracked_resource(owner_device, scratch_entry.texture);
     }
 
     viewport_blit_variants.clear();
@@ -710,10 +693,7 @@ RID OutputCompositor::get_cached_framebuffer(RenderingDevice *p_device, const RI
                 entry_device && entry_device->framebuffer_is_valid(entry->framebuffer)) {
             return entry->framebuffer;
         }
-        if (entry->framebuffer.is_valid() && entry_device && entry_device->framebuffer_is_valid(entry->framebuffer)) {
-            entry_device->free(entry->framebuffer);
-        }
-        _forget_resource(entry->framebuffer);
+        _free_tracked_resource(entry_device, entry->framebuffer);
         output_cache.cached_framebuffers.erase(key);
     }
 

--- a/modules/gaussian_splatting/interfaces/output_compositor.cpp
+++ b/modules/gaussian_splatting/interfaces/output_compositor.cpp
@@ -286,7 +286,7 @@ void OutputCompositor::_forget_resource(const RID &p_rid) {
     }
 }
 
-void OutputCompositor::_free_tracked_resource(RenderingDevice *p_fallback_device, RID &r_rid) {
+void OutputCompositor::_free_tracked_resource(RenderingDevice *p_fallback_device, RID &r_rid, TrackedResourceKind p_kind) {
     if (!r_rid.is_valid()) {
         return;
     }
@@ -299,7 +299,28 @@ void OutputCompositor::_free_tracked_resource(RenderingDevice *p_fallback_device
     }
 
     if (p_fallback_device) {
-        p_fallback_device->free(r_rid);
+        bool resource_valid = false;
+        switch (p_kind) {
+            case TrackedResourceKind::Texture:
+                resource_valid = p_fallback_device->texture_is_valid(r_rid);
+                break;
+            case TrackedResourceKind::Framebuffer:
+                resource_valid = p_fallback_device->framebuffer_is_valid(r_rid);
+                break;
+            case TrackedResourceKind::ComputePipeline:
+                resource_valid = p_fallback_device->compute_pipeline_is_valid(r_rid);
+                break;
+            case TrackedResourceKind::Shader:
+            case TrackedResourceKind::Sampler:
+                // RenderingDevice exposes no shader/sampler validity query. These
+                // resources are normally ledger-tracked; untracked fallback keeps
+                // the previous best-effort behavior for legacy cached entries.
+                resource_valid = true;
+                break;
+        }
+        if (resource_valid) {
+            p_fallback_device->free(r_rid);
+        }
     }
     r_rid = RID();
 }
@@ -436,7 +457,7 @@ RID OutputCompositor::_ensure_viewport_blit_sampler(RenderingDevice *p_device) {
         }
 
         RenderingDevice *owner_device = existing->owner_device ? existing->owner_device : p_device;
-        _free_tracked_resource(owner_device, existing->sampler);
+        _free_tracked_resource(owner_device, existing->sampler, TrackedResourceKind::Sampler);
         viewport_blit_samplers.erase(device_key);
     }
 
@@ -492,7 +513,7 @@ RID OutputCompositor::_ensure_viewport_blit_scratch(RenderingDevice *p_device, c
             return existing->texture;
         }
         RenderingDevice *owner_device = existing->owner_device ? existing->owner_device : p_device;
-        _free_tracked_resource(owner_device, existing->texture);
+        _free_tracked_resource(owner_device, existing->texture, TrackedResourceKind::Texture);
         viewport_blit_scratch.erase(key);
     }
 
@@ -516,7 +537,7 @@ RID OutputCompositor::_ensure_viewport_blit_scratch(RenderingDevice *p_device, c
             ViewportBlitScratch *victim = viewport_blit_scratch.getptr(oldest_key);
             if (victim) {
                 RenderingDevice *owner_device = victim->owner_device ? victim->owner_device : p_device;
-                _free_tracked_resource(owner_device, victim->texture);
+                _free_tracked_resource(owner_device, victim->texture, TrackedResourceKind::Texture);
                 viewport_blit_scratch.erase(oldest_key);
             }
         }
@@ -580,8 +601,8 @@ bool OutputCompositor::_ensure_viewport_blit_pipeline(RenderingDevice *p_device,
         }
 
         RenderingDevice *owner_device = variant->owner_device ? variant->owner_device : p_device;
-        _free_tracked_resource(owner_device, variant->pipeline);
-        _free_tracked_resource(owner_device, variant->shader);
+        _free_tracked_resource(owner_device, variant->pipeline, TrackedResourceKind::ComputePipeline);
+        _free_tracked_resource(owner_device, variant->shader, TrackedResourceKind::Shader);
         viewport_blit_variants.erase(key);
     }
 
@@ -647,7 +668,7 @@ void OutputCompositor::clear_cached_framebuffers() {
     for (KeyValue<uint64_t, CachedFramebuffer> &E : output_cache.cached_framebuffers) {
         CachedFramebuffer &entry = E.value;
         RenderingDevice *fb_device = entry.device ? entry.device : rd;
-        _free_tracked_resource(fb_device, entry.framebuffer);
+        _free_tracked_resource(fb_device, entry.framebuffer, TrackedResourceKind::Framebuffer);
     }
 
     output_cache.cached_framebuffers.clear();
@@ -659,20 +680,20 @@ void OutputCompositor::clear_viewport_blit_resources() {
     for (KeyValue<uint64_t, ViewportBlitVariant> &E : viewport_blit_variants) {
         ViewportBlitVariant &variant = E.value;
         RenderingDevice *owner_device = variant.owner_device ? variant.owner_device : rd;
-        _free_tracked_resource(owner_device, variant.pipeline);
-        _free_tracked_resource(owner_device, variant.shader);
+        _free_tracked_resource(owner_device, variant.pipeline, TrackedResourceKind::ComputePipeline);
+        _free_tracked_resource(owner_device, variant.shader, TrackedResourceKind::Shader);
     }
 
     for (KeyValue<uint64_t, ViewportBlitSampler> &E : viewport_blit_samplers) {
         ViewportBlitSampler &sampler_entry = E.value;
         RenderingDevice *owner_device = sampler_entry.owner_device ? sampler_entry.owner_device : rd;
-        _free_tracked_resource(owner_device, sampler_entry.sampler);
+        _free_tracked_resource(owner_device, sampler_entry.sampler, TrackedResourceKind::Sampler);
     }
 
     for (KeyValue<uint64_t, ViewportBlitScratch> &E : viewport_blit_scratch) {
         ViewportBlitScratch &scratch_entry = E.value;
         RenderingDevice *owner_device = scratch_entry.owner_device ? scratch_entry.owner_device : rd;
-        _free_tracked_resource(owner_device, scratch_entry.texture);
+        _free_tracked_resource(owner_device, scratch_entry.texture, TrackedResourceKind::Texture);
     }
 
     viewport_blit_variants.clear();
@@ -693,7 +714,7 @@ RID OutputCompositor::get_cached_framebuffer(RenderingDevice *p_device, const RI
                 entry_device && entry_device->framebuffer_is_valid(entry->framebuffer)) {
             return entry->framebuffer;
         }
-        _free_tracked_resource(entry_device, entry->framebuffer);
+        _free_tracked_resource(entry_device, entry->framebuffer, TrackedResourceKind::Framebuffer);
         output_cache.cached_framebuffers.erase(key);
     }
 

--- a/modules/gaussian_splatting/interfaces/output_compositor.h
+++ b/modules/gaussian_splatting/interfaces/output_compositor.h
@@ -241,6 +241,7 @@ private:
     bool _is_depth_texture_valid(const RID &p_depth_texture) const;
     void _track_resource(const RID &p_rid, RenderingDevice *p_device, bool p_owned = true, const char *p_label = nullptr);
     void _forget_resource(const RID &p_rid);
+    void _free_tracked_resource(RenderingDevice *p_fallback_device, RID &r_rid);
 
     // Viewport blit helpers
     bool _ensure_viewport_blit_pipeline(RenderingDevice *p_device, RD::DataFormat p_format, RID &r_shader, RID &r_pipeline);

--- a/modules/gaussian_splatting/interfaces/output_compositor.h
+++ b/modules/gaussian_splatting/interfaces/output_compositor.h
@@ -179,6 +179,14 @@ private:
         RGBA32F = 2,
     };
 
+    enum class TrackedResourceKind {
+        Texture,
+        Framebuffer,
+        ComputePipeline,
+        Shader,
+        Sampler,
+    };
+
     // Viewport blit shader/pipeline variant
     struct ViewportBlitVariant {
         RID shader;
@@ -241,7 +249,7 @@ private:
     bool _is_depth_texture_valid(const RID &p_depth_texture) const;
     void _track_resource(const RID &p_rid, RenderingDevice *p_device, bool p_owned = true, const char *p_label = nullptr);
     void _forget_resource(const RID &p_rid);
-    void _free_tracked_resource(RenderingDevice *p_fallback_device, RID &r_rid);
+    void _free_tracked_resource(RenderingDevice *p_fallback_device, RID &r_rid, TrackedResourceKind p_kind);
 
     // Viewport blit helpers
     bool _ensure_viewport_blit_pipeline(RenderingDevice *p_device, RD::DataFormat p_format, RID &r_shader, RID &r_pipeline);

--- a/modules/gaussian_splatting/interfaces/render_device_manager.cpp
+++ b/modules/gaussian_splatting/interfaces/render_device_manager.cpp
@@ -117,10 +117,12 @@ Error RenderDeviceManager::initialize(RenderingDevice *p_primary_device) {
 }
 
 void RenderDeviceManager::shutdown() {
-	const uint32_t owned_resource_count = get_tracked_owned_resource_count();
-	if (owned_resource_count > 0) {
+	last_shutdown_tracked_resource_count = get_tracked_resource_count();
+	last_shutdown_owned_resource_count = get_tracked_owned_resource_count();
+	last_shutdown_borrowed_resource_count = get_tracked_borrowed_resource_count();
+	if (last_shutdown_owned_resource_count > 0) {
 		ERR_PRINT(vformat("[RenderDeviceManager] Shutting down with %d tracked owned resources; owners should release RIDs before manager shutdown",
-				owned_resource_count));
+				last_shutdown_owned_resource_count));
 	}
 
 	resource_owner_map.clear();
@@ -364,6 +366,10 @@ void RenderDeviceManager::track_resource(const RID &p_rid, RenderingDevice *p_de
 	} else {
 		texture_owner_map.erase(rid_id);
 	}
+}
+
+bool RenderDeviceManager::has_tracked_resource(const RID &p_rid) const {
+	return p_rid.is_valid() && resource_owner_map.has(p_rid.get_id());
 }
 
 RenderingDevice *RenderDeviceManager::get_resource_owner(const RID &p_rid, RenderingDevice *p_fallback) const {

--- a/modules/gaussian_splatting/interfaces/render_device_manager.h
+++ b/modules/gaussian_splatting/interfaces/render_device_manager.h
@@ -30,6 +30,7 @@ public:
 
     // Resource ownership tracking
     virtual void track_resource(const RID &p_rid, RenderingDevice *p_device, bool p_owned = true, const char *p_label = nullptr) = 0;
+    virtual bool has_tracked_resource(const RID &p_rid) const = 0;
     virtual RenderingDevice *get_resource_owner(const RID &p_rid, RenderingDevice *p_fallback = nullptr) const = 0;
     virtual void forget_resource(const RID &p_rid) = 0;
     virtual void free_owned_resource(RenderingDevice *p_fallback_device, RID &p_rid) = 0;
@@ -67,6 +68,7 @@ public:
     bool ensure_submission_device(const char *p_context) override;
 
     void track_resource(const RID &p_rid, RenderingDevice *p_device, bool p_owned = true, const char *p_label = nullptr) override;
+    bool has_tracked_resource(const RID &p_rid) const override;
     RenderingDevice *get_resource_owner(const RID &p_rid, RenderingDevice *p_fallback = nullptr) const override;
     void forget_resource(const RID &p_rid) override;
     void free_owned_resource(RenderingDevice *p_fallback_device, RID &p_rid) override;
@@ -110,6 +112,9 @@ public:
     uint32_t get_tracked_owned_resource_count() const;
     uint32_t get_tracked_borrowed_resource_count() const;
     uint32_t get_tracked_texture_count() const { return texture_owner_map.size(); }
+    uint32_t get_last_shutdown_tracked_resource_count() const { return last_shutdown_tracked_resource_count; }
+    uint32_t get_last_shutdown_owned_resource_count() const { return last_shutdown_owned_resource_count; }
+    uint32_t get_last_shutdown_borrowed_resource_count() const { return last_shutdown_borrowed_resource_count; }
 
 protected:
     static void _bind_methods();
@@ -140,6 +145,9 @@ private:
 	HashMap<uint64_t, String> resource_label_map;
 	HashMap<uint64_t, uint8_t> resource_type_map;
 	HashMap<uint64_t, RenderingDevice *> texture_owner_map;
+	uint32_t last_shutdown_tracked_resource_count = 0;
+	uint32_t last_shutdown_owned_resource_count = 0;
+	uint32_t last_shutdown_borrowed_resource_count = 0;
 
     // Diagnostics
     Vector<TextureTraceEntry> texture_trace;

--- a/modules/gaussian_splatting/tests/test_output_compositor_composite_hazard.h
+++ b/modules/gaussian_splatting/tests/test_output_compositor_composite_hazard.h
@@ -5,6 +5,7 @@
 
 #include "../interfaces/output_compositor.h"
 #include "../interfaces/output_compositor_interfaces.h"
+#include "../interfaces/render_device_manager.h"
 
 #include "core/io/image.h"
 #include "core/math/math_funcs.h"
@@ -243,6 +244,136 @@ TEST_CASE("[GaussianSplatting][RequiresGPU][HazardRepro] Compositor scratch-copy
 	// All cleanup (textures, compositor shutdown, locally-allocated fallback
 	// RD if any) is handled by _scope's destructor on function exit — including
 	// any path where an earlier REQUIRE failure threw a doctest exception.
+}
+
+TEST_CASE("[GaussianSplatting][RequiresGPU] OutputCompositor scratch resources return owned tracking to baseline across repeated shutdown") {
+	REQUIRE_GPU_DEVICE();
+
+	Ref<RenderDeviceManager> device_manager;
+	device_manager.instantiate();
+	REQUIRE(device_manager->initialize(rd) == OK);
+
+	const uint32_t baseline_tracked = device_manager->get_tracked_resource_count();
+	const uint32_t baseline_owned = device_manager->get_tracked_owned_resource_count();
+
+	for (int iteration = 0; iteration < 2; iteration++) {
+		HazardTestScope scope(rd);
+
+		RD::TextureFormat color_source_format;
+		color_source_format.width = 16;
+		color_source_format.height = 16;
+		color_source_format.depth = 1;
+		color_source_format.array_layers = 1;
+		color_source_format.mipmaps = 1;
+		color_source_format.texture_type = RD::TEXTURE_TYPE_2D;
+		color_source_format.samples = RD::TEXTURE_SAMPLES_1;
+		color_source_format.format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
+		color_source_format.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT |
+				RD::TEXTURE_USAGE_CAN_UPDATE_BIT |
+				RD::TEXTURE_USAGE_CAN_COPY_TO_BIT |
+				RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
+
+		RD::TextureFormat color_destination_format = color_source_format;
+		color_destination_format.usage_bits = RD::TEXTURE_USAGE_STORAGE_BIT |
+				RD::TEXTURE_USAGE_SAMPLING_BIT |
+				RD::TEXTURE_USAGE_CAN_UPDATE_BIT |
+				RD::TEXTURE_USAGE_CAN_COPY_TO_BIT |
+				RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
+
+		RID source_tex = rd->texture_create(color_source_format, RD::TextureView());
+		RID destination_tex = rd->texture_create(color_destination_format, RD::TextureView());
+		scope.track(source_tex);
+		scope.track(destination_tex);
+		REQUIRE(source_tex.is_valid());
+		REQUIRE(destination_tex.is_valid());
+
+		Vector<uint8_t> source_data;
+		source_data.resize(16 * 16 * 4);
+		Vector<uint8_t> destination_data;
+		destination_data.resize(16 * 16 * 4);
+		for (int i = 0; i < source_data.size(); i += 4) {
+			source_data.write[i + 0] = 64;
+			source_data.write[i + 1] = 64;
+			source_data.write[i + 2] = 64;
+			source_data.write[i + 3] = 128;
+			destination_data.write[i + 0] = 12;
+			destination_data.write[i + 1] = 24;
+			destination_data.write[i + 2] = 48;
+			destination_data.write[i + 3] = 255;
+		}
+		REQUIRE(rd->texture_update(source_tex, 0, source_data) == OK);
+		REQUIRE(rd->texture_update(destination_tex, 0, destination_data) == OK);
+
+		RD::TextureFormat depth_format;
+		depth_format.width = 16;
+		depth_format.height = 16;
+		depth_format.depth = 1;
+		depth_format.array_layers = 1;
+		depth_format.mipmaps = 1;
+		depth_format.texture_type = RD::TEXTURE_TYPE_2D;
+		depth_format.samples = RD::TEXTURE_SAMPLES_1;
+		depth_format.format = RD::DATA_FORMAT_D32_SFLOAT;
+		depth_format.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT |
+				RD::TEXTURE_USAGE_CAN_UPDATE_BIT |
+				RD::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+
+		RID source_depth = rd->texture_create(depth_format, RD::TextureView());
+		RID destination_depth = rd->texture_create(depth_format, RD::TextureView());
+		scope.track(source_depth);
+		scope.track(destination_depth);
+		REQUIRE(source_depth.is_valid());
+		REQUIRE(destination_depth.is_valid());
+
+		Vector<uint8_t> depth_far_bytes;
+		depth_far_bytes.resize(16 * 16 * sizeof(float));
+		const float far_depth = 1.0f;
+		for (int i = 0; i < 16 * 16; i++) {
+			memcpy(depth_far_bytes.ptrw() + i * sizeof(float), &far_depth, sizeof(float));
+		}
+		REQUIRE(rd->texture_update(source_depth, 0, depth_far_bytes) == OK);
+		REQUIRE(rd->texture_update(destination_depth, 0, depth_far_bytes) == OK);
+
+		Ref<OutputCompositor> compositor;
+		compositor.instantiate();
+		compositor->set_device_manager(device_manager);
+		scope.compositor = compositor;
+		REQUIRE(compositor->initialize(rd) == OK);
+
+		OutputCopyParams params;
+		params.source_texture = source_tex;
+		params.source_depth = source_depth;
+		params.destination_texture = destination_tex;
+		params.destination_depth = destination_depth;
+		params.viewport_size = Size2i(16, 16);
+		params.composite_with_destination = true;
+		params.source_is_premultiplied = true;
+		params.depth_test_enabled = true;
+		params.z_near = 0.05f;
+		params.z_far = 4000.0f;
+		params.depth_linearize_mul = 1.0f;
+		params.depth_linearize_add = 1.0f;
+		params.depth_epsilon = 0.01f;
+
+		OutputCopyResult result = compositor->copy_to_render_target(params);
+		if (!result.success) {
+			print_line(vformat("[OutputCompositorLifetime] copy_to_render_target failed: %s", result.error));
+		}
+		REQUIRE(result.success);
+
+		CHECK(compositor->get_viewport_blit_scratch_count() == 1u);
+		CHECK(compositor->get_blit_variant_count() == 1u);
+		CHECK(device_manager->get_tracked_owned_resource_count() > baseline_owned);
+
+		compositor->shutdown();
+		CHECK(compositor->get_viewport_blit_scratch_count() == 0u);
+		CHECK(compositor->get_blit_variant_count() == 0u);
+		CHECK(device_manager->get_tracked_resource_count() == baseline_tracked);
+		CHECK(device_manager->get_tracked_owned_resource_count() == baseline_owned);
+		scope.compositor.unref();
+	}
+
+	device_manager->shutdown();
+	CHECK(device_manager->get_last_shutdown_owned_resource_count() == 0u);
 }
 
 } // namespace TestGaussianSplatting

--- a/modules/gaussian_splatting/tests/test_output_compositor_composite_hazard.h
+++ b/modules/gaussian_splatting/tests/test_output_compositor_composite_hazard.h
@@ -376,6 +376,90 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] OutputCompositor scratch resources r
 	CHECK(device_manager->get_last_shutdown_owned_resource_count() == 0u);
 }
 
+TEST_CASE("[GaussianSplatting][RequiresGPU] OutputCompositor untracked cleanup skips stale resources") {
+	REQUIRE_GPU_DEVICE();
+
+	HazardTestScope scope(rd);
+
+	RD::TextureFormat color_format;
+	color_format.width = 16;
+	color_format.height = 16;
+	color_format.depth = 1;
+	color_format.array_layers = 1;
+	color_format.mipmaps = 1;
+	color_format.texture_type = RD::TEXTURE_TYPE_2D;
+	color_format.samples = RD::TEXTURE_SAMPLES_1;
+	color_format.format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
+	color_format.usage_bits = RD::TEXTURE_USAGE_STORAGE_BIT |
+			RD::TEXTURE_USAGE_SAMPLING_BIT |
+			RD::TEXTURE_USAGE_CAN_UPDATE_BIT |
+			RD::TEXTURE_USAGE_CAN_COPY_TO_BIT |
+			RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT |
+			RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
+
+	RID source_tex = rd->texture_create(color_format, RD::TextureView());
+	RID destination_tex = rd->texture_create(color_format, RD::TextureView());
+	RID framebuffer_tex = rd->texture_create(color_format, RD::TextureView());
+	scope.track(source_tex);
+	scope.track(destination_tex);
+	scope.track(framebuffer_tex);
+	REQUIRE(source_tex.is_valid());
+	REQUIRE(destination_tex.is_valid());
+	REQUIRE(framebuffer_tex.is_valid());
+
+	Vector<uint8_t> source_data;
+	source_data.resize(16 * 16 * 4);
+	Vector<uint8_t> destination_data;
+	destination_data.resize(16 * 16 * 4);
+	for (int i = 0; i < source_data.size(); i += 4) {
+		source_data.write[i + 0] = 80;
+		source_data.write[i + 1] = 120;
+		source_data.write[i + 2] = 160;
+		source_data.write[i + 3] = 192;
+		destination_data.write[i + 0] = 16;
+		destination_data.write[i + 1] = 32;
+		destination_data.write[i + 2] = 48;
+		destination_data.write[i + 3] = 255;
+	}
+	REQUIRE(rd->texture_update(source_tex, 0, source_data) == OK);
+	REQUIRE(rd->texture_update(destination_tex, 0, destination_data) == OK);
+
+	Ref<OutputCompositor> compositor;
+	compositor.instantiate();
+	scope.compositor = compositor;
+	REQUIRE(compositor->initialize(rd) == OK);
+
+	OutputCopyParams params;
+	params.source_texture = source_tex;
+	params.destination_texture = destination_tex;
+	params.viewport_size = Size2i(16, 16);
+	params.composite_with_destination = true;
+	params.source_is_premultiplied = true;
+	params.depth_test_enabled = false;
+
+	OutputCopyResult result = compositor->copy_to_render_target(params);
+	if (!result.success) {
+		print_line(vformat("[OutputCompositorUntrackedLifetime] copy_to_render_target failed: %s", result.error));
+	}
+	REQUIRE(result.success);
+	CHECK(compositor->get_viewport_blit_scratch_count() == 1u);
+	CHECK(compositor->get_blit_variant_count() == 1u);
+
+	RID framebuffer = compositor->get_cached_framebuffer(rd, framebuffer_tex);
+	REQUIRE(framebuffer.is_valid());
+	CHECK(compositor->get_cached_framebuffer_count() == 1u);
+	rd->free(framebuffer);
+	CHECK_FALSE(rd->framebuffer_is_valid(framebuffer));
+
+	compositor->clear_cached_framebuffers();
+	CHECK(compositor->get_cached_framebuffer_count() == 0u);
+
+	compositor->shutdown();
+	CHECK(compositor->get_viewport_blit_scratch_count() == 0u);
+	CHECK(compositor->get_blit_variant_count() == 0u);
+	scope.compositor.unref();
+}
+
 } // namespace TestGaussianSplatting
 
 #endif // TESTS_ENABLED

--- a/modules/gaussian_splatting/tests/test_render_device_manager_ownership.h
+++ b/modules/gaussian_splatting/tests/test_render_device_manager_ownership.h
@@ -275,6 +275,8 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] RenderDeviceManager exposes owned an
 	CHECK(manager->get_tracked_resource_count() == 2);
 	CHECK(manager->get_tracked_owned_resource_count() == 1);
 	CHECK(manager->get_tracked_borrowed_resource_count() == 1);
+	CHECK(manager->has_tracked_resource(owned_buffer));
+	CHECK(manager->has_tracked_resource(borrowed_buffer));
 
 	RID managed_owned = owned_buffer;
 	manager->free_owned_resource(rd, managed_owned);
@@ -282,6 +284,8 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] RenderDeviceManager exposes owned an
 	CHECK(manager->get_tracked_resource_count() == 1);
 	CHECK(manager->get_tracked_owned_resource_count() == 0);
 	CHECK(manager->get_tracked_borrowed_resource_count() == 1);
+	CHECK_FALSE(manager->has_tracked_resource(owned_buffer));
+	CHECK(manager->has_tracked_resource(borrowed_buffer));
 
 	manager->forget_resource(borrowed_buffer);
 	rd->free(borrowed_buffer);
@@ -289,8 +293,12 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] RenderDeviceManager exposes owned an
 	CHECK(manager->get_tracked_resource_count() == 0);
 	CHECK(manager->get_tracked_owned_resource_count() == 0);
 	CHECK(manager->get_tracked_borrowed_resource_count() == 0);
+	CHECK_FALSE(manager->has_tracked_resource(borrowed_buffer));
 
 	manager->shutdown();
+	CHECK(manager->get_last_shutdown_tracked_resource_count() == 0);
+	CHECK(manager->get_last_shutdown_owned_resource_count() == 0);
+	CHECK(manager->get_last_shutdown_borrowed_resource_count() == 0);
 	if (owns_rd) {
 		memdelete(rd);
 	}
@@ -341,6 +349,9 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] RenderDeviceManager shutdown clears 
 
 	CHECK(manager->get_tracked_resource_count() == 0);
 	CHECK(manager->get_tracked_owned_resource_count() == 0);
+	CHECK(manager->get_last_shutdown_tracked_resource_count() == 1);
+	CHECK(manager->get_last_shutdown_owned_resource_count() == 1);
+	CHECK(manager->get_last_shutdown_borrowed_resource_count() == 0);
 	CHECK(manager->get_context().main_device == nullptr);
 	CHECK(manager->get_context().resource_device == nullptr);
 	CHECK(manager->get_context().submission_device == nullptr);

--- a/modules/gaussian_splatting/tests/test_renderer_pipeline.h
+++ b/modules/gaussian_splatting/tests/test_renderer_pipeline.h
@@ -3382,9 +3382,209 @@ static bool create_test_render_buffers(const Vector2i &p_internal_resolution, RI
     return r_render_buffers->has_internal_texture();
 }
 
+TEST_CASE("[GaussianSplatting][RequiresGPU] Renderer teardown reaches zero owned GPU resources before device manager shutdown") {
+	RenderingServer *rs = RenderingServer::get_singleton();
+	if (rs == nullptr) {
+		MESSAGE("Skipping test - Rendering server unavailable");
+		return;
+	}
+
+	ScopedGaussianManagerPipeline manager_scope;
+	GaussianSplatManager *manager = manager_scope.get();
+	if (manager == nullptr) {
+		MESSAGE("Skipping test - GaussianSplatManager unavailable");
+		return;
+	}
+
+	ScopedRenderingDeviceLease device_lease;
+	RenderingDevice *primary_rd = device_lease.acquire(rs, manager);
+	if (primary_rd == nullptr) {
+		MESSAGE("Skipping test - Rendering device unavailable");
+		return;
+	}
+
+	Ref<GaussianSplatRenderer> renderer;
+	renderer.instantiate(primary_rd);
+	REQUIRE(renderer.is_valid());
+	renderer->initialize();
+
+	Ref<RenderDeviceManager> device_manager = renderer->get_subsystem_state().device_manager;
+	REQUIRE(device_manager.is_valid());
+
+	GaussianSplatRenderer::ResourceState &resource_state = renderer->get_resource_state();
+	REQUIRE(resource_state.buffer_manager.is_valid());
+	const Error buffer_manager_err = resource_state.buffer_manager->initialize(primary_rd, 16);
+	CHECK(buffer_manager_err == OK);
+	if (buffer_manager_err != OK) {
+		renderer.unref();
+		return;
+	}
+	resource_state.buffer_manager_initialized = true;
+	GPUBufferManager::BufferHandle buffer_manager_handle = resource_state.buffer_manager->get_current_read_handle();
+	REQUIRE(buffer_manager_handle.is_valid());
+
+	const RID atlas_buffer = primary_rd->storage_buffer_create(128);
+	const RID asset_meta_buffer = primary_rd->storage_buffer_create(64);
+	const RID chunk_meta_buffer = primary_rd->storage_buffer_create(96);
+	const RID asset_chunk_index_buffer = primary_rd->storage_buffer_create(32);
+	if (!atlas_buffer.is_valid() || !asset_meta_buffer.is_valid() ||
+			!chunk_meta_buffer.is_valid() || !asset_chunk_index_buffer.is_valid()) {
+		if (atlas_buffer.is_valid()) {
+			primary_rd->free(atlas_buffer);
+		}
+		if (asset_meta_buffer.is_valid()) {
+			primary_rd->free(asset_meta_buffer);
+		}
+		if (chunk_meta_buffer.is_valid()) {
+			primary_rd->free(chunk_meta_buffer);
+		}
+		if (asset_chunk_index_buffer.is_valid()) {
+			primary_rd->free(asset_chunk_index_buffer);
+		}
+		renderer.unref();
+		return;
+	}
+	renderer->track_resource_owner(atlas_buffer, primary_rd, true, "test_teardown_resident_atlas_gaussian_buffer");
+	renderer->track_resource_owner(asset_meta_buffer, primary_rd, true, "test_teardown_resident_asset_meta_buffer");
+	renderer->track_resource_owner(chunk_meta_buffer, primary_rd, true, "test_teardown_resident_chunk_meta_buffer");
+	renderer->track_resource_owner(asset_chunk_index_buffer, primary_rd, true, "test_teardown_resident_asset_chunk_index_buffer");
+	resource_state.resident_atlas_gaussian_buffer = atlas_buffer;
+	resource_state.resident_asset_meta_buffer = asset_meta_buffer;
+	resource_state.resident_chunk_meta_buffer = chunk_meta_buffer;
+	resource_state.resident_asset_chunk_index_buffer = asset_chunk_index_buffer;
+	resource_state.resident_atlas_gaussian_buffer_size = 128;
+	resource_state.resident_asset_meta_buffer_size = 64;
+	resource_state.resident_chunk_meta_buffer_size = 96;
+	resource_state.resident_asset_chunk_index_buffer_size = 32;
+	resource_state.instance_pipeline_atlas_generation = 352;
+	resource_state.resident_atlas_gaussian_count = 4;
+	resource_state.resident_dispatch_chunk_count = 1;
+	resource_state.resident_max_chunk_splats = 4;
+
+	Ref<OutputCompositor> compositor = renderer->get_subsystem_state().output_compositor;
+	REQUIRE(compositor.is_valid());
+	REQUIRE(compositor->initialize(primary_rd) == OK);
+
+	const Vector2i copy_size(16, 16);
+	const RD::TextureUsageBits source_usage = static_cast<RD::TextureUsageBits>(
+			RD::TEXTURE_USAGE_SAMPLING_BIT |
+			RD::TEXTURE_USAGE_CAN_UPDATE_BIT |
+			RD::TEXTURE_USAGE_CAN_COPY_TO_BIT |
+			RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT);
+	const RD::TextureUsageBits destination_usage = static_cast<RD::TextureUsageBits>(
+			RD::TEXTURE_USAGE_STORAGE_BIT |
+			RD::TEXTURE_USAGE_SAMPLING_BIT |
+			RD::TEXTURE_USAGE_CAN_UPDATE_BIT |
+			RD::TEXTURE_USAGE_CAN_COPY_TO_BIT |
+			RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT);
+	const RD::TextureUsageBits depth_usage = static_cast<RD::TextureUsageBits>(
+			RD::TEXTURE_USAGE_SAMPLING_BIT |
+			RD::TEXTURE_USAGE_CAN_UPDATE_BIT |
+			RD::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+
+	RID source_texture = create_test_texture(primary_rd, copy_size, RD::DATA_FORMAT_R8G8B8A8_UNORM, source_usage);
+	RID destination_texture = create_test_texture(primary_rd, copy_size, RD::DATA_FORMAT_R8G8B8A8_UNORM, destination_usage);
+	RID source_depth = create_test_texture(primary_rd, copy_size, RD::DATA_FORMAT_D32_SFLOAT, depth_usage);
+	RID destination_depth = create_test_texture(primary_rd, copy_size, RD::DATA_FORMAT_D32_SFLOAT, depth_usage);
+	auto free_external_textures = [&]() {
+		if (source_texture.is_valid() && primary_rd->texture_is_valid(source_texture)) {
+			primary_rd->free(source_texture);
+		}
+		if (destination_texture.is_valid() && primary_rd->texture_is_valid(destination_texture)) {
+			primary_rd->free(destination_texture);
+		}
+		if (source_depth.is_valid() && primary_rd->texture_is_valid(source_depth)) {
+			primary_rd->free(source_depth);
+		}
+		if (destination_depth.is_valid() && primary_rd->texture_is_valid(destination_depth)) {
+			primary_rd->free(destination_depth);
+		}
+	};
+	if (!source_texture.is_valid() || !destination_texture.is_valid() ||
+			!source_depth.is_valid() || !destination_depth.is_valid()) {
+		free_external_textures();
+		renderer.unref();
+		return;
+	}
+
+	Vector<uint8_t> color_bytes;
+	color_bytes.resize(copy_size.x * copy_size.y * 4);
+	for (int i = 0; i < color_bytes.size(); i += 4) {
+		color_bytes.write[i + 0] = 96;
+		color_bytes.write[i + 1] = 128;
+		color_bytes.write[i + 2] = 160;
+		color_bytes.write[i + 3] = 192;
+	}
+	const Error source_update_err = primary_rd->texture_update(source_texture, 0, color_bytes);
+	const Error destination_update_err = primary_rd->texture_update(destination_texture, 0, color_bytes);
+	CHECK(source_update_err == OK);
+	CHECK(destination_update_err == OK);
+	if (source_update_err != OK || destination_update_err != OK) {
+		free_external_textures();
+		renderer.unref();
+		return;
+	}
+
+	Vector<uint8_t> depth_far_bytes;
+	depth_far_bytes.resize(copy_size.x * copy_size.y * sizeof(float));
+	const float far_depth = 1.0f;
+	for (int i = 0; i < copy_size.x * copy_size.y; i++) {
+		memcpy(depth_far_bytes.ptrw() + i * sizeof(float), &far_depth, sizeof(float));
+	}
+	const Error source_depth_update_err = primary_rd->texture_update(source_depth, 0, depth_far_bytes);
+	const Error destination_depth_update_err = primary_rd->texture_update(destination_depth, 0, depth_far_bytes);
+	CHECK(source_depth_update_err == OK);
+	CHECK(destination_depth_update_err == OK);
+	if (source_depth_update_err != OK || destination_depth_update_err != OK) {
+		free_external_textures();
+		renderer.unref();
+		return;
+	}
+
+	OutputCopyParams params;
+	params.source_texture = source_texture;
+	params.source_depth = source_depth;
+	params.destination_texture = destination_texture;
+	params.destination_depth = destination_depth;
+	params.viewport_size = Size2i(copy_size.x, copy_size.y);
+	params.composite_with_destination = true;
+	params.source_is_premultiplied = true;
+	params.depth_test_enabled = true;
+	params.z_near = 0.05f;
+	params.z_far = 4000.0f;
+	params.depth_linearize_mul = 1.0f;
+	params.depth_linearize_add = 1.0f;
+	params.depth_epsilon = 0.01f;
+
+	OutputCopyResult copy_result = compositor->copy_to_render_target(params);
+	if (!copy_result.success) {
+		print_line(vformat("[RendererTeardownLifetime] copy_to_render_target failed: %s", copy_result.error));
+	}
+	CHECK(copy_result.success);
+	if (!copy_result.success) {
+		free_external_textures();
+		renderer.unref();
+		return;
+	}
+	CHECK(compositor->get_viewport_blit_scratch_count() == 1u);
+	CHECK(device_manager->get_tracked_owned_resource_count() > 0u);
+
+	renderer.unref();
+
+	CHECK(device_manager->get_last_shutdown_owned_resource_count() == 0u);
+	CHECK(device_manager->get_tracked_owned_resource_count() == 0u);
+	CHECK_FALSE(buffer_manager_handle.device->buffer_is_valid(buffer_manager_handle.buffer));
+	CHECK_FALSE(primary_rd->buffer_is_valid(atlas_buffer));
+	CHECK_FALSE(primary_rd->buffer_is_valid(asset_meta_buffer));
+	CHECK_FALSE(primary_rd->buffer_is_valid(chunk_meta_buffer));
+	CHECK_FALSE(primary_rd->buffer_is_valid(asset_chunk_index_buffer));
+
+	free_external_textures();
+}
+
 TEST_CASE("[GaussianSplatting][RequiresGPU] Raster path eligibility follows viewport output format") {
-    RenderingServer *rs = RenderingServer::get_singleton();
-    if (rs == nullptr) {
+	RenderingServer *rs = RenderingServer::get_singleton();
+	if (rs == nullptr) {
         MESSAGE("Skipping test - Rendering server unavailable");
         return;
     }


### PR DESCRIPTION
## Goal

Move GPU lifetime from best-effort cleanup to a provable ownership contract. The broader renderer goal is deterministic GPU resource lifetime: owned RIDs must be freed through one owner ledger, teardown must leave zero owned resources, and tests must fail when a render path retains GPU resources.

## What changed

- Routes `OutputCompositor` cached framebuffer, viewport blit pipeline, sampler, and scratch cleanup through the `RenderDeviceManager` ownership ledger when resources are tracked.
- Adds `RenderDeviceManager::has_tracked_resource()` so the compositor can distinguish tracked owned resources from untracked fallback resources without guessing via owner resolution.
- Records last-shutdown tracked/owned/borrowed counts before manager state is cleared, making shutdown leak assertions possible.
- Adds GPU-required tests for compositor repeated shutdown cleanup and renderer teardown reaching zero owned GPU resources.

## Validation

- `python3 tests/ci/run_module_tests.py --guard-only --base-ref origin/master`
- `scons platform=linuxbsd target=editor dev_build=yes tests=yes module_gaussian_splatting_enabled=yes progress=no -j2 bin/obj/modules/gaussian_splatting/interfaces/output_compositor.linuxbsd.editor.dev.x86_64.o bin/obj/modules/gaussian_splatting/interfaces/render_device_manager.linuxbsd.editor.dev.x86_64.o bin/obj/modules/gaussian_splatting/tests/test_gaussian_splatting.linuxbsd.editor.dev.x86_64.o`
- `git diff --check`

## Runtime proof still required

The new tests are tagged `RequiresGPU`; this PR needs the GPU lane to execute them before #352 should be considered closed.

Refs #298
Refs #327
Refs #352