### PR TITLE
gaussian_splatting: tag WorldSubmission tests with [SceneTree]

### DIFF
--- a/modules/gaussian_splatting/tests/test_scene_director_submission_scaffolding.h
+++ b/modules/gaussian_splatting/tests/test_scene_director_submission_scaffolding.h
@@ -183,7 +183,7 @@ TEST_CASE("[GaussianSplatting][SceneDirector][SceneTree] World submission entryp
 	}
 }
 
-TEST_CASE("[GaussianSplatting][SceneDirector][WorldSubmission] Same-owner resubmit preserves the original renderer restore point") {
+TEST_CASE("[GaussianSplatting][SceneDirector][WorldSubmission][SceneTree] Same-owner resubmit preserves the original renderer restore point") {
 	GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
 	const bool owns_director = (director == nullptr);
 	if (!director) {
@@ -286,7 +286,7 @@ TEST_CASE("[GaussianSplatting][SceneDirector][WorldSubmission] Same-owner resubm
 	}
 }
 
-TEST_CASE("[GaussianSplatting][SceneDirector][WorldSubmission] Same-owner resubmit defaults omitted overrides from the preserved baseline") {
+TEST_CASE("[GaussianSplatting][SceneDirector][WorldSubmission][SceneTree] Same-owner resubmit defaults omitted overrides from the preserved baseline") {
 	GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
 	const bool owns_director = (director == nullptr);
 	if (!director) {
@@ -607,7 +607,7 @@ TEST_CASE("[GaussianSplatting][World][SceneTree] strict identity transform rejec
 	}
 }
 
-TEST_CASE("[GaussianSplatting][SceneDirector][WorldSubmission] Zero-splat submissions do not surface residency authority") {
+TEST_CASE("[GaussianSplatting][SceneDirector][WorldSubmission][SceneTree] Zero-splat submissions do not surface residency authority") {
 	GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
 	const bool owns_director = (director == nullptr);
 	if (!director) {
@@ -682,7 +682,7 @@ TEST_CASE("[GaussianSplatting][SceneDirector][WorldSubmission] Zero-splat submis
 	}
 }
 
-TEST_CASE("[GaussianSplatting][SceneDirector][WorldSubmission] Staged world submissions mark streaming path ownership in the backend plan") {
+TEST_CASE("[GaussianSplatting][SceneDirector][WorldSubmission][SceneTree] Staged world submissions mark streaming path ownership in the backend plan") {
 	GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
 	const bool owns_director = (director == nullptr);
 	if (!director) {


### PR DESCRIPTION
## Context

**PR 1c of work package #352** (Renderer Lifetime Proof). Closes the 602-event `CrashHandlerException` cascade observed in headless `run_module_tests.py` runs.

This is the third PR to attempt to close the cascade. The first two (#383 PR 1, and PR 1b — escalated rather than shipped) empirically falsified the original "lifetime issue" framing. The cascade turns out to be a test-infrastructure tagging bug, not a renderer-lifetime issue at all.

## Root cause (empirically diagnosed by PR 1b, re-verified by this PR)

The four `[SceneDirector][WorldSubmission]` tests in `test_scene_director_submission_scaffolding.h` lacked the `[SceneTree]` tag. `tests/test_main.cpp:333` (`GodotTestCaseListener::test_case_start`) only initializes `MessageQueue`/`Input`/`RenderingServerDefault`/`SceneTree`/physics/navigation when the test case name contains `[SceneTree]` or `[Editor]`. Without the tag, these tests null-deref on missing singletons. `platform/windows/crash_handler_windows_seh.cpp:158` then amplifies the single fault into 602 events by returning `EXCEPTION_CONTINUE_SEARCH` after `SymInitialize` fails (sibling issue #385).

This PR's investigation re-verified the empirical claim by reverting the retag and running the same untagged-lane filter:

| State of `test_scene_director_submission_scaffolding.h` | Untagged-lane exit code | `CrashHandlerException` count |
|---|---|---|
| Base (without retag) | -1073741819 / 0xC0000005 | **602** |
| With retag (this PR) | 1 (4 unrelated pre-existing test failures) | **0** |

## What this PR does

Adds `[SceneTree]` to **4 / 4** TEST_CASE declarations in `test_scene_director_submission_scaffolding.h`:

- Line 186: `Same-owner resubmit preserves the original renderer restore point`
- Line 289: `Same-owner resubmit defaults omitted overrides from the preserved baseline`
- Line 610: `Zero-splat submissions do not surface residency authority`
- Line 685: `Staged world submissions mark streaming path ownership in the backend plan`

These were the only `[WorldSubmission]`-only tests in the file. All other tests in the file already carry either `[SceneTree]` or `[Editor]`. No code change beyond test tag strings (4 insertions / 4 deletions, all in test name string literals).

## Verification

| Check | Before | After |
|---|---|---|
| `CrashHandlerException` count in `run_module_tests.py` log | 602 | **0** |
| `[untagged]` advisory lane | crashed (exit -1073741819) | advisory (exit 1, 4 unrelated pre-existing test failures, no crashes) |
| `MODULE_TESTS_EXIT` | 0 | **0** |
| 4 retagged WorldSubmission tests run cleanly in isolation (`--test-case=*][WorldSubmission]*`) | n/a | **`test cases: 4 / 4 passed / 0 failed / 1759 skipped, Status: SUCCESS!`** |
| All 19 strict per-tag GaussianSplatting lanes | passed | **passed** (338 tests, 5494 assertions) |
| `headless-ci` runtime validation | 3 GD pass / 2 g++ fail | **3 GD pass / 2 g++ fail** (g++ unavailable on this Windows host, documented baseline) |

The `[untagged]` advisory lane retains exit 1 because of four unrelated pre-existing test failures (none crash, none new): `[Thumbnail] Generator caches deterministic asset+settings keys`, `[Thumbnail] Editor preview generator uses stored images on worker threads`, `[NodeSurface][Cleanup] GaussianSplatNode3D no longer exposes ply_file_path or auto_load`, and `[GaussianSplatting] frame backend plan centralizes streaming bootstrap without synthetic primary fallback`. The two `[Thumbnail]` cases appear because doctest `--test-case-exclude` parsing is unreliable beyond ~10 repeated flags (already documented in `run_module_tests.py:97-99`), which is exactly why the lane is declared advisory. None of these failures changed across base ↔ with-fix builds.

## Sibling issue

#385 — Windows SEH handler amplifies single fault to ~602 events when `SymInitialize` fails. Independent of this fix. With this PR alone, a future regression that null-derefs in a non-`[SceneTree]` test will still amplify to 602 events; the SEH-handler fix would clamp that to 1.

## Out of scope

- SEH handler amplification (#385).
- PR 1's streaming-layer defensive guards (#383) remain valuable defense-in-depth and are not affected by this PR.
- The four pre-existing `[untagged]`-lane test failures listed above; they pre-date this work package and persist on base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
