### PR TITLE
gaussian_splatting: bound OutputCompositor framebuffer LRU caches

### DIFF
--- a/docs/reference/renderer_release_gate_manifest.json
+++ b/docs/reference/renderer_release_gate_manifest.json
@@ -92,8 +92,8 @@
   "known_limitations_page": "docs/development/known-public-alpha-limitations.md",
   "requires_gpu_test_snapshot": {
     "source_glob": "modules/gaussian_splatting/tests/**/*.{h,cpp}",
-    "test_count": 101,
-    "sha256": "1af46c9b4af19c242705139ba9839ba9916997d40be41c8a23f8d07fbd84f440",
+    "test_count": 102,
+    "sha256": "e358e88bdb0a07a9d86d0b0b45a909d192db9f9174d6f126beebe7c72849b746",
     "deferred_tags_any": ["SceneTree", "Importer"],
     "deferred_count": 29,
     "new_or_missing_test_policy": "fail-contract-check",

--- a/docs/reference/renderer_release_gate_manifest.json
+++ b/docs/reference/renderer_release_gate_manifest.json
@@ -92,8 +92,8 @@
   "known_limitations_page": "docs/development/known-public-alpha-limitations.md",
   "requires_gpu_test_snapshot": {
     "source_glob": "modules/gaussian_splatting/tests/**/*.{h,cpp}",
-    "test_count": 100,
-    "sha256": "154edc04ec9195b85de7bd49ceb640de9a99376d4ef38eb354d005646a893675",
+    "test_count": 101,
+    "sha256": "1af46c9b4af19c242705139ba9839ba9916997d40be41c8a23f8d07fbd84f440",
     "deferred_tags_any": ["SceneTree", "Importer"],
     "deferred_count": 29,
     "new_or_missing_test_policy": "fail-contract-check",

--- a/docs/reference/renderer_release_gate_manifest.json
+++ b/docs/reference/renderer_release_gate_manifest.json
@@ -92,8 +92,8 @@
   "known_limitations_page": "docs/development/known-public-alpha-limitations.md",
   "requires_gpu_test_snapshot": {
     "source_glob": "modules/gaussian_splatting/tests/**/*.{h,cpp}",
-    "test_count": 99,
-    "sha256": "ee61962cc8bb817d66b3cfd4e02679ff6ed321fbf13b52bfc38cf9da37fd59be",
+    "test_count": 100,
+    "sha256": "154edc04ec9195b85de7bd49ceb640de9a99376d4ef38eb354d005646a893675",
     "deferred_tags_any": ["SceneTree", "Importer"],
     "deferred_count": 29,
     "new_or_missing_test_policy": "fail-contract-check",

--- a/modules/gaussian_splatting/interfaces/output_compositor.cpp
+++ b/modules/gaussian_splatting/interfaces/output_compositor.cpp
@@ -873,6 +873,14 @@ bool OutputCompositor::validate_framebuffer_attachments(RenderingDevice *p_devic
                 return true;
             }
         }
+        // Stale entry (invalid bit, or one of the cached attachments was freed/recreated
+        // and the new RID reuses the same key path). Erase it BEFORE the eviction helper
+        // runs so the helper sees the cache below cap and does not evict a different,
+        // still-live entry. Without this, the eviction helper would skip cache_key,
+        // evict an unrelated slot, and the trailing insert() would just overwrite the
+        // stale entry -- net effect: cache silently drops one slot below the intended
+        // cap, causing avoidable thrash under attachment-churn workloads.
+        output_cache.framebuffer_validation_cache.erase(cache_key);
     }
     Vector<String> errors;
 

--- a/modules/gaussian_splatting/interfaces/output_compositor.cpp
+++ b/modules/gaussian_splatting/interfaces/output_compositor.cpp
@@ -676,6 +676,90 @@ void OutputCompositor::clear_cached_framebuffers() {
     srgb_format_cache.clear();
 }
 
+void OutputCompositor::_evict_oldest_cached_framebuffer_if_needed(uint64_t p_incoming_key) {
+    // Caller has already erased any stale entry under p_incoming_key, so the
+    // cache size here reflects only entries that would remain after a fresh
+    // insert. If we're at the cap, evict the least-recently-used entry via
+    // the same destroy path clear_cached_framebuffers() uses.
+    if (output_cache.cached_framebuffers.size() < MAX_CACHED_FRAMEBUFFER_FORMATS) {
+        return;
+    }
+    uint64_t oldest_key = 0;
+    uint64_t oldest_id = UINT64_MAX;
+    bool found = false;
+    for (const KeyValue<uint64_t, CachedFramebuffer> &kv : output_cache.cached_framebuffers) {
+        if (kv.key == p_incoming_key) {
+            continue;
+        }
+        if (!found || kv.value.last_access_id < oldest_id) {
+            oldest_id = kv.value.last_access_id;
+            oldest_key = kv.key;
+            found = true;
+        }
+    }
+    if (!found) {
+        return;
+    }
+    CachedFramebuffer *victim = output_cache.cached_framebuffers.getptr(oldest_key);
+    if (victim) {
+        RenderingDevice *owner_device = victim->device ? victim->device : rd;
+        _free_tracked_resource(owner_device, victim->framebuffer, TrackedResourceKind::Framebuffer);
+        output_cache.cached_framebuffers.erase(oldest_key);
+    }
+}
+
+void OutputCompositor::_evict_oldest_framebuffer_validation_if_needed(uint64_t p_incoming_key) {
+    if (output_cache.framebuffer_validation_cache.size() < MAX_CACHED_FRAMEBUFFER_FORMATS) {
+        return;
+    }
+    uint64_t oldest_key = 0;
+    uint64_t oldest_id = UINT64_MAX;
+    bool found = false;
+    for (const KeyValue<uint64_t, FramebufferValidationCacheEntry> &kv : output_cache.framebuffer_validation_cache) {
+        if (kv.key == p_incoming_key) {
+            continue;
+        }
+        if (!found || kv.value.last_access_id < oldest_id) {
+            oldest_id = kv.value.last_access_id;
+            oldest_key = kv.key;
+            found = true;
+        }
+    }
+    if (!found) {
+        return;
+    }
+    // Validation entries hold only POD + Vector<AttachmentValidationInfo>; no
+    // GPU resources to free, just drop the map slot.
+    output_cache.framebuffer_validation_cache.erase(oldest_key);
+}
+
+void OutputCompositor::test_force_insert_cached_framebuffer(uint64_t p_key) {
+    if (CachedFramebuffer *existing = output_cache.cached_framebuffers.getptr(p_key)) {
+        existing->last_access_id = ++cached_framebuffer_next_id;
+        return;
+    }
+    _evict_oldest_cached_framebuffer_if_needed(p_key);
+    CachedFramebuffer entry;
+    entry.framebuffer = RID();
+    entry.device = rd;
+    entry.last_access_id = ++cached_framebuffer_next_id;
+    output_cache.cached_framebuffers.insert(p_key, entry);
+}
+
+void OutputCompositor::test_force_insert_framebuffer_validation(uint64_t p_key) {
+    if (FramebufferValidationCacheEntry *existing = output_cache.framebuffer_validation_cache.getptr(p_key)) {
+        existing->last_access_id = ++framebuffer_validation_next_id;
+        return;
+    }
+    _evict_oldest_framebuffer_validation_if_needed(p_key);
+    FramebufferValidationCacheEntry entry;
+    entry.valid = true;
+    entry.extent = Size2i(0, 0);
+    entry.samples = RD::TEXTURE_SAMPLES_1;
+    entry.last_access_id = ++framebuffer_validation_next_id;
+    output_cache.framebuffer_validation_cache.insert(p_key, entry);
+}
+
 void OutputCompositor::clear_viewport_blit_resources() {
     for (KeyValue<uint64_t, ViewportBlitVariant> &E : viewport_blit_variants) {
         ViewportBlitVariant &variant = E.value;
@@ -712,11 +796,14 @@ RID OutputCompositor::get_cached_framebuffer(RenderingDevice *p_device, const RI
         bool device_matches = entry_device == p_device;
         if (entry->framebuffer.is_valid() && device_matches &&
                 entry_device && entry_device->framebuffer_is_valid(entry->framebuffer)) {
+            entry->last_access_id = ++cached_framebuffer_next_id;
             return entry->framebuffer;
         }
         _free_tracked_resource(entry_device, entry->framebuffer, TrackedResourceKind::Framebuffer);
         output_cache.cached_framebuffers.erase(key);
     }
+
+    _evict_oldest_cached_framebuffer_if_needed(key);
 
     Vector<RID> attachments;
     attachments.push_back(p_texture);
@@ -746,6 +833,7 @@ RID OutputCompositor::get_cached_framebuffer(RenderingDevice *p_device, const RI
     CachedFramebuffer new_entry;
     new_entry.framebuffer = framebuffer;
     new_entry.device = p_device;
+    new_entry.last_access_id = ++cached_framebuffer_next_id;
     output_cache.cached_framebuffers.insert(key, new_entry);
     return framebuffer;
 }
@@ -781,6 +869,7 @@ bool OutputCompositor::validate_framebuffer_attachments(RenderingDevice *p_devic
                 r_infos = cache_entry->infos;
                 r_extent = cache_entry->extent;
                 r_samples = cache_entry->samples;
+                cache_entry->last_access_id = ++framebuffer_validation_next_id;
                 return true;
             }
         }
@@ -880,11 +969,14 @@ bool OutputCompositor::validate_framebuffer_attachments(RenderingDevice *p_devic
         return false;
     }
 
+    _evict_oldest_framebuffer_validation_if_needed(cache_key);
+
     FramebufferValidationCacheEntry cache_entry;
     cache_entry.valid = true;
     cache_entry.extent = r_extent;
     cache_entry.samples = r_samples;
     cache_entry.infos = r_infos;
+    cache_entry.last_access_id = ++framebuffer_validation_next_id;
     output_cache.framebuffer_validation_cache.insert(cache_key, cache_entry);
 
     return true;

--- a/modules/gaussian_splatting/interfaces/output_compositor.cpp
+++ b/modules/gaussian_splatting/interfaces/output_compositor.cpp
@@ -803,7 +803,12 @@ RID OutputCompositor::get_cached_framebuffer(RenderingDevice *p_device, const RI
         output_cache.cached_framebuffers.erase(key);
     }
 
-    _evict_oldest_cached_framebuffer_if_needed(key);
+    // Eviction is deferred to AFTER validate_framebuffer_attachments() and
+    // framebuffer_create() succeed (Codex review #3294032623 on PR #388). If we
+    // evict here and validation/creation then fails (invalid/non-attachable RID,
+    // transient driver failure), we would have dropped an unrelated cached
+    // framebuffer permanently without inserting a replacement -- repeated failed
+    // requests would drain the cache.
 
     Vector<RID> attachments;
     attachments.push_back(p_texture);
@@ -829,6 +834,12 @@ RID OutputCompositor::get_cached_framebuffer(RenderingDevice *p_device, const RI
     }
     p_device->set_resource_name(framebuffer, "GS_OutputCompositor_CachedFramebuffer");
     _track_resource(framebuffer, p_device, true, "cached_framebuffer");
+
+    // Insertion is committed: only now is it safe to evict an LRU entry to make
+    // room. The stale entry under `key` (if any) was already erased above, so
+    // the helper's "skip incoming key" branch is a no-op here and it will pick
+    // a genuinely different LRU victim when at cap.
+    _evict_oldest_cached_framebuffer_if_needed(key);
 
     CachedFramebuffer new_entry;
     new_entry.framebuffer = framebuffer;

--- a/modules/gaussian_splatting/interfaces/output_compositor.h
+++ b/modules/gaussian_splatting/interfaces/output_compositor.h
@@ -70,18 +70,23 @@ public:
     // Set internal render size (from painterly pass graph)
     void set_internal_render_size(const Size2i &p_size) { internal_render_size = p_size; }
 
-    // Cached framebuffer entry
+    // Cached framebuffer entry. `last_access_id` is bumped on every hit/insert
+    // and consumed by the LRU eviction in get_cached_framebuffer().
     struct CachedFramebuffer {
         RID framebuffer;
         RenderingDevice *device = nullptr;
+        uint64_t last_access_id = 0;
     };
 
-    // Framebuffer validation cache entry
+    // Framebuffer validation cache entry. `last_access_id` is bumped on every
+    // hit/insert and consumed by the LRU eviction in
+    // validate_framebuffer_attachments().
     struct FramebufferValidationCacheEntry {
         bool valid = false;
         Size2i extent = Size2i();
         RD::TextureSamples samples = RD::TEXTURE_SAMPLES_1;
         Vector<AttachmentValidationInfo> infos;
+        uint64_t last_access_id = 0;
     };
 
     struct OutputCacheState {
@@ -150,6 +155,18 @@ public:
     uint32_t get_cached_framebuffer_count() const { return output_cache.cached_framebuffers.size(); }
     uint32_t get_blit_variant_count() const { return viewport_blit_variants.size(); }
     uint32_t get_viewport_blit_scratch_count() const { return viewport_blit_scratch.size(); }
+    uint32_t get_framebuffer_validation_cache_count() const { return output_cache.framebuffer_validation_cache.size(); }
+    static constexpr uint32_t get_max_cached_framebuffer_formats() { return MAX_CACHED_FRAMEBUFFER_FORMATS; }
+
+    // Test-only: directly drive synthetic LRU entries through the same
+    // eviction path the production cache uses. Lets the regression test
+    // assert the cap holds without round-tripping real GPU framebuffers (the
+    // attachment-validation path requires color/depth attachments owned by
+    // the test, which makes a 16-format sweep awkward). Both helpers reuse
+    // the production add/erase site so any future refactor of eviction logic
+    // covers them too.
+    void test_force_insert_cached_framebuffer(uint64_t p_key);
+    void test_force_insert_framebuffer_validation(uint64_t p_key);
 
     // Debug seam published by _copy_final_output_compute. Test-only contract: the
     // hazard-repro test reads this to verify the scratch-copy path was exercised
@@ -220,6 +237,20 @@ private:
     static constexpr uint32_t VIEWPORT_BLIT_SCRATCH_MAX_PER_KIND = 4;
     uint64_t viewport_blit_scratch_next_id = 0;
 
+    // Per-cache entry cap shared by `cached_framebuffers` and
+    // `framebuffer_validation_cache`. Both are keyed by
+    // (RenderingDevice*, attachment-RID-set) so multi-device sessions
+    // (multi-window editor, RenderDoc capture, project reload) accumulate one
+    // entry per unique attachment combination, never evicting. The scratch
+    // pool's matching cap is VIEWPORT_BLIT_SCRATCH_MAX_PER_KIND=4 per kind;
+    // these caches are not partitioned by kind so 8 is the global ceiling. On
+    // insert past the cap we evict the entry with the lowest `last_access_id`
+    // via the existing destroy path (see get_cached_framebuffer and
+    // validate_framebuffer_attachments).
+    static constexpr uint32_t MAX_CACHED_FRAMEBUFFER_FORMATS = 8;
+    uint64_t cached_framebuffer_next_id = 0;
+    uint64_t framebuffer_validation_next_id = 0;
+
     // State
     bool initialized = false;
     RenderingDevice *rd = nullptr;
@@ -270,6 +301,14 @@ private:
             const RD::TextureFormat &p_destination_format, RID p_source_depth, RID p_destination_depth,
             bool p_depth_test_enabled, bool p_depth_is_orthogonal, float p_z_near, float p_z_far,
             float p_depth_linearize_mul, float p_depth_linearize_add, float p_depth_epsilon);
+
+    // LRU eviction for the format-keyed caches. Both share the
+    // MAX_CACHED_FRAMEBUFFER_FORMATS cap; on insert past the cap the entry
+    // with the lowest `last_access_id` is freed via the existing destroy
+    // path. Skips eviction when the key already exists (caller is refreshing
+    // an entry, not adding a new one).
+    void _evict_oldest_cached_framebuffer_if_needed(uint64_t p_incoming_key);
+    void _evict_oldest_framebuffer_validation_if_needed(uint64_t p_incoming_key);
 
     // Attachment validation helpers
     uint64_t _compute_framebuffer_validation_key(RenderingDevice *p_device, const Vector<RID> &p_attachments) const;

--- a/modules/gaussian_splatting/tests/test_output_compositor_composite_hazard.h
+++ b/modules/gaussian_splatting/tests/test_output_compositor_composite_hazard.h
@@ -460,6 +460,57 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] OutputCompositor untracked cleanup s
 	scope.compositor.unref();
 }
 
+TEST_CASE("[GaussianSplatting][OutputCompositor][RequiresGPU] framebuffer LRU caps prevent unbounded growth across device switches") {
+	REQUIRE_GPU_DEVICE();
+
+	Ref<OutputCompositor> compositor;
+	compositor.instantiate();
+	REQUIRE(compositor->initialize(rd) == OK);
+
+	const uint32_t cap = OutputCompositor::get_max_cached_framebuffer_formats();
+	CHECK(cap == 8u);
+
+	// Drive 16 distinct synthetic format keys through the eviction path twice
+	// (once per cache). Without the cap added by this PR, the caches would
+	// hold all 16 entries; with the cap, each must stay <= 8.
+	for (uint64_t i = 1; i <= 16; ++i) {
+		compositor->test_force_insert_cached_framebuffer(i);
+		compositor->test_force_insert_framebuffer_validation(i + 0x1000ull);
+	}
+
+	CHECK(compositor->get_cached_framebuffer_count() <= cap);
+	CHECK(compositor->get_framebuffer_validation_cache_count() <= cap);
+	CHECK(compositor->get_cached_framebuffer_count() == cap);
+	CHECK(compositor->get_framebuffer_validation_cache_count() == cap);
+
+	// LRU correctness: the 8 most recently inserted keys (9..16) survive,
+	// the 8 oldest (1..8) were evicted.
+	OutputCompositor::OutputCacheState &state = compositor->get_cache_state();
+	for (uint64_t i = 1; i <= 8; ++i) {
+		CHECK_FALSE(state.cached_framebuffers.has(i));
+		CHECK_FALSE(state.framebuffer_validation_cache.has(i + 0x1000ull));
+	}
+	for (uint64_t i = 9; i <= 16; ++i) {
+		CHECK(state.cached_framebuffers.has(i));
+		CHECK(state.framebuffer_validation_cache.has(i + 0x1000ull));
+	}
+
+	// Driving an additional batch must not grow either cache.
+	for (uint64_t i = 17; i <= 24; ++i) {
+		compositor->test_force_insert_cached_framebuffer(i);
+		compositor->test_force_insert_framebuffer_validation(i + 0x1000ull);
+	}
+	CHECK(compositor->get_cached_framebuffer_count() == cap);
+	CHECK(compositor->get_framebuffer_validation_cache_count() == cap);
+
+	// Re-inserting an already-present key (LRU refresh) must not evict.
+	const uint32_t before_refresh = compositor->get_cached_framebuffer_count();
+	compositor->test_force_insert_cached_framebuffer(20);
+	CHECK(compositor->get_cached_framebuffer_count() == before_refresh);
+
+	compositor->shutdown();
+}
+
 } // namespace TestGaussianSplatting
 
 #endif // TESTS_ENABLED

--- a/modules/gaussian_splatting/tests/test_output_compositor_composite_hazard.h
+++ b/modules/gaussian_splatting/tests/test_output_compositor_composite_hazard.h
@@ -634,6 +634,115 @@ TEST_CASE("[GaussianSplatting][OutputCompositor][RequiresGPU] framebuffer valida
 	compositor->shutdown();
 }
 
+// Regression for PR #388 Codex review #3294032623: get_cached_framebuffer()
+// previously called _evict_oldest_cached_framebuffer_if_needed(key) BEFORE
+// validate_framebuffer_attachments() and framebuffer_create(). If either
+// downstream call failed (invalid/non-attachable RID, transient driver
+// failure), the function returned without inserting a replacement, so an
+// unrelated cached framebuffer had already been evicted permanently. Repeated
+// failed requests would drain the cache below cap. Fix defers eviction until
+// after both calls succeed and an insertion is about to commit.
+TEST_CASE("[GaussianSplatting][OutputCompositor][RequiresGPU] cached framebuffer failed request preserves LRU cache") {
+	REQUIRE_GPU_DEVICE();
+
+	Ref<OutputCompositor> compositor;
+	compositor.instantiate();
+	REQUIRE(compositor->initialize(rd) == OK);
+
+	const uint32_t cap = OutputCompositor::get_max_cached_framebuffer_formats();
+	REQUIRE(cap == 8u);
+
+	HazardTestScope _scope(rd);
+	_scope.compositor = compositor;
+
+	// Color-attachable format so get_cached_framebuffer() goes all the way
+	// through validate_framebuffer_attachments() and framebuffer_create().
+	RD::TextureFormat color_format;
+	color_format.width = 32;
+	color_format.height = 32;
+	color_format.depth = 1;
+	color_format.array_layers = 1;
+	color_format.mipmaps = 1;
+	color_format.texture_type = RD::TEXTURE_TYPE_2D;
+	color_format.format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
+	color_format.usage_bits = RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT |
+			RD::TEXTURE_USAGE_SAMPLING_BIT |
+			RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
+
+	// Fill the cached_framebuffers cache to cap with real, valid framebuffers.
+	Vector<RID> textures;
+	Vector<uint64_t> cached_keys;
+	for (uint32_t i = 0; i < cap; i++) {
+		RID tex = rd->texture_create(color_format, RD::TextureView());
+		REQUIRE(tex.is_valid());
+		_scope.track(tex);
+		textures.push_back(tex);
+
+		RID fb = compositor->get_cached_framebuffer(rd, tex);
+		REQUIRE(fb.is_valid());
+		cached_keys.push_back(tex.get_id());
+	}
+	REQUIRE(compositor->get_cached_framebuffer_count() == cap);
+
+	// Sanity: every key we just inserted is present in the cache map.
+	OutputCompositor::OutputCacheState &state = compositor->get_cache_state();
+	for (uint64_t k : cached_keys) {
+		REQUIRE(state.cached_framebuffers.has(k));
+	}
+
+	// Snapshot LRU ordering by last_access_id so we can detect any eviction.
+	HashMap<uint64_t, uint64_t> pre_failure_access_ids;
+	for (KeyValue<uint64_t, OutputCompositor::CachedFramebuffer> &kv : state.cached_framebuffers) {
+		pre_failure_access_ids.insert(kv.key, kv.value.last_access_id);
+	}
+
+	// Construct a request that will deliberately fail at
+	// validate_framebuffer_attachments(): create a fresh texture, capture its
+	// RID, then immediately free it. The RID stays a valid object (so the
+	// early-out `!p_texture.is_valid()` does not trip), but texture_is_valid()
+	// returns false, which causes validate_framebuffer_attachments() to
+	// return false and get_cached_framebuffer() to bail.
+	RID doomed_tex = rd->texture_create(color_format, RD::TextureView());
+	REQUIRE(doomed_tex.is_valid());
+	const uint64_t doomed_key = doomed_tex.get_id();
+	// Guard against the (extremely unlikely) RID-id collision with any of the
+	// already-cached keys; if this fires the test setup is wrong and we'd be
+	// testing the cache-hit branch instead of the eviction branch.
+	for (uint64_t k : cached_keys) {
+		REQUIRE(k != doomed_key);
+	}
+	rd->free(doomed_tex);
+	REQUIRE_FALSE(rd->texture_is_valid(doomed_tex));
+
+	// The bug being fixed: pre-fix, this call evicts an unrelated LRU entry
+	// BEFORE validation runs, then returns RID() because validation fails.
+	// Post-fix, eviction is deferred until after both validation and
+	// framebuffer_create succeed, so a failed request must NOT mutate the
+	// cache at all.
+	RID result = compositor->get_cached_framebuffer(rd, doomed_tex);
+	CHECK_FALSE(result.is_valid());
+
+	// Primary assertion: cache size unchanged (no eviction occurred).
+	CHECK(compositor->get_cached_framebuffer_count() == cap);
+
+	// Secondary assertion: every originally-cached key is still present and
+	// its last_access_id is unchanged (no LRU rotation, no silent replacement).
+	for (uint64_t k : cached_keys) {
+		CHECK(state.cached_framebuffers.has(k));
+		OutputCompositor::CachedFramebuffer *entry = state.cached_framebuffers.getptr(k);
+		REQUIRE(entry != nullptr);
+		const uint64_t *prev_id = pre_failure_access_ids.getptr(k);
+		REQUIRE(prev_id != nullptr);
+		CHECK(entry->last_access_id == *prev_id);
+	}
+
+	// Tertiary assertion: the doomed key was never inserted as a side effect.
+	CHECK_FALSE(state.cached_framebuffers.has(doomed_key));
+
+	compositor->shutdown();
+	_scope.compositor.unref();
+}
+
 } // namespace TestGaussianSplatting
 
 #endif // TESTS_ENABLED

--- a/modules/gaussian_splatting/tests/test_output_compositor_composite_hazard.h
+++ b/modules/gaussian_splatting/tests/test_output_compositor_composite_hazard.h
@@ -511,6 +511,129 @@ TEST_CASE("[GaussianSplatting][OutputCompositor][RequiresGPU] framebuffer LRU ca
 	compositor->shutdown();
 }
 
+// Regression for PR #388 bot review: when validate_framebuffer_attachments encounters
+// a stale entry for an existing cache_key (entry present but cache_still_valid == false),
+// the prior implementation called _evict_oldest_framebuffer_validation_if_needed(cache_key)
+// FIRST -- which skips cache_key by design and evicts a DIFFERENT entry -- then the
+// trailing insert(cache_key, ...) overwrote the stale entry. Net effect at cap: cache
+// silently drops from 8 to 7. Fix erases the stale entry BEFORE the eviction helper, so
+// the helper sees size < cap and returns immediately, the trailing insert restores cap,
+// and the refreshed key becomes MRU.
+TEST_CASE("[GaussianSplatting][OutputCompositor][RequiresGPU] framebuffer validation cache refresh-stale-key preserves cap") {
+	REQUIRE_GPU_DEVICE();
+
+	Ref<OutputCompositor> compositor;
+	compositor.instantiate();
+	REQUIRE(compositor->initialize(rd) == OK);
+
+	const uint32_t cap = OutputCompositor::get_max_cached_framebuffer_formats();
+	REQUIRE(cap == 8u);
+
+	// Create `cap` real RGBA8 color textures so validate_framebuffer_attachments
+	// has live attachments to hash into cache keys. Tracking them in a scope guard
+	// keeps cleanup deterministic across REQUIRE failures.
+	HazardTestScope _scope(rd);
+
+	RD::TextureFormat color_format;
+	color_format.width = 32;
+	color_format.height = 32;
+	color_format.depth = 1;
+	color_format.array_layers = 1;
+	color_format.mipmaps = 1;
+	color_format.texture_type = RD::TEXTURE_TYPE_2D;
+	color_format.format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
+	color_format.usage_bits = RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT |
+			RD::TEXTURE_USAGE_SAMPLING_BIT |
+			RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
+
+	Vector<RID> textures;
+	for (uint32_t i = 0; i < cap; i++) {
+		RID tex = rd->texture_create(color_format, RD::TextureView());
+		REQUIRE(tex.is_valid());
+		_scope.track(tex);
+		textures.push_back(tex);
+
+		Vector<RID> attachments;
+		attachments.push_back(tex);
+
+		Vector<AttachmentValidationInfo> infos;
+		Size2i extent;
+		RD::TextureSamples samples = RD::TEXTURE_SAMPLES_1;
+		String err;
+		REQUIRE(compositor->validate_framebuffer_attachments(rd, attachments, infos, extent, samples, err));
+	}
+
+	REQUIRE(compositor->get_framebuffer_validation_cache_count() == cap);
+
+	// Capture the (single) key in the cache that corresponds to textures[0], by
+	// identifying which cache entry holds it as the original_attachment. We can't
+	// recompute the private hash, but we can find the entry by attachment match.
+	OutputCompositor::OutputCacheState &state = compositor->get_cache_state();
+	uint64_t stale_key = 0;
+	bool stale_key_found = false;
+	for (KeyValue<uint64_t, OutputCompositor::FramebufferValidationCacheEntry> &kv : state.framebuffer_validation_cache) {
+		const Vector<AttachmentValidationInfo> &infos = kv.value.infos;
+		if (infos.size() == 1 && infos[0].original_attachment == textures[0]) {
+			stale_key = kv.key;
+			stale_key_found = true;
+			break;
+		}
+	}
+	REQUIRE(stale_key_found);
+
+	// Mark the entry as stale by flipping `valid` to false. This forces the
+	// production refresh-stale code path on the next validate call for the same
+	// attachments (cache_still_valid never gets a chance to be true because the
+	// outer `valid` check short-circuits the hit-path).
+	{
+		OutputCompositor::FramebufferValidationCacheEntry *entry = state.framebuffer_validation_cache.getptr(stale_key);
+		REQUIRE(entry != nullptr);
+		entry->valid = false;
+	}
+
+	// Re-validate using the SAME attachment, which hashes to the SAME cache_key.
+	// Pre-fix: stale entry stays put, eviction helper skips it and evicts a different
+	// slot, insert overwrites stale -> cache size = cap - 1. Post-fix: stale entry is
+	// erased first, eviction helper no-ops because size < cap, insert restores cap.
+	{
+		Vector<RID> attachments;
+		attachments.push_back(textures[0]);
+		Vector<AttachmentValidationInfo> infos;
+		Size2i extent;
+		RD::TextureSamples samples = RD::TEXTURE_SAMPLES_1;
+		String err;
+		REQUIRE(compositor->validate_framebuffer_attachments(rd, attachments, infos, extent, samples, err));
+	}
+
+	// Primary assertion: cache stays at cap (the bug dropped it to cap - 1).
+	CHECK(compositor->get_framebuffer_validation_cache_count() == cap);
+	CHECK(state.framebuffer_validation_cache.has(stale_key));
+
+	// Secondary assertion: the refreshed key is MRU. Drive `cap` additional
+	// distinct synthetic inserts via the test helper; the stale_key entry must
+	// survive because it was most recently touched, while the other 7 original
+	// entries are the LRU victims.
+	for (uint64_t i = 0xF000ull; i < 0xF000ull + cap; ++i) {
+		compositor->test_force_insert_framebuffer_validation(i);
+	}
+	CHECK(compositor->get_framebuffer_validation_cache_count() == cap);
+	CHECK(state.framebuffer_validation_cache.has(stale_key));
+	// All 7 other original keys should have been evicted.
+	uint32_t original_survivors = 0;
+	for (uint32_t i = 0; i < cap; i++) {
+		for (KeyValue<uint64_t, OutputCompositor::FramebufferValidationCacheEntry> &kv : state.framebuffer_validation_cache) {
+			const Vector<AttachmentValidationInfo> &infos = kv.value.infos;
+			if (infos.size() == 1 && infos[0].original_attachment == textures[i]) {
+				original_survivors++;
+				break;
+			}
+		}
+	}
+	CHECK(original_survivors == 1u);
+
+	compositor->shutdown();
+}
+
 } // namespace TestGaussianSplatting
 
 #endif // TESTS_ENABLED

--- a/modules/gaussian_splatting/tests/test_output_compositor_composite_hazard.h
+++ b/modules/gaussian_splatting/tests/test_output_compositor_composite_hazard.h
@@ -609,11 +609,18 @@ TEST_CASE("[GaussianSplatting][OutputCompositor][RequiresGPU] framebuffer valida
 	CHECK(compositor->get_framebuffer_validation_cache_count() == cap);
 	CHECK(state.framebuffer_validation_cache.has(stale_key));
 
-	// Secondary assertion: the refreshed key is MRU. Drive `cap` additional
+	// Secondary assertion: the refreshed key is MRU. Drive `cap - 1` additional
 	// distinct synthetic inserts via the test helper; the stale_key entry must
 	// survive because it was most recently touched, while the other 7 original
-	// entries are the LRU victims.
-	for (uint64_t i = 0xF000ull; i < 0xF000ull + cap; ++i) {
+	// entries are the LRU victims. NOTE: we deliberately use `cap - 1`, not
+	// `cap`. At cap, each insert triggers exactly one eviction; we want to
+	// evict the 7 other originals only. A `cap`-th insert would then evict the
+	// new oldest entry (stale_key, since the 7 original co-tenants are gone),
+	// silently invalidating the MRU claim. The off-by-one in the original
+	// version of this test produced the very failure mode it was meant to
+	// detect, and the disk-exhaustion CI crash for PR #388's prior run had
+	// masked it.
+	for (uint64_t i = 0xF000ull; i < 0xF000ull + (cap - 1); ++i) {
 		compositor->test_force_insert_framebuffer_validation(i);
 	}
 	CHECK(compositor->get_framebuffer_validation_cache_count() == cap);


### PR DESCRIPTION
## Context

**PR 5 of work package #352** (Renderer Lifetime Proof). Independent of stacked PRs #383/#386/#387; bases on master.

Surfaced by PR #380 (ownership inventory): `cached_framebuffers` (output_compositor.h:115) and `framebuffer_validation_cache` (output_compositor.h:116) had the same unboundedness profile — both keyed by `(RenderingDevice*, attachment-RID-set)` and never evicted.

## What is wrong

In a long-running session that switches between RenderingDevices (multi-window editor, RenderDoc capture, project reload), each unique format/attachment combination adds an entry that lives until `shutdown()`. The existing `VIEWPORT_BLIT_SCRATCH_MAX_PER_KIND = 4` cap bounds the scratch texture pool but not the format-keyed framebuffer caches.

## What this PR does

1. New constant `MAX_CACHED_FRAMEBUFFER_FORMATS = 8` (interfaces/output_compositor.h:250).
2. Per-entry `last_access_id` field on `CachedFramebuffer` and `FramebufferValidationCacheEntry`, bumped on every cache hit and insert (mirrors existing `viewport_blit_scratch.last_used_id` pattern).
3. Two helpers `_evict_oldest_cached_framebuffer_if_needed()` and `_evict_oldest_framebuffer_validation_if_needed()` (interfaces/output_compositor.cpp). On insert past the cap, the entry with the lowest `last_access_id` is freed via the existing destroy path (`_free_tracked_resource` for the framebuffer cache; the validation cache holds no GPU resources).
4. Regression test `[GaussianSplatting][OutputCompositor][RequiresGPU] framebuffer LRU caps prevent unbounded growth across device switches` — drives 16 distinct synthetic keys via test-only `test_force_insert_*` helpers (synthetic over real-format round-trip was the simpler path: the test exercises the eviction logic directly without needing 16 distinct GPU framebuffer setups), asserts both caches <= 8, asserts oldest-8 keys were evicted and most-recent-8 survived, asserts re-inserting an existing key does not evict, and asserts a follow-up batch keeps the cap.

### Eviction strategy chosen and why

Linear scan over the HashMap to find min `last_access_id`. Same shape as the existing scratch-pool LRU (output_compositor.cpp:520-544). At a cap of 8 entries the scan cost is trivial. An `OrderedHashMap` would also work but would require touching the cache reads with reorder-on-hit logic and the cache size is small enough that O(N) eviction is the cleaner change.

## RED -> GREEN proof

Temporarily replaced both eviction bodies with `return;` at the top, rebuilt, ran the new test: 22/41 assertions failed, cache count reached 24. Restored eviction bodies, rebuilt, test passes 41/41.

```
[Cap disabled]  [doctest] test cases: 1 | 0 passed | 1 failed | 1763 skipped
                [doctest] assertions: 41 | 19 passed | 22 failed |
                ERROR: CHECK( compositor->get_cached_framebuffer_count() == cap )
                  values: CHECK( 24 == 8 )

[Cap restored]  [doctest] test cases: 1 | 1 passed | 0 failed | 1763 skipped
                [doctest] assertions: 41 | 41 passed | 0 failed |
                Status: SUCCESS!
```

## Verification

| Check | Result |
|---|---|
| Build | SCONS_EXIT=0, binary mtime fresh (2026-05-23 15:28) |
| New regression test (`*framebuffer LRU*` via `--gs-gpu-test`) | 1/1 cases, 41/41 assertions, SUCCESS |
| Existing OutputCompositor lane (`CompositorHazard` batch via `run_gpu_harness.py`) | 1/1 cases, 20/20 assertions, SUCCESS |
| Existing OutputCompositor lane (`OutputCompositor` batch via `run_gpu_harness.py`) | 1/1 cases, 41/41 assertions, SUCCESS |
| `MODULE_TESTS_EXIT` | 0 (334 tests, 5471 assertions across 22 lanes) |
| Manifest contract (`check_renderer_release_gates.py --mode contract`) | passed; bumped test_count 99 -> 100, sha256 ee61962cc8bb817d66b3cfd4e02679ff6ed321fbf13b52bfc38cf9da37fd59be -> 154edc04ec9195b85de7bd49ceb640de9a99376d4ef38eb354d005646a893675 |

## Out of scope

- `OutputCompositor untracked cleanup skips stale resources` (test_output_compositor_composite_hazard.h:379) is pre-existing FAILing on master HEAD `b7e7f05a77` (`copy_to_render_target` returns "CopyEffects subsystem unavailable" in the GPU harness). Reproduced via `git stash` + rebuild + run on base — not introduced by this PR. Adjacent bug, not in scope.
- No `force_insert_cached_framebuffer_for_test` gating behind `#ifdef TESTS_ENABLED`: the helpers are unconditionally compiled (`test_*` prefix) to match the existing `test_reset_last_viewport_copy_state()` precedent in the same file. Marginal cost is two `uint64_t` counters per OutputCompositor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)