### PR TITLE
gaussian_splatting: pin node-asset-gpu-ci profile to vulkan

### DIFF
--- a/tests/runtime/runtime_scenarios.json
+++ b/tests/runtime/runtime_scenarios.json
@@ -41,7 +41,7 @@
     },
     "node-asset-gpu-ci": {
       "description": "Focused GPU-backed proof that a canonical GaussianSplatNode3D renders a fixture GaussianSplatAsset and produces visual evidence.",
-      "gd_mode": "non-headless",
+      "gd_mode": "windows-vulkan",
       "cpp_tests": [],
       "gd_tests": [
         "Canonical Node Asset Render"


### PR DESCRIPTION
## Context

**PR 0d of work package #352** (Renderer Lifetime Proof). Pre-work blocker. Depends on #378.

## What''s wrong

The `node-asset-gpu-ci` profile in `tests/runtime/runtime_scenarios.json` set `gd_mode: "non-headless"`. `_resolve_mode_args` in `tests/runtime/run_runtime_validation.py:551` translates that to **no rendering-driver flag**. On Windows in `--script` invocation Godot defaults to OpenGL Compatibility, which has no `RenderingDevice` singleton:

- `RenderingServer.get_rendering_device()` returns null
- `GaussianSplatManager::_create_local_device_on_render_thread` logs "Failed to create primary local RenderingDevice"
- `GaussianSplatSceneDirector` returns a `SharedWorld` with null `renderer`
- `GaussianSplatNode3D.get_renderer()` returns null forever
- canonical-render proof script reports `skipped_unavailable`

The renderer-proof gate criterion was structurally unable to pass on this profile, regardless of the .gd script''s correctness.

## What this PR does

One-line change in `tests/runtime/runtime_scenarios.json`: `node-asset-gpu-ci.gd_mode` `"non-headless"` -> `"windows-vulkan"`. Matches what `streaming-gpu-ci` already uses.

```diff
     "node-asset-gpu-ci": {
       "description": "Focused GPU-backed proof that a canonical GaussianSplatNode3D renders a fixture GaussianSplatAsset and produces visual evidence.",
-      "gd_mode": "non-headless",
+      "gd_mode": "windows-vulkan",
```

## PR 0a application strategy

PR #378 is not in this branch. For verification, I applied its 2-line diff manually to `tests/runtime/test_canonical_node_asset_render.gd` (cast `image.duplicate()` to `Image`, wrap `max(1, VISUAL_SAMPLE_STRIDE)` in `int(...)`), ran the verification below, then reverted that file before committing. This PR therefore touches **only** `tests/runtime/runtime_scenarios.json` and must be landed on top of (or alongside) #378 for the gate to be green end-to-end.

## Verification (empirical)

Before (with PR 0a applied, but `gd_mode=non-headless`, per PR 0a''s own report):

```
proof_status: "skipped_unavailable"
reason: "Renderer unavailable for canonical node asset proof (local RenderingDevice required)."
```

After (this PR + PR 0a''s diff applied locally):

```
  "gd_mode": "windows-vulkan",
  "scenario_config": "tests\\runtime\\runtime_scenarios.json",
  "renderer_proof": {
    "required": true,
    "status": "passed",
    "passed": 1,
    "unavailable": 0,
    "failed": 0,
    "total": 1,
    "failure_reasons": [],
    "proof_tests": [
      {
        "name": "Canonical Node Asset Render",
        "result_status": "passed",
        "proof_kind": "canonical_node_asset",
        "proof_status": "passed",
        "reason": "Canonical GaussianSplatNode3D rendered fixture asset with viewport-visible evidence.",
        "asset_path": "res://tests/fixtures/test_splats.ply",
        "visible_splats_max": 1024,
        "visual_luma_variance_max": 0.00826032211838341,
        "visual_luma_range_max": 0.869399995110929,
        "visual_non_background_samples_max": 129600,
        "visual_non_background_ratio_max": 1.0
      }
    ]
  },
  "schema_valid": true,
  "schema_errors": []
}
[runtime] Report saved to tests\runtime\runtime_validation_report.json
PROFILE_EXIT=0
```

All pass criteria met: `PROFILE_EXIT=0`, `renderer_proof.status: "passed"`, no `skipped_unavailable`, visible-splats and visual-luma metrics non-zero.

## Follow-up

`release-ci.gd_mode` has the same `non-headless`-then-driver-roulette flaw. It silently fails 4-7 tests depending on which driver Godot happens to pick on a given run. Filed as separate issue (linked below). Not fixed here to keep PR scope clean.

Refs: #352, depends on #378