### PR TITLE
gaussian_splatting: type renderer-proof script vars for warnings-as-errors

### DIFF
--- a/tests/runtime/test_canonical_node_asset_render.gd
+++ b/tests/runtime/test_canonical_node_asset_render.gd
@@ -275,7 +275,7 @@ func _capture_viewport() -> Image:
 
 
 func _compute_visual_metrics(image: Image) -> Dictionary:
-	var prepared = image.duplicate()
+	var prepared: Image = image.duplicate() as Image
 	if prepared == null:
 		return _empty_visual_metrics(0, 0)
 	prepared.convert(Image.FORMAT_RGBA8)
@@ -284,7 +284,7 @@ func _compute_visual_metrics(image: Image) -> Dictionary:
 	if width <= 0 or height <= 0:
 		return _empty_visual_metrics(width, height)
 
-	var stride := max(1, VISUAL_SAMPLE_STRIDE)
+	var stride: int = int(max(1, VISUAL_SAMPLE_STRIDE))
 	var luma_sum := 0.0
 	var luma_sq_sum := 0.0
 	var sample_count := 0


### PR DESCRIPTION
## Context

This is **PR 0a of work package #352** (Renderer Lifetime Proof) — a pre-work blocker for the lifetime gate to have teeth. It is independent of the rest of #352 and reviewable on its own.

## What's wrong

`tests/runtime/test_canonical_node_asset_render.gd` does not parse on master. The GDScript config treats `INFERRED_DECLARATION` warnings as errors, and ``var prepared = image.duplicate()`` (line 278) infers `prepared` as Variant because `Image.duplicate()` returns `Resource`. The cascade kills `width`, `height`, `c`, `luma` (lines 282/283/296/297) and ``max(1, VISUAL_SAMPLE_STRIDE)`` independently fails on line 287.

Empirical proof (on master, pre-fix):

```
SCRIPT ERROR: Parse Error: Cannot infer the type of "width" variable...
   at: GDScript::reload (res://tests/runtime/test_canonical_node_asset_render.gd:282)
... (4 more)
ERROR: Failed to load script "res://tests/runtime/test_canonical_node_asset_render.gd" with error "Parse error".
```

Consequence: the release-gate manifest's renderer-proof criterion (PR #374, PR #377) can never report ``renderer_proof_status=passed`` because the proof test exits before emitting any metric. The enforced gate has no teeth on this criterion.

## What this PR does

Adds explicit type annotations to break the inference cascade. No behavior change — same arithmetic, same control flow.

- Line 278: cast ``image.duplicate()`` to ``Image`` so subsequent calls resolve.
- Line 287: cast ``max(...)`` to ``int`` so ``stride`` types cleanly.
- Lines 282/283/296/297: ``:=`` now resolves because ``prepared`` is typed.

## Verification

| Check | Result |
|---|---|
| Parse | ``& $Godot --verbose --script tests\runtime\test_canonical_node_asset_render.gd`` produces no Parse Error lines and no "Failed to load script" line. The script now emits the ``[RUNTIME_METRICS]`` JSON payload (with ``renderer_proof_status`` field) instead of dying at load. |
| Runtime (``node-asset-gpu-ci`` profile) | Now executes end-to-end and reports ``proof_status: "skipped_unavailable"`` with reason ``"Renderer unavailable for canonical node asset proof (local RenderingDevice required)."``. This is a different, environment-level failure (no local RenderingDevice in the headless invocation context) — separate from the parse blocker fixed here. |

Before this PR: gate could not even read the proof metric. After this PR: gate reads the proof metric and can correctly distinguish passed / failed / skipped_unavailable.

## Out of scope (follow-ups)

- The ``node-asset-gpu-ci`` profile still does not reach ``passed`` in this environment because the headless ``--script`` invocation path does not bring up a local RenderingDevice. This is the next blocker for the renderer-proof gate to be green in CI and is a separate concern from the parse error fixed here. Worth a follow-up issue / PR under #352.
- Worktree contained unrelated dirty files (fixture JSONs, a stray ``.gsplatcache``) which were intentionally NOT included in this commit. They look like locally regenerated artifacts unrelated to the renderer-proof gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)