### PR TITLE
gaussian_splatting: release module-owned static StringNames at unregister

### DIFF
--- a/modules/gaussian_splatting/core/gaussian_splat_manager.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_manager.cpp
@@ -7,6 +7,7 @@
 #include "core/variant/variant.h"
 #include "gaussian_data.h"
 #include "gs_project_settings.h"
+#include "module_string_names.h"
 #include "quality_tier_config.h"
 #include "streaming_vram_regulator.h"
 #include "../renderer/sorting_settings_utils.h"
@@ -25,7 +26,15 @@
 #endif
 
 namespace {
-static const StringName &RENDERDOC_COMPATIBILITY_PATH() { static const StringName s("rendering/gaussian_splatting/renderdoc_compatibility"); return s; }
+// Resolves to the module-owned StringName cache when the module is
+// initialized; constructs an on-demand fallback otherwise (e.g. during
+// early test fixtures). Releasing the cache at module unregister keeps
+// the path out of the engine's exit-time orphan StringName report.
+static const StringName &RENDERDOC_COMPATIBILITY_PATH() {
+    return gs::get_module_string_name_or_construct(
+            &gs::ModuleStringNames::renderdoc_compatibility_path,
+            "rendering/gaussian_splatting/renderdoc_compatibility");
+}
 // Project settings helpers: delegates to gs_project_settings.h (gs::settings namespace).
 static uint32_t _get_uint_setting(ProjectSettings *ps, const StringName &name, uint32_t fallback) {
     return gs::settings::get_uint(ps, name, fallback);

--- a/modules/gaussian_splatting/core/module_string_names.cpp
+++ b/modules/gaussian_splatting/core/module_string_names.cpp
@@ -1,0 +1,68 @@
+/**************************************************************************/
+/*  module_string_names.cpp                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+
+#include "module_string_names.h"
+
+namespace gs {
+
+namespace {
+ModuleStringNames *g_module_string_names = nullptr;
+} // namespace
+
+void ModuleStringNames::initialize() {
+	renderdoc_compatibility_path = StringName("rendering/gaussian_splatting/renderdoc_compatibility");
+	sorting_target_sort_time_path = StringName("rendering/gaussian_splatting/sorting/target_sort_time_ms");
+	legacy_gpu_sorting_target_sort_time_path = StringName("rendering/gaussian_splatting/gpu_sorting/target_sort_time_ms");
+}
+
+void ModuleStringNames::release() {
+	// Assigning a default-constructed StringName drops the ref so the
+	// underlying slot leaves the StringName table when no other holder
+	// remains. Without this the cached StringNames would live in static
+	// storage until program exit and surface as orphans at cleanup time.
+	renderdoc_compatibility_path = StringName();
+	sorting_target_sort_time_path = StringName();
+	legacy_gpu_sorting_target_sort_time_path = StringName();
+}
+
+ModuleStringNames *get_module_string_names() {
+	return g_module_string_names;
+}
+
+const StringName &get_module_string_name_or_construct(
+		StringName ModuleStringNames::*member, const char *p_literal) {
+	if (g_module_string_names) {
+		return g_module_string_names->*member;
+	}
+	// Pre-initialize / post-release fallback. Returns a function-local
+	// static so the StringName has stable storage across the call. This
+	// path runs only before initialize_gaussian_splatting_module() or
+	// after uninitialize, neither of which should hit hot rendering code.
+	static StringName fallback;
+	fallback = StringName(p_literal);
+	return fallback;
+}
+
+void initialize_module_string_names() {
+	if (g_module_string_names != nullptr) {
+		return;
+	}
+	g_module_string_names = new ModuleStringNames();
+	g_module_string_names->initialize();
+}
+
+void release_module_string_names() {
+	if (g_module_string_names == nullptr) {
+		return;
+	}
+	g_module_string_names->release();
+	delete g_module_string_names;
+	g_module_string_names = nullptr;
+}
+
+} // namespace gs

--- a/modules/gaussian_splatting/core/module_string_names.h
+++ b/modules/gaussian_splatting/core/module_string_names.h
@@ -1,0 +1,72 @@
+/**************************************************************************/
+/*  module_string_names.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+
+/*
+ * Module-owned StringNames whose lifetime must straddle module
+ * register/unregister so the engine's exit-time orphan StringName report
+ * (StringName::cleanup) does not surface them.
+ *
+ * Function-local `static const StringName s("...")` cache sites are easy
+ * to write but cannot be released — the StringName lives in static
+ * storage until program exit, which means its slot in the StringName
+ * table is occupied past the module's unregister window. Anything that
+ * references those slots from the other side (e.g. a Dictionary that has
+ * already been freed) shows up as `Orphan StringName: ... (total: N)`.
+ *
+ * This struct holds the small set of paths that were previously cached
+ * via function-local statics. register_types.cpp::
+ * initialize_gaussian_splatting_module() constructs the struct; the
+ * matching uninitialize() call drops it, releasing the StringNames
+ * cleanly so they leave the StringName table at unregister.
+ *
+ * See tests/ci/run_module_tests.py::_run_stringname_orphan_guard_step
+ * for the CI guard that asserts the orphan count stays bounded.
+ */
+
+#ifndef GAUSSIAN_SPLATTING_MODULE_STRING_NAMES_H
+#define GAUSSIAN_SPLATTING_MODULE_STRING_NAMES_H
+
+#include "core/string/string_name.h"
+
+namespace gs {
+
+struct ModuleStringNames {
+	// gaussian_splat_manager.cpp — project-setting key for RenderDoc compat.
+	StringName renderdoc_compatibility_path;
+
+	// renderer/sorting_settings_utils.h — canonical and legacy sort-target
+	// project-setting keys. Legacy retained for read-only compatibility.
+	StringName sorting_target_sort_time_path;
+	StringName legacy_gpu_sorting_target_sort_time_path;
+
+	void initialize();
+	void release();
+};
+
+// Returns the module-owned StringName cache. Returns nullptr before
+// initialize_gaussian_splatting_module() runs and after
+// uninitialize_gaussian_splatting_module() runs; callers must check or
+// fall back to constructing a StringName on demand.
+ModuleStringNames *get_module_string_names();
+
+// Returns a const reference to a StringName held by the module-owned
+// cache, or constructs one on demand if the cache is not yet
+// initialized. Used by inline accessors in header files where pulling
+// the cache singleton dependency in is undesirable.
+const StringName &get_module_string_name_or_construct(
+		StringName ModuleStringNames::*member, const char *p_literal);
+
+// initialize_module_string_names()/release_module_string_names() are
+// invoked from register_types.cpp around the module lifecycle. Safe to
+// call release before any initialize (no-op).
+void initialize_module_string_names();
+void release_module_string_names();
+
+} // namespace gs
+
+#endif // GAUSSIAN_SPLATTING_MODULE_STRING_NAMES_H

--- a/modules/gaussian_splatting/logger/startup_trace.cpp
+++ b/modules/gaussian_splatting/logger/startup_trace.cpp
@@ -91,6 +91,18 @@ void GSStartupTrace::reset() {
 	ever_flushed = false;
 }
 
+void GSStartupTrace::release_module_strings() {
+	// Same clear surface as reset(); separate entry point so the intent
+	// (module unregister, not asset-open reset) is explicit at call sites.
+	MutexLock lock(state_mutex);
+	sealed_traces.clear();
+	totals_usec.clear();
+	insertion_order.clear();
+	pending_flush_count.store(0, std::memory_order_relaxed);
+	active_begin_usec = 0;
+	ever_flushed = false;
+}
+
 // flush() and consume_pending_flush() used to be separate operations, but
 // decrementing pending_flush_count outside the state_mutex creates a window in
 // which a concurrent begin_asset_open() observes count==0 and skips sealing

--- a/modules/gaussian_splatting/logger/startup_trace.h
+++ b/modules/gaussian_splatting/logger/startup_trace.h
@@ -41,6 +41,14 @@ public:
 
 	void reset();
 
+	// Releases all StringNames cached in the phase totals/insertion-order
+	// containers. Called at module unregister so phase names recorded via
+	// GS_STARTUP_SCOPE (manager_construct, module_register,
+	// device_request_primary, device_request_shared, ...) do not show up
+	// in the engine's exit-time orphan StringName report. Differs from
+	// reset() only in intent — the underlying clears are the same.
+	void release_module_strings();
+
 	void begin_scope(const StringName &p_phase);
 	void end_scope(const StringName &p_phase, uint64_t p_start_usec);
 

--- a/modules/gaussian_splatting/register_types.cpp
+++ b/modules/gaussian_splatting/register_types.cpp
@@ -9,9 +9,11 @@
 #include "core/gaussian_splat_scene_director.h"
 #include "core/gaussian_splat_config_registry.h"
 #include "core/gaussian_streaming.h"
+#include "core/module_string_names.h"
 #include "core/streaming_chunk_payload_source.h"
 #include "renderer/gaussian_splat_renderer.h"
 #include "renderer/gpu_buffer_manager.h"
+#include "renderer/pipeline_feature_set.h"
 #include "renderer/spirv_disk_cache.h"
 #include "core/gaussian_splat_manager.h"
 #include "core/config/engine.h"
@@ -71,6 +73,13 @@ void initialize_gaussian_splatting_module(ModuleInitializationLevel p_level) {
     // Register diagnostics setting before any GS code reads it; the trace
     // singleton refreshes its cached enable flag after registration.
     if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+        // Module-owned StringName cache must be live before any code under
+        // initialize_gaussian_splatting_module reads a path through the
+        // module_string_names accessors. Construct it first so paths like
+        // sorting_target_sort_time_path resolve into the releasable
+        // storage instead of the on-demand fallback that would leak.
+        gs::initialize_module_string_names();
+
         GLOBAL_DEF("rendering/gaussian_splatting/diagnostics/startup_trace", true);
         GSStartupTrace::get_singleton()->refresh_enabled();
         GSStartupTrace::get_singleton()->reset();
@@ -254,6 +263,23 @@ void uninitialize_gaussian_splatting_module(ModuleInitializationLevel p_level) {
             GaussianSplattingPerformanceMonitors::destroy_singleton();
             GaussianRenderingDiagnostics::destroy_singleton();
             SPIRVDiskCache::shutdown();
+
+            // Release module-owned StringName caches before the module
+            // unregisters so the engine's exit-time orphan StringName
+            // report (StringName::cleanup) does not surface them. Order
+            // matches the bug report's grouping:
+            //   1. PipelineFeatureSet snapshots — drops the pipeline_*
+            //      keys and the generic value/source/source_label/
+            //      display_value/note/fidelity_limited entry-field keys.
+            //   2. GSStartupTrace phase storage — drops manager_construct,
+            //      module_register, device_request_primary, and
+            //      device_request_shared.
+            //   3. ModuleStringNames — drops the function-local-static
+            //      replacements for the renderdoc_compatibility and
+            //      sorting target-sort-time paths.
+            release_pipeline_feature_set_module_strings();
+            GSStartupTrace::get_singleton()->release_module_strings();
+            gs::release_module_string_names();
             break;
 
 #ifdef TOOLS_ENABLED

--- a/modules/gaussian_splatting/renderer/pipeline_feature_set.cpp
+++ b/modules/gaussian_splatting/renderer/pipeline_feature_set.cpp
@@ -369,6 +369,12 @@ void PipelineFeatureSet::print_config_summary() const {
     GS_LOG_INFO_DEFAULT("[Pipeline Feature Set] ================================================");
 }
 
+void PipelineFeatureSet::clear_provenance_snapshots() {
+    loaded_provenance_snapshot.clear();
+    effective_provenance_snapshot.clear();
+    effective_provenance_snapshot_valid = false;
+}
+
 void initialize_pipeline_feature_set() {
     _register_pipeline_project_settings();
     g_pipeline_feature_set.load_from_project_settings();
@@ -380,4 +386,13 @@ void initialize_pipeline_feature_set() {
         g_pipeline_feature_set.reset_to_defaults();
         g_pipeline_feature_set.save_to_project_settings();
     }
+}
+
+void release_pipeline_feature_set_module_strings() {
+    // The global feature-set Dictionary entries cache module-owned
+    // StringName keys (pipeline_two_stage_sort, ..., value, source, ...)
+    // that the engine's exit-time orphan StringName report would otherwise
+    // flag. Dropping the snapshot Dictionaries decrements those refcounts
+    // so the keys leave the StringName table cleanly at unregister.
+    g_pipeline_feature_set.clear_provenance_snapshots();
 }

--- a/modules/gaussian_splatting/renderer/pipeline_feature_set.h
+++ b/modules/gaussian_splatting/renderer/pipeline_feature_set.h
@@ -53,10 +53,23 @@ struct PipelineFeatureSet {
     Dictionary loaded_provenance_snapshot;
     mutable Dictionary effective_provenance_snapshot;
     mutable bool effective_provenance_snapshot_valid = false;
+
+    // Releases provenance snapshot Dictionaries, dropping the StringName
+    // keys that constructor SNAME-style helpers cache for the lifetime of
+    // the snapshot. Called at module unregister so the engine's exit-time
+    // orphan StringName report stays bounded. See:
+    // tests/ci/run_module_tests.py::_run_stringname_orphan_guard_step
+    void clear_provenance_snapshots();
 };
 
 extern PipelineFeatureSet g_pipeline_feature_set;
 
 void initialize_pipeline_feature_set();
+
+// Releases the global pipeline feature set's provenance snapshots. Wrapper
+// for register_types.cpp::uninitialize_gaussian_splatting_module() so the
+// per-call-site StringName keys (pipeline_two_stage_sort, ..., value,
+// source, ...) do not show up in the exit-time orphan StringName report.
+void release_pipeline_feature_set_module_strings();
 
 #endif // PIPELINE_FEATURE_SET_H

--- a/modules/gaussian_splatting/renderer/sorting_settings_utils.h
+++ b/modules/gaussian_splatting/renderer/sorting_settings_utils.h
@@ -3,6 +3,7 @@
 
 #include "core/config/project_settings.h"
 #include "../core/gs_project_settings.h"
+#include "../core/module_string_names.h"
 
 #include "core/error/error_macros.h"
 #include "core/string/string_name.h"
@@ -10,14 +11,22 @@
 namespace gs {
 namespace sorting_settings {
 
+// The setting paths are cached in the module-owned StringName struct so
+// they can be released at module unregister; without this the
+// function-local statics would surface in the engine's exit-time orphan
+// StringName report. The fallback path constructs an on-demand
+// StringName for early callers (test fixtures) before
+// initialize_gaussian_splatting_module() runs.
 static inline const StringName &target_sort_time_path() {
-	static const StringName path("rendering/gaussian_splatting/sorting/target_sort_time_ms");
-	return path;
+	return gs::get_module_string_name_or_construct(
+			&gs::ModuleStringNames::sorting_target_sort_time_path,
+			"rendering/gaussian_splatting/sorting/target_sort_time_ms");
 }
 
 static inline const StringName &legacy_gpu_target_sort_time_path() {
-	static const StringName path("rendering/gaussian_splatting/gpu_sorting/target_sort_time_ms");
-	return path;
+	return gs::get_module_string_name_or_construct(
+			&gs::ModuleStringNames::legacy_gpu_sorting_target_sort_time_path,
+			"rendering/gaussian_splatting/gpu_sorting/target_sort_time_ms");
 }
 
 static inline bool has_explicit_target_sort_time_override(ProjectSettings *p_ps) {

--- a/tests/ci/run_module_tests.py
+++ b/tests/ci/run_module_tests.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 from dataclasses import dataclass
 import importlib.util
+import json
 import os
 import re
 import subprocess
@@ -142,6 +143,44 @@ HISTORY_ARTIFACT_GUARD_MODE_ENV = "GS_CI_HISTORY_ARTIFACT_GUARD_MODE"
 HISTORY_ARTIFACT_GUARD_MODES = ("off", "warn", "strict")
 HISTORY_ARTIFACT_MATCH_COUNT_RE = re.compile(r"Matched blob entries:\s*(\d+)")
 DOCTEST_SKIP_MARKER_RE = re.compile(r"(?m)^\s*(?:Skipping(?: test)?\s*-\s+.+)$")
+
+# StringName orphan guard: PR 6 of work package #352.
+#
+# Headless --verbose runs of the engine trigger StringName::cleanup() in
+# core/string/string_name.cpp, which prints `Orphan StringName: ...`
+# lines for any StringName whose refcount != static_count at exit. The
+# Gaussian Splatting module previously surfaced ~19 orphan entries from
+# its own cached StringName paths and Dictionary-key sites because the
+# module never released those caches at unregister. PR 6 closes the
+# module-owned cases; this guard locks the post-fix count in place so a
+# future regression cannot silently re-leak module-owned StringNames.
+#
+# The guard runs the binary on the canonical synthetic-test project
+# (which loads the module, registers project settings, and exits via
+# --quit). The `--test --test-case=*Synthetic*` doctest mode does NOT
+# exercise the orphan report because doctest's exit path is not the same
+# as the engine's cleanup path, so the project-with-quit run is what
+# actually exercises StringName::cleanup.
+#
+# Threshold is configurable so the guard can absorb a small bounded set
+# of orphans that may come from engine-side Variant infrastructure
+# rather than from this module. PR 7 will tighten this to a
+# delta-vs-baseline rule of zero. Set GS_STRINGNAME_ORPHAN_THRESHOLD to
+# override the default. Set GS_STRINGNAME_ORPHAN_PROJECT to override the
+# probe project (default tests/examples/godot/test_project).
+STRINGNAME_ORPHAN_GUARD_DEFAULT_PROJECT = (
+    ROOT / "tests" / "examples" / "godot" / "test_project"
+)
+STRINGNAME_ORPHAN_GUARD_PROJECT_ENV = "GS_STRINGNAME_ORPHAN_PROJECT"
+# Empirical post-fix module-owned orphan count is 0; a small headroom
+# absorbs unrelated engine-side noise.
+STRINGNAME_ORPHAN_GUARD_DEFAULT_THRESHOLD = 5
+STRINGNAME_ORPHAN_GUARD_THRESHOLD_ENV = "GS_STRINGNAME_ORPHAN_THRESHOLD"
+STRINGNAME_ORPHAN_GUARD_BINARY_ENV = "GODOT_BINARY"
+STRINGNAME_ORPHAN_GUARD_TIMEOUT_SEC = 120
+STRINGNAME_ORPHAN_LINE_RE = re.compile(
+    r"^Orphan StringName:\s*(?P<name>[^\(]+?)\s*\(.*\)\s*$", re.MULTILINE
+)
 
 SETTING_MUTATION_RE = re.compile(r"->set_setting\s*\(")
 FS_WRITE_RULES = (
@@ -836,6 +875,172 @@ def _run_render_guard_step(base_ref: str | None) -> int | None:
     return None
 
 
+def _resolve_stringname_orphan_threshold() -> int:
+    raw = os.environ.get(STRINGNAME_ORPHAN_GUARD_THRESHOLD_ENV, "").strip()
+    if not raw:
+        return STRINGNAME_ORPHAN_GUARD_DEFAULT_THRESHOLD
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return STRINGNAME_ORPHAN_GUARD_DEFAULT_THRESHOLD
+
+
+def _count_stringname_orphans(output: str) -> tuple[int, list[str]]:
+    matches = STRINGNAME_ORPHAN_LINE_RE.findall(output)
+    return len(matches), matches
+
+
+def _emit_stringname_orphan_lifetime_line(
+    passed: bool, delta: int, threshold: int, fail_reason: str
+) -> None:
+    payload = {
+        "scenario": "stringname_orphans",
+        "passed": passed,
+        "stringname_orphan_delta": delta,
+        "threshold_orphans": threshold,
+        "fail_reason": fail_reason,
+    }
+    # Stable ordering so PR 7's manifest parser can diff the line verbatim.
+    print("[GS-LIFETIME] " + json.dumps(payload, sort_keys=False, separators=(",", ":")))
+
+
+def _resolve_stringname_orphan_project() -> Path:
+    raw = os.environ.get(STRINGNAME_ORPHAN_GUARD_PROJECT_ENV, "").strip()
+    if raw:
+        candidate = Path(raw)
+        if not candidate.is_absolute():
+            candidate = (ROOT / candidate).resolve()
+        return candidate
+    return STRINGNAME_ORPHAN_GUARD_DEFAULT_PROJECT
+
+
+def _run_stringname_orphan_guard_step(godot: str) -> int | None:
+    """Subprocess CI guard for PR 6 of work package #352.
+
+    Spawns the Godot binary headless+verbose against a representative
+    project (default tests/examples/godot/test_project) with --quit so
+    that StringName::cleanup() runs at exit, then counts the
+    ``Orphan StringName:`` lines it emits. Emits one ``[GS-LIFETIME]``
+    JSON line shaped to match the stringname_orphans scenario PR 7's
+    manifest gate will consume.
+
+    The guard is informational for now: it passes when the orphan count
+    is at or below threshold. PR 7 tightens this to ``delta vs baseline
+    must be 0``. Missing binary path or missing probe project is
+    non-fatal (the guard short-circuits and emits a passing line with a
+    sentinel delta of -1 so guard-only mode still completes in
+    environments without a built binary or sample project).
+    """
+    threshold = _resolve_stringname_orphan_threshold()
+    project = _resolve_stringname_orphan_project()
+    normalized_binary = _normalize_process_arg(godot)
+    if not normalized_binary:
+        print(
+            "[module-tests] StringName orphan guard skipped: no Godot binary "
+            f"specified (set --godot-binary or {STRINGNAME_ORPHAN_GUARD_BINARY_ENV})."
+        )
+        _emit_stringname_orphan_lifetime_line(
+            passed=True,
+            delta=-1,
+            threshold=threshold,
+            fail_reason="binary_unspecified",
+        )
+        return None
+
+    binary_path = Path(normalized_binary)
+    if not binary_path.is_file():
+        print(
+            f"[module-tests] StringName orphan guard skipped: binary not found "
+            f"at '{normalized_binary}'."
+        )
+        _emit_stringname_orphan_lifetime_line(
+            passed=True,
+            delta=-1,
+            threshold=threshold,
+            fail_reason="binary_missing",
+        )
+        return None
+
+    if not project.is_dir() or not (project / "project.godot").is_file():
+        print(
+            f"[module-tests] StringName orphan guard skipped: probe project "
+            f"not found at '{project}'."
+        )
+        _emit_stringname_orphan_lifetime_line(
+            passed=True,
+            delta=-1,
+            threshold=threshold,
+            fail_reason="project_missing",
+        )
+        return None
+
+    command = [
+        normalized_binary,
+        "--path",
+        str(project),
+        "--headless",
+        "--verbose",
+        "--quit",
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=STRINGNAME_ORPHAN_GUARD_TIMEOUT_SEC,
+        )
+    except (FileNotFoundError, PermissionError, OSError, subprocess.TimeoutExpired) as exc:
+        print(
+            f"[module-tests] StringName orphan guard failed to run: "
+            f"{type(exc).__name__}: {exc}"
+        )
+        _emit_stringname_orphan_lifetime_line(
+            passed=False,
+            delta=-1,
+            threshold=threshold,
+            fail_reason=f"subprocess_error:{type(exc).__name__}",
+        )
+        return 1
+
+    combined_output = (result.stdout or "") + (result.stderr or "")
+    orphan_count, orphan_names = _count_stringname_orphans(combined_output)
+
+    print(
+        f"[module-tests] StringName orphan guard: count={orphan_count} "
+        f"threshold={threshold} project={project.name} exit={result.returncode}."
+    )
+    if orphan_count > 0:
+        sample = ", ".join(sorted(set(orphan_names))[:10])
+        print(f"[module-tests]   orphan StringNames (deduped, first 10): {sample}")
+
+    if orphan_count > threshold:
+        fail_reason = (
+            f"orphan_count_above_threshold:{orphan_count}>{threshold}"
+        )
+        _emit_stringname_orphan_lifetime_line(
+            passed=False,
+            delta=orphan_count,
+            threshold=threshold,
+            fail_reason=fail_reason,
+        )
+        print(
+            f"[module-tests] StringName orphan guard FAILED: "
+            f"{orphan_count} orphans exceeds threshold {threshold}."
+        )
+        return 1
+
+    _emit_stringname_orphan_lifetime_line(
+        passed=True,
+        delta=orphan_count,
+        threshold=threshold,
+        fail_reason="",
+    )
+    return None
+
+
 def _run_static_guard_step() -> int | None:
     guards_ok, guard_failures = _run_static_format_guards()
     if not guards_ok:
@@ -951,6 +1156,7 @@ def _run_ci_guard_steps(cli_args: argparse.Namespace) -> int | None:
             lambda: _run_history_artifact_guard_step(history_guard_mode),
             lambda: _run_optional_message_guards(cli_args),
             lambda: _run_configured_render_and_static_guards(cli_args),
+            lambda: _run_stringname_orphan_guard_step(cli_args.godot_binary),
         )
     )
 

--- a/tests/ci/run_module_tests.py
+++ b/tests/ci/run_module_tests.py
@@ -13,6 +13,7 @@ import importlib.util
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -948,10 +949,14 @@ def _run_stringname_orphan_guard_step(godot: str) -> int | None:
         return None
 
     binary_path = Path(normalized_binary)
-    if not binary_path.is_file():
+    # Accept either a direct file path or a command-style name that is
+    # resolvable via PATH (e.g. the default `godot`). shutil.which honors
+    # PATHEXT on Windows so `godot` can resolve to `godot.exe`/`.bat`.
+    path_resolved_binary = shutil.which(normalized_binary)
+    if not binary_path.is_file() and path_resolved_binary is None:
         print(
             f"[module-tests] StringName orphan guard skipped: binary not found "
-            f"at '{normalized_binary}'."
+            f"at '{normalized_binary}' and not resolvable via PATH."
         )
         _emit_stringname_orphan_lifetime_line(
             passed=True,
@@ -960,6 +965,11 @@ def _run_stringname_orphan_guard_step(godot: str) -> int | None:
             fail_reason="binary_missing",
         )
         return None
+    # Prefer the literal path when it exists; otherwise use the PATH-resolved
+    # location so subprocess.run does not need to re-resolve via PATHEXT.
+    invocation_binary = (
+        normalized_binary if binary_path.is_file() else path_resolved_binary
+    )
 
     if not project.is_dir() or not (project / "project.godot").is_file():
         print(
@@ -975,7 +985,7 @@ def _run_stringname_orphan_guard_step(godot: str) -> int | None:
         return None
 
     command = [
-        normalized_binary,
+        invocation_binary,
         "--path",
         str(project),
         "--headless",
@@ -1015,6 +1025,25 @@ def _run_stringname_orphan_guard_step(godot: str) -> int | None:
     if orphan_count > 0:
         sample = ", ".join(sorted(set(orphan_names))[:10])
         print(f"[module-tests]   orphan StringNames (deduped, first 10): {sample}")
+
+    # A crashed/failed Godot invocation must not be reported as a passing
+    # guard just because the orphan parse stayed under threshold (the
+    # teardown path we are validating may not even have executed). Emit a
+    # failing [GS-LIFETIME] line so PR 7's manifest parser consumes it
+    # uniformly as a failure.
+    if result.returncode != 0:
+        fail_reason = f"probe_exit:{result.returncode}"
+        _emit_stringname_orphan_lifetime_line(
+            passed=False,
+            delta=orphan_count,
+            threshold=threshold,
+            fail_reason=fail_reason,
+        )
+        print(
+            f"[module-tests] StringName orphan guard FAILED: probe exited with "
+            f"code {result.returncode}."
+        )
+        return 1
 
     if orphan_count > threshold:
         fail_reason = (


### PR DESCRIPTION
## Context

**PR 6 of work package #352**. Bases on master; independent of stacked Wave 2/3 PRs.

## What's wrong

Headless `--verbose` runs of the editor against `tests/examples/godot/test_project --quit` produced this at exit (captured by `StringName::cleanup()` in DEBUG builds):

```
StringName: 19 unclaimed string names at exit.
Orphan StringName: fidelity_limited (total: 6)
Orphan StringName: rendering/gaussian_splatting/sorting/target_sort_time_ms (total: 2)
Orphan StringName: manager_construct (total: 2)
Orphan StringName: module_register (total: 2)
Orphan StringName: pipeline_sh_amortization (total: 1)
Orphan StringName: device_request_primary (total: 2)
Orphan StringName: note (total: 6)
Orphan StringName: rendering/gaussian_splatting/renderdoc_compatibility (total: 1)
Orphan StringName: value (total: 6)
Orphan StringName: pipeline_fast_raster (total: 1)
Orphan StringName: pipeline_packed_stage_data (total: 1)
Orphan StringName: rendering/gaussian_splatting/gpu_sorting/target_sort_time_ms (total: 1)
Orphan StringName: pipeline_sh_amortization_divisor (total: 1)
Orphan StringName: pipeline_two_stage_sort (total: 1)
Orphan StringName: source_label (total: 6)
Orphan StringName: display_value (total: 6)
Orphan StringName: pipeline_tighter_bounds (total: 1)
Orphan StringName: device_request_shared (total: 2)
Orphan StringName: source (total: 6)
```

All 19 are MODULE-OWNED. Three storage sites kept the cached StringNames alive past module unregister:

| Storage site | Orphan names | Why it leaked |
| --- | --- | --- |
| `GSStartupTrace::totals_usec / insertion_order` (singleton HashMap) | `manager_construct`, `module_register`, `device_request_primary`, `device_request_shared` | `GS_STARTUP_SCOPE("...")` records each phase into the HashMap; the singleton outlives module unregister and only `reset()` clears it — and `reset()` is not called from unregister. |
| `g_pipeline_feature_set.loaded_provenance_snapshot / effective_provenance_snapshot` (Dictionaries) | `pipeline_two_stage_sort`, `pipeline_packed_stage_data`, `pipeline_tighter_bounds`, `pipeline_fast_raster`, `pipeline_sh_amortization`, `pipeline_sh_amortization_divisor`, plus the generic make_entry field keys (`value`, `source`, `source_label`, `display_value`, `note`, `fidelity_limited`) | `set_entry()` builds Dictionaries keyed by `StringName("...")`; the global feature-set is never cleared. |
| Function-local `static const StringName` in `core/gaussian_splat_manager.cpp` and `renderer/sorting_settings_utils.h` | `rendering/gaussian_splatting/renderdoc_compatibility`, `rendering/gaussian_splatting/sorting/target_sort_time_ms`, `rendering/gaussian_splatting/gpu_sorting/target_sort_time_ms` | function-local static StringName lives in static storage until program exit, no release hook reachable from outside the function. |

The generic field-name keys (`value`, `source`, etc.) were verified by grep to be module-owned: they only appear inside `core/effective_config_snapshot.h::make_entry()` and `set_entry()`, which are called exclusively from `pipeline_feature_set.cpp`. Clearing the snapshot Dictionaries releases them along with the `pipeline_*` keys.

## What this PR does

1. **New file `modules/gaussian_splatting/core/module_string_names.{h,cpp}`** — heap-allocated `ModuleStringNames` struct holding the three path StringNames that previously lived in function-local statics. `initialize_module_string_names()` constructs it at module register; `release_module_string_names()` zeroes the fields (via `StringName()` assignment) and frees the struct at unregister. Header callers go through `get_module_string_name_or_construct()` which falls back to an on-demand StringName when the cache is not yet active (test fixtures, pre-init).
2. **`logger/startup_trace.{h,cpp}`** — add `GSStartupTrace::release_module_strings()` (separate entry point from `reset()` so the intent at the call site is explicit). Clears `totals_usec`, `insertion_order`, and `sealed_traces`.
3. **`renderer/pipeline_feature_set.{h,cpp}`** — add `PipelineFeatureSet::clear_provenance_snapshots()` plus a free-function `release_pipeline_feature_set_module_strings()` wrapper. Clears both snapshot Dictionaries.
4. **`core/gaussian_splat_manager.cpp` and `renderer/sorting_settings_utils.h`** — `RENDERDOC_COMPATIBILITY_PATH`, `target_sort_time_path`, and `legacy_gpu_target_sort_time_path` now resolve through `get_module_string_name_or_construct` instead of caching their own function-local statics. 4 call sites updated (3 accessor bodies + 1 include).
5. **`register_types.cpp`** — `initialize_gaussian_splatting_module(SCENE)` calls `gs::initialize_module_string_names()` before any module init code that reads a path through the new accessors. `uninitialize_gaussian_splatting_module(SCENE)` calls the three release functions in dependency order: pipeline snapshots first, then trace phase storage, then the module StringName cache.
6. **`tests/ci/run_module_tests.py`** — new `_run_stringname_orphan_guard_step(godot)` hooked into `_run_ci_guard_steps`. Runs the binary headless+verbose against `tests/examples/godot/test_project --quit` and counts `Orphan StringName:` lines from `StringName::cleanup()`. Emits one `[GS-LIFETIME] {"scenario":"stringname_orphans","passed":true,"stringname_orphan_delta":N,"threshold_orphans":M,"fail_reason":""}` JSON line so PR 7''s manifest gate consumes the same contract as PR 3''s fixture. Threshold defaults to 5 (configurable via `GS_STRINGNAME_ORPHAN_THRESHOLD`); probe project overridable via `GS_STRINGNAME_ORPHAN_PROJECT`. Missing binary / missing project is non-fatal (sentinel `-1` delta, `fail_reason="binary_missing"` etc.), so guard-only mode still completes in environments without a build.

Why not `--test --test-case=*Synthetic*` (as the brief proposed)? Empirically that mode does not exercise `StringName::cleanup()` — doctest''s exit path differs from the engine''s cleanup path, so the orphan report is never printed. The `--path <project> --quit` flow is the actual reproducer for the bug.

## Verification

Worktree dev build (SCONS_EXIT=0, mtime fresh):

| Check | Baseline (master) | After PR 6 |
| --- | --- | --- |
| Module-owned orphans (project_quit probe) | 19 | **0** |
| Total orphans (project_quit probe) | 19 | **0** |
| `MODULE_TESTS_EXIT` | 0 | **0** |
| Guard step (`--guard-only`) | n/a | **0** |
| Module-test summary | n/a | 22 lanes, 334 tests, 5471 assertions |
| `[GS-LIFETIME]` line | n/a | `{"scenario":"stringname_orphans","passed":true,"stringname_orphan_delta":0,"threshold_orphans":5,"fail_reason":""}` |
| Renderer release gate (`--mode contract`) | passing | **passing** |

## Orphans left intentionally

None at present. All 19 orphans from the bug report are gone. The `threshold_orphans=5` headroom in the guard absorbs potential engine-side noise that might be introduced by future engine bumps; PR 7 will tighten this to `delta-vs-baseline == 0`.

## Out of scope

- SceneDirector teardown ordering (PR 4, branch `codex/gs-352-scene-director-teardown-world`).
- OutputCompositor LRU lifetime (PR 5, branch `codex/gs-352-output-compositor-lru-bound`).
- Streaming bootstrap ordering (PR 1, separate branch).
- `test_renderer_lifetime_proof.h` fixture changes (PR 3/4 own that file).
- SEH handler hardening (#385).

## Manifest

No `renderer_release_gate_manifest.json` bump: no new TEST_CASEs were added, only a CI guard step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)