### PR TITLE
gaussian_splatting: lifetime_accounting_proof gate criterion

### DIFF
--- a/docs/reference/renderer-release-gates.md
+++ b/docs/reference/renderer-release-gates.md
@@ -145,6 +145,13 @@ number from the PR #389 scenario. The gate skips the count check when the
 sentinel is present, then enforces `stringname_orphans_max` when the
 `stringname_orphans` scenario supplies the real delta.
 
+The manifest also declares `advisory_fields_strict_for` — a map from scenario
+name to the list of advisory fields that scenario MUST report (even if the
+value is the sentinel). This closes a hole where a strict scenario could drop
+the advisory field entirely and silently bypass its count threshold; the
+`stringname_orphans` scenario is the canonical strict consumer of
+`stringname_orphan_delta`.
+
 ### Example stdout line
 
 ```text
@@ -180,7 +187,9 @@ python3 tests/ci/check_renderer_release_gates.py \
    `advisory_fields` and the corresponding cap in `thresholds_counts`. The
    validator's advisory-mapping currently routes `stringname_orphan_delta` to
    `stringname_orphans_max`; new advisory fields look up their cap by their own
-   name in `thresholds_counts`.
+   name in `thresholds_counts`. If the scenario is the canonical producer of
+   that advisory counter (so the field MUST always appear in its entry), also
+   list the scenario -> [field] pair under `advisory_fields_strict_for`.
 4. Have the producing fixture/guard print `[GS-LIFETIME] {...}` lines that
    include `scenario`, `passed`, `fail_reason`, and the metric/advisory fields
    referenced above.

--- a/docs/reference/renderer-release-gates.md
+++ b/docs/reference/renderer-release-gates.md
@@ -115,6 +115,76 @@ evidence:
 The current public performance dashboard remains a non-authoritative snapshot
 until a complete candidate evidence bundle exists.
 
+## Lifetime Accounting Proof
+
+The `lifetime_accounting_proof` manifest section gates the renderer-lifetime
+hazards tracked by #352. It consumes structured `[GS-LIFETIME]` JSON lines
+written to stdout by the renderer lifetime-proof fixture (PR #386) and the
+orphan-`StringName` CI guard (PR #389). Each scenario emits one self-contained
+JSON object after the marker prefix declared in the manifest
+(`stdout_marker`, currently `"[GS-LIFETIME] "`).
+
+A passing run reports every required scenario exactly once with `passed=true`,
+its scenario-specific byte counter below the manifest threshold, and either a
+real orphan-`StringName` delta below the count threshold or the
+`advisory_sentinel_value` (`-1`, "not measured this run").
+
+### Required scenarios
+
+| Scenario | Source | Metric (`scenario_metric_fields`) | Byte threshold |
+| --- | --- | --- | --- |
+| `renderer_instance` | PR #386 fixture | `rd_bytes_leaked` | 4194304 |
+| `failed_init` | PR #386 fixture | `rd_bytes_leaked` | 4194304 |
+| `scene_director_reload` | PR #386 fixture | `rd_bytes_leaked` (growth) | 262144 |
+| `asset_attach_detach` | PR #386 fixture | `rd_bytes_leaked` (growth) | 65536 |
+| `stringname_orphans` | PR #389 guard | `stringname_orphan_delta` (advisory) | `stringname_orphans_max=5` |
+
+The advisory counter `stringname_orphan_delta` is reported by every PR #386
+scenario as the sentinel `-1` ("not measured this run") and only carries a real
+number from the PR #389 scenario. The gate skips the count check when the
+sentinel is present, then enforces `stringname_orphans_max` when the
+`stringname_orphans` scenario supplies the real delta.
+
+### Example stdout line
+
+```text
+[GS-LIFETIME] {"scenario":"renderer_instance","passed":true,"rd_bytes_leaked":131072,
+"rdm_owned_leaked":0,"rdm_tracked_leaked":0,"teardown_sync":true,
+"threshold_bytes":4194304,"stringname_orphan_delta":-1,"fail_reason":""}
+```
+
+### Running the check
+
+`--mode contract` only validates that the manifest section exists and is
+well-formed:
+
+```bash
+python3 tests/ci/check_renderer_release_gates.py --mode contract
+```
+
+`--mode lifetime` consumes a captured stdout artifact and runs the full
+scenario-by-scenario check:
+
+```bash
+python3 tests/ci/check_renderer_release_gates.py \
+  --mode lifetime \
+  --lifetime-stdout artifacts/lifetime_stdout.log
+```
+
+### Adding a new scenario
+
+1. Add the scenario name to `required_scenarios` in the manifest section.
+2. If the scenario reports a byte counter, register the field name in
+   `scenario_metric_fields` and the threshold in `thresholds_bytes`.
+3. If the scenario reports a new advisory counter, add the field name to
+   `advisory_fields` and the corresponding cap in `thresholds_counts`. The
+   validator's advisory-mapping currently routes `stringname_orphan_delta` to
+   `stringname_orphans_max`; new advisory fields look up their cap by their own
+   name in `thresholds_counts`.
+4. Have the producing fixture/guard print `[GS-LIFETIME] {...}` lines that
+   include `scenario`, `passed`, `fail_reason`, and the metric/advisory fields
+   referenced above.
+
 ## CI Hook
 
 Run the direct contract check locally:

--- a/docs/reference/renderer_release_gate_manifest.json
+++ b/docs/reference/renderer_release_gate_manifest.json
@@ -212,6 +212,37 @@
     ],
     "each_artifact_requires": ["path", "sha256", "godot_binary_commit", "godot_binary_mtime_utc"]
   },
+  "lifetime_accounting_proof": {
+    "stdout_marker": "[GS-LIFETIME] ",
+    "required_scenarios": [
+      "renderer_instance",
+      "failed_init",
+      "scene_director_reload",
+      "asset_attach_detach",
+      "stringname_orphans"
+    ],
+    "scenario_metric_fields": {
+      "renderer_instance": "rd_bytes_leaked",
+      "failed_init": "rd_bytes_leaked",
+      "scene_director_reload": "rd_bytes_leaked",
+      "asset_attach_detach": "rd_bytes_leaked"
+    },
+    "thresholds_bytes": {
+      "renderer_instance": 4194304,
+      "failed_init": 4194304,
+      "scene_director_reload": 262144,
+      "asset_attach_detach": 65536
+    },
+    "thresholds_counts": {
+      "stringname_orphans_max": 5
+    },
+    "test_binary_lane": "GaussianSplatting [Lifetime]",
+    "gpu_harness_batch": "Lifetime",
+    "advisory_fields": ["stringname_orphan_delta"],
+    "advisory_sentinel_value": -1,
+    "source_prs": [386, 389],
+    "owner_issue": 352
+  },
   "references": [
     "docs/reference/renderer-release-gates.md",
     "docs/development/known-public-alpha-limitations.md",

--- a/docs/reference/renderer_release_gate_manifest.json
+++ b/docs/reference/renderer_release_gate_manifest.json
@@ -240,6 +240,9 @@
     "gpu_harness_batch": "Lifetime",
     "advisory_fields": ["stringname_orphan_delta"],
     "advisory_sentinel_value": -1,
+    "advisory_fields_strict_for": {
+      "stringname_orphans": ["stringname_orphan_delta"]
+    },
     "source_prs": [386, 389],
     "owner_issue": 352
   },

--- a/tests/ci/check_renderer_release_gates.py
+++ b/tests/ci/check_renderer_release_gates.py
@@ -632,6 +632,44 @@ def _validate_lifetime_accounting_proof_schema(manifest: dict[str, Any]) -> list
                 f"disablable by omitting the field from the entry"
             )
 
+    # Cross-field invariant: every required scenario that declares a metric
+    # field (i.e., appears in scenario_metric_fields) MUST also have a
+    # thresholds_bytes entry. Otherwise the runtime byte-threshold check
+    # silently no-ops (the `if byte_threshold is not None` branch in
+    # validate_lifetime_accounting_proof falls through), and a manifest
+    # typo or accidental key removal can disable the byte guard while still
+    # passing the lifetime gate with arbitrarily large rd_bytes_leaked
+    # values (Codex P2 review on PR #390; bot verified the exploit by
+    # removing asset_attach_detach from thresholds_bytes and feeding a
+    # huge leak value -- validate_lifetime_accounting_proof returned
+    # success).
+    required_scenarios_list: list[str] = []
+    if isinstance(required_scenarios, list):
+        required_scenarios_list = [
+            name for name in required_scenarios if isinstance(name, str) and name
+        ]
+    metric_fields_dict: dict[str, Any] = (
+        metric_fields if isinstance(metric_fields, dict) else {}
+    )
+    thresholds_bytes_dict: dict[str, Any] = (
+        thresholds_bytes if isinstance(thresholds_bytes, dict) else {}
+    )
+    for scenario in required_scenarios_list:
+        if scenario not in metric_fields_dict:
+            # Scenarios without a declared metric field (e.g.
+            # stringname_orphans, which is count-only) do not participate
+            # in byte-threshold enforcement and so do not require an
+            # entry in thresholds_bytes.
+            continue
+        if scenario not in thresholds_bytes_dict:
+            failures.append(
+                f"lifetime_accounting_proof.thresholds_bytes must declare an entry for "
+                f"required scenario {scenario!r} because scenario_metric_fields binds it "
+                f"to metric {metric_fields_dict[scenario]!r}; otherwise the byte-leak "
+                f"guard is silently disabled by a manifest typo or accidental key removal "
+                f"(byte threshold not declared (manifest invariant))"
+            )
+
     for field in ("test_binary_lane", "gpu_harness_batch"):
         value = section.get(field)
         if value is not None and (not isinstance(value, str) or not value):
@@ -1514,8 +1552,8 @@ def validate_lifetime_accounting_proof(
 
             # Byte-threshold check using the scenario-specific metric field.
             byte_threshold = thresholds_bytes.get(scenario)
+            metric_field = metric_fields.get(scenario)
             if byte_threshold is not None:
-                metric_field = metric_fields.get(scenario)
                 if not metric_field:
                     reasons.append(
                         f"lifetime scenario {scenario} has bytes threshold but no scenario_metric_fields entry"
@@ -1534,6 +1572,27 @@ def validate_lifetime_accounting_proof(
                         reasons.append(
                             f"lifetime scenario {scenario} {metric_field}={metric_value} exceeds threshold {byte_threshold}"
                         )
+            elif metric_field:
+                # Codex P2 review on PR #390: defense-in-depth. When the
+                # scenario declares a metric field (via
+                # scenario_metric_fields) but no corresponding
+                # thresholds_bytes entry, the original code silently
+                # skipped the byte check entirely -- a manifest typo or
+                # accidental key removal could disable the byte guard
+                # while still letting the runtime pass arbitrarily large
+                # rd_bytes_leaked values. The schema validator normally
+                # rejects this at contract time, but if someone edits the
+                # schema check out the runtime must still refuse to
+                # silently accept entries that report a real numeric
+                # value in the metric field with no threshold.
+                metric_value = entry.get(metric_field)
+                if metric_value is not None and _is_json_number(metric_value):
+                    reasons.append(
+                        f"lifetime scenario {scenario} {metric_field}={metric_value} "
+                        f"cannot be enforced because thresholds_bytes.{scenario} is not "
+                        f"declared (byte threshold not declared (manifest invariant); the "
+                        f"schema check should have rejected this)"
+                    )
 
             # Strict-required advisory fields: scenarios listed in
             # advisory_fields_strict_for MUST report each named field, even if

--- a/tests/ci/check_renderer_release_gates.py
+++ b/tests/ci/check_renderer_release_gates.py
@@ -553,13 +553,14 @@ def _validate_lifetime_accounting_proof_schema(manifest: dict[str, Any]) -> list
     if sentinel is not None and not _is_json_number(sentinel):
         failures.append("lifetime_accounting_proof.advisory_sentinel_value must be numeric or omitted")
 
-    strict_for = section.get("advisory_fields_strict_for", {})
-    if not isinstance(strict_for, dict):
+    strict_for_raw = section.get("advisory_fields_strict_for", {})
+    strict_for_valid: dict[str, list[str]] = {}
+    if not isinstance(strict_for_raw, dict):
         failures.append(
             "lifetime_accounting_proof.advisory_fields_strict_for must be a JSON object mapping scenario -> [field, ...]"
         )
     else:
-        for scenario, fields in strict_for.items():
+        for scenario, fields in strict_for_raw.items():
             if not isinstance(scenario, str) or not scenario:
                 failures.append(
                     "lifetime_accounting_proof.advisory_fields_strict_for keys must be non-empty strings"
@@ -570,11 +571,48 @@ def _validate_lifetime_accounting_proof_schema(manifest: dict[str, Any]) -> list
                     f"lifetime_accounting_proof.advisory_fields_strict_for[{scenario!r}] must be a non-empty list of field names"
                 )
                 continue
+            valid_fields: list[str] = []
             for index, field_name in enumerate(fields):
                 if not isinstance(field_name, str) or not field_name:
                     failures.append(
                         f"lifetime_accounting_proof.advisory_fields_strict_for[{scenario!r}][{index}] must be a non-empty string"
                     )
+                    continue
+                valid_fields.append(field_name)
+            if valid_fields:
+                strict_for_valid[scenario] = valid_fields
+
+    # Cross-field invariant: any advisory field that is bounded by a
+    # thresholds_counts entry at runtime MUST appear in
+    # advisory_fields_strict_for under the threshold's scenario; otherwise a
+    # manifest can silently drop the field from the entry and the count
+    # threshold goes unenforced (Codex P2 review on PR #390). The current
+    # runtime mapping in validate_lifetime_accounting_proof hardcodes
+    # stringname_orphan_delta -> stringname_orphans_max, owned by the
+    # stringname_orphans scenario; declare that binding here.
+    ADVISORY_FIELD_STRICT_BINDINGS: dict[str, tuple[str, str]] = {
+        # advisory_field -> (required strict scenario, count threshold key)
+        "stringname_orphan_delta": ("stringname_orphans", "stringname_orphans_max"),
+    }
+    advisory_fields_set: set[str] = set()
+    if isinstance(advisory_fields, list):
+        advisory_fields_set = {name for name in advisory_fields if isinstance(name, str) and name}
+    for advisory_field, (required_scenario, count_threshold_key) in ADVISORY_FIELD_STRICT_BINDINGS.items():
+        if advisory_field not in advisory_fields_set:
+            continue
+        # Only enforce when the count threshold is actually declared; otherwise
+        # there is no threshold to silently disable.
+        if not isinstance(thresholds_counts, dict) or count_threshold_key not in thresholds_counts:
+            continue
+        strict_fields_for_scenario = strict_for_valid.get(required_scenario, [])
+        if advisory_field not in strict_fields_for_scenario:
+            failures.append(
+                f"lifetime_accounting_proof.advisory_fields_strict_for must require "
+                f"{advisory_field!r} under scenario {required_scenario!r} when "
+                f"advisory_fields lists {advisory_field!r} and thresholds_counts declares "
+                f"{count_threshold_key!r}; otherwise the count threshold is silently "
+                f"disablable by omitting the field from the entry"
+            )
 
     for field in ("test_binary_lane", "gpu_harness_batch"):
         value = section.get(field)

--- a/tests/ci/check_renderer_release_gates.py
+++ b/tests/ci/check_renderer_release_gates.py
@@ -553,6 +553,29 @@ def _validate_lifetime_accounting_proof_schema(manifest: dict[str, Any]) -> list
     if sentinel is not None and not _is_json_number(sentinel):
         failures.append("lifetime_accounting_proof.advisory_sentinel_value must be numeric or omitted")
 
+    strict_for = section.get("advisory_fields_strict_for", {})
+    if not isinstance(strict_for, dict):
+        failures.append(
+            "lifetime_accounting_proof.advisory_fields_strict_for must be a JSON object mapping scenario -> [field, ...]"
+        )
+    else:
+        for scenario, fields in strict_for.items():
+            if not isinstance(scenario, str) or not scenario:
+                failures.append(
+                    "lifetime_accounting_proof.advisory_fields_strict_for keys must be non-empty strings"
+                )
+                continue
+            if not isinstance(fields, list) or not fields:
+                failures.append(
+                    f"lifetime_accounting_proof.advisory_fields_strict_for[{scenario!r}] must be a non-empty list of field names"
+                )
+                continue
+            for index, field_name in enumerate(fields):
+                if not isinstance(field_name, str) or not field_name:
+                    failures.append(
+                        f"lifetime_accounting_proof.advisory_fields_strict_for[{scenario!r}][{index}] must be a non-empty string"
+                    )
+
     for field in ("test_binary_lane", "gpu_harness_batch"):
         value = section.get(field)
         if value is not None and (not isinstance(value, str) or not value):
@@ -1386,6 +1409,12 @@ def validate_lifetime_accounting_proof(
     thresholds_counts = manifest_section.get("thresholds_counts", {}) or {}
     advisory_fields = manifest_section.get("advisory_fields", []) or []
     advisory_sentinel = manifest_section.get("advisory_sentinel_value")
+    # advisory_fields_strict_for maps scenario -> [advisory_field, ...] for
+    # scenarios where the advisory field MUST be present in the entry. The
+    # sentinel value remains a tolerated "not measured this run" signal in
+    # strict scenarios (it is the absence of the field, not the sentinel,
+    # that masks regressions like the orphan threshold never being enforced).
+    advisory_fields_strict_for = manifest_section.get("advisory_fields_strict_for", {}) or {}
 
     try:
         lines = _coerce_lifetime_stdout_lines(stdout_artifact_or_path)
@@ -1437,9 +1466,24 @@ def validate_lifetime_accounting_proof(
                             f"lifetime scenario {scenario} {metric_field}={metric_value} exceeds threshold {byte_threshold}"
                         )
 
+            # Strict-required advisory fields: scenarios listed in
+            # advisory_fields_strict_for MUST report each named field, even if
+            # the value is the sentinel. A silently missing field would
+            # otherwise let the count threshold go unenforced (e.g.
+            # stringname_orphans dropping stringname_orphan_delta entirely).
+            strict_required_for_scenario = advisory_fields_strict_for.get(scenario, []) or []
+            for required_field in strict_required_for_scenario:
+                if required_field not in entry:
+                    reasons.append(
+                        f"lifetime scenario {scenario} missing required advisory field {required_field!r} "
+                        f"(advisory_fields_strict_for requires it; sentinel {advisory_sentinel!r} is tolerated)"
+                    )
+
             # Advisory-field checks. -1 sentinel means "not measured this run".
             for advisory_field in advisory_fields:
                 if advisory_field not in entry:
+                    # Absent fields are tolerated for non-strict scenarios.
+                    # Strict-required scenarios already failed above.
                     continue
                 value = entry.get(advisory_field)
                 if advisory_sentinel is not None and value == advisory_sentinel:

--- a/tests/ci/check_renderer_release_gates.py
+++ b/tests/ci/check_renderer_release_gates.py
@@ -474,6 +474,19 @@ def _validate_workflow_policy(root: Path, manifest: dict[str, Any]) -> list[str]
     return failures
 
 
+# Cross-field invariant binding for lifetime advisory fields. Each entry
+# maps an advisory_field -> (required strict scenario, count threshold key).
+# Used at schema-check time to require thresholds_counts to declare the
+# threshold and advisory_fields_strict_for to require the field, and at
+# runtime to look up the threshold from the advisory field. Keeping the
+# table shared means both sides cannot drift apart (Codex P2 review on
+# PR #390).
+ADVISORY_FIELD_STRICT_BINDINGS: dict[str, tuple[str, str]] = {
+    # advisory_field -> (required strict scenario, count threshold key)
+    "stringname_orphan_delta": ("stringname_orphans", "stringname_orphans_max"),
+}
+
+
 def _validate_lifetime_accounting_proof_schema(manifest: dict[str, Any]) -> list[str]:
     section = manifest.get("lifetime_accounting_proof")
     if section is None:
@@ -586,23 +599,28 @@ def _validate_lifetime_accounting_proof_schema(manifest: dict[str, Any]) -> list
     # thresholds_counts entry at runtime MUST appear in
     # advisory_fields_strict_for under the threshold's scenario; otherwise a
     # manifest can silently drop the field from the entry and the count
-    # threshold goes unenforced (Codex P2 review on PR #390). The current
-    # runtime mapping in validate_lifetime_accounting_proof hardcodes
-    # stringname_orphan_delta -> stringname_orphans_max, owned by the
-    # stringname_orphans scenario; declare that binding here.
-    ADVISORY_FIELD_STRICT_BINDINGS: dict[str, tuple[str, str]] = {
-        # advisory_field -> (required strict scenario, count threshold key)
-        "stringname_orphan_delta": ("stringname_orphans", "stringname_orphans_max"),
-    }
+    # threshold goes unenforced (Codex P2 review on PR #390). The binding
+    # is declared once at module scope as ADVISORY_FIELD_STRICT_BINDINGS
+    # so the schema validator and the runtime validator look up the same
+    # advisory_field -> (scenario, count_threshold_key) mapping.
     advisory_fields_set: set[str] = set()
     if isinstance(advisory_fields, list):
         advisory_fields_set = {name for name in advisory_fields if isinstance(name, str) and name}
     for advisory_field, (required_scenario, count_threshold_key) in ADVISORY_FIELD_STRICT_BINDINGS.items():
         if advisory_field not in advisory_fields_set:
             continue
-        # Only enforce when the count threshold is actually declared; otherwise
-        # there is no threshold to silently disable.
+        # Codex P2 review on PR #390: the count threshold must be declared
+        # whenever the advisory field is listed. A missing threshold would
+        # let the runtime silently skip enforcement (arbitrarily large
+        # orphan deltas pass as long as passed=true). Reject the manifest
+        # at contract-check time instead.
         if not isinstance(thresholds_counts, dict) or count_threshold_key not in thresholds_counts:
+            failures.append(
+                f"lifetime_accounting_proof.thresholds_counts must declare "
+                f"{count_threshold_key!r} when advisory_fields lists "
+                f"{advisory_field!r}; otherwise the orphan-count guard is "
+                f"silently disabled by a manifest typo or accidental key removal"
+            )
             continue
         strict_fields_for_scenario = strict_for_valid.get(required_scenario, [])
         if advisory_field not in strict_fields_for_scenario:
@@ -1471,8 +1489,21 @@ def validate_lifetime_accounting_proof(
         by_scenario.setdefault(scenario, []).append(entry)
 
     for scenario in required_scenarios:
-        if scenario not in by_scenario:
+        scenario_entries = by_scenario.get(scenario, [])
+        count = len(scenario_entries)
+        if count == 0:
             reasons.append(f"lifetime scenario missing from stdout: {scenario}")
+        elif count > 1:
+            # Codex P1 review on PR #390: required scenarios must appear
+            # EXACTLY once. Concatenated or stale logs can otherwise
+            # contribute entries that satisfy required coverage even
+            # when the latest run omitted scenarios. Any duplicate (any
+            # mix of passed=true/false) is treated as suspect.
+            reasons.append(
+                f"lifetime scenario {scenario} reported {count} entries; "
+                f"expected exactly one (duplicate lifetime entry -- "
+                f"concatenated or stale logs)"
+            )
 
     for scenario, scenario_entries in by_scenario.items():
         for entry in scenario_entries:
@@ -1526,13 +1557,33 @@ def validate_lifetime_accounting_proof(
                 value = entry.get(advisory_field)
                 if advisory_sentinel is not None and value == advisory_sentinel:
                     continue
-                # Map advisory field to a thresholds_counts key. The
-                # stringname_orphan_delta field is bounded by stringname_orphans_max.
-                if advisory_field == "stringname_orphan_delta":
-                    count_threshold = thresholds_counts.get("stringname_orphans_max")
+                # Map advisory field to a thresholds_counts key via the
+                # shared ADVISORY_FIELD_STRICT_BINDINGS table. Fall back to
+                # the advisory field name itself when no explicit binding
+                # is declared (legacy behaviour).
+                binding = ADVISORY_FIELD_STRICT_BINDINGS.get(advisory_field)
+                if binding is not None:
+                    _, count_threshold_key = binding
                 else:
-                    count_threshold = thresholds_counts.get(advisory_field)
+                    count_threshold_key = advisory_field
+                count_threshold = thresholds_counts.get(count_threshold_key)
                 if count_threshold is None:
+                    if binding is not None:
+                        # Codex P2 review on PR #390: defense-in-depth.
+                        # When the manifest binds this advisory field to a
+                        # count threshold key but the threshold is missing,
+                        # never silently skip enforcement -- the schema
+                        # check normally rejects this at contract time,
+                        # but if someone edits the schema check out the
+                        # runtime must still refuse to pass arbitrarily
+                        # large deltas.
+                        reasons.append(
+                            f"lifetime scenario {scenario} advisory field "
+                            f"{advisory_field}={value} cannot be enforced "
+                            f"because thresholds_counts.{count_threshold_key} "
+                            f"is not declared (manifest invariant; the schema "
+                            f"check should have rejected this)"
+                        )
                     continue
                 if not _is_json_number(value):
                     reasons.append(

--- a/tests/ci/check_renderer_release_gates.py
+++ b/tests/ci/check_renderer_release_gates.py
@@ -508,6 +508,32 @@ def _validate_lifetime_accounting_proof_schema(manifest: dict[str, Any]) -> list
                 failures.append(
                     f"lifetime_accounting_proof.required_scenarios[{index}] must be a non-empty string"
                 )
+        # Codex P2 review on PR #390 (comment #3295128412): the element-type
+        # loop above accepts duplicate scenario names, so a manifest typo
+        # that replaces "failed_init" with a second "renderer_instance"
+        # silently disables coverage for the dropped scenario -- the
+        # runtime walks scenarios via membership in required_scenarios, so
+        # the duplicated entry is matched twice while failed_init is never
+        # required to appear in stdout, and validate_lifetime_accounting_proof
+        # passes a stdout artifact that never reports failed_init at all.
+        # Reject duplicates at contract time and name them so the operator
+        # can locate the typo immediately.
+        seen: list[str] = []
+        duplicates: list[str] = []
+        for name in required_scenarios:
+            if not isinstance(name, str) or not name:
+                continue
+            if name in seen and name not in duplicates:
+                duplicates.append(name)
+            else:
+                seen.append(name)
+        if duplicates:
+            failures.append(
+                f"lifetime_accounting_proof.required_scenarios contains duplicate "
+                f"entries: {duplicates}; every scenario name must be unique so that "
+                f"a typo replacing one scenario with a copy of another cannot "
+                f"silently disable coverage for the dropped scenario"
+            )
 
     metric_fields = section.get("scenario_metric_fields", {})
     if not isinstance(metric_fields, dict):

--- a/tests/ci/check_renderer_release_gates.py
+++ b/tests/ci/check_renderer_release_gates.py
@@ -1624,6 +1624,22 @@ def main(argv: list[str] | None = None) -> int:
         if not args.lifetime_stdout:
             print("--lifetime-stdout is required in lifetime mode", file=sys.stderr)
             return 2
+        # Codex P2 review on PR #390 (comment #3294976919): run the schema
+        # validator BEFORE invoking validate_lifetime_accounting_proof so
+        # standalone lifetime runs cannot silently accept a malformed
+        # manifest. Without this, e.g. removing advisory_fields_strict_for
+        # or thresholds_counts.stringname_orphans_max would slip past the
+        # lifetime gate because the runtime treats the bound advisory
+        # field as optional. The strictest interpretation -- no opt-out
+        # flag -- is intentional: any workflow that invokes lifetime mode
+        # by itself (local checks, CI lifetime jobs) must satisfy the
+        # same schema invariants that contract mode enforces.
+        schema_failures = _validate_lifetime_accounting_proof_schema(manifest)
+        if schema_failures:
+            print("Renderer release gate lifetime schema check failed:")
+            for failure in schema_failures:
+                print(f" - {failure}")
+            return 1
         section = manifest.get("lifetime_accounting_proof")
         if not isinstance(section, dict):
             print("manifest is missing lifetime_accounting_proof section", file=sys.stderr)

--- a/tests/ci/check_renderer_release_gates.py
+++ b/tests/ci/check_renderer_release_gates.py
@@ -474,6 +474,93 @@ def _validate_workflow_policy(root: Path, manifest: dict[str, Any]) -> list[str]
     return failures
 
 
+def _validate_lifetime_accounting_proof_schema(manifest: dict[str, Any]) -> list[str]:
+    section = manifest.get("lifetime_accounting_proof")
+    if section is None:
+        return ["lifetime_accounting_proof section is missing"]
+    if not isinstance(section, dict):
+        return ["lifetime_accounting_proof must be a JSON object"]
+
+    failures: list[str] = []
+    marker = section.get("stdout_marker")
+    if not isinstance(marker, str) or not marker:
+        failures.append("lifetime_accounting_proof.stdout_marker must be a non-empty string")
+
+    required_scenarios = section.get("required_scenarios")
+    if not isinstance(required_scenarios, list) or not required_scenarios:
+        failures.append("lifetime_accounting_proof.required_scenarios must be a non-empty list")
+    else:
+        for index, name in enumerate(required_scenarios):
+            if not isinstance(name, str) or not name:
+                failures.append(
+                    f"lifetime_accounting_proof.required_scenarios[{index}] must be a non-empty string"
+                )
+
+    metric_fields = section.get("scenario_metric_fields", {})
+    if not isinstance(metric_fields, dict):
+        failures.append("lifetime_accounting_proof.scenario_metric_fields must be a JSON object")
+        metric_fields = {}
+    else:
+        for scenario, field in metric_fields.items():
+            if not isinstance(scenario, str) or not scenario:
+                failures.append(
+                    "lifetime_accounting_proof.scenario_metric_fields keys must be non-empty strings"
+                )
+                continue
+            if not isinstance(field, str) or not field:
+                failures.append(
+                    f"lifetime_accounting_proof.scenario_metric_fields[{scenario!r}] must be a non-empty string"
+                )
+
+    thresholds_bytes = section.get("thresholds_bytes")
+    if not isinstance(thresholds_bytes, dict) or not thresholds_bytes:
+        failures.append("lifetime_accounting_proof.thresholds_bytes must be a non-empty JSON object")
+    else:
+        for scenario, value in thresholds_bytes.items():
+            if not isinstance(scenario, str) or not scenario:
+                failures.append("lifetime_accounting_proof.thresholds_bytes keys must be non-empty strings")
+                continue
+            if not _is_json_number(value) or value < 0:
+                failures.append(
+                    f"lifetime_accounting_proof.thresholds_bytes[{scenario!r}] must be a non-negative number"
+                )
+
+    thresholds_counts = section.get("thresholds_counts", {})
+    if not isinstance(thresholds_counts, dict):
+        failures.append("lifetime_accounting_proof.thresholds_counts must be a JSON object")
+        thresholds_counts = {}
+    else:
+        for name, value in thresholds_counts.items():
+            if not isinstance(name, str) or not name:
+                failures.append("lifetime_accounting_proof.thresholds_counts keys must be non-empty strings")
+                continue
+            if not _is_json_number(value) or value < 0:
+                failures.append(
+                    f"lifetime_accounting_proof.thresholds_counts[{name!r}] must be a non-negative number"
+                )
+
+    advisory_fields = section.get("advisory_fields", [])
+    if not isinstance(advisory_fields, list):
+        failures.append("lifetime_accounting_proof.advisory_fields must be a list")
+    else:
+        for index, name in enumerate(advisory_fields):
+            if not isinstance(name, str) or not name:
+                failures.append(
+                    f"lifetime_accounting_proof.advisory_fields[{index}] must be a non-empty string"
+                )
+
+    sentinel = section.get("advisory_sentinel_value")
+    if sentinel is not None and not _is_json_number(sentinel):
+        failures.append("lifetime_accounting_proof.advisory_sentinel_value must be numeric or omitted")
+
+    for field in ("test_binary_lane", "gpu_harness_batch"):
+        value = section.get(field)
+        if value is not None and (not isinstance(value, str) or not value):
+            failures.append(f"lifetime_accounting_proof.{field} must be a non-empty string when present")
+
+    return failures
+
+
 def validate_contract(root: Path, manifest: dict[str, Any]) -> list[str]:
     tests = _extract_requires_gpu_tests(root)
     failures: list[str] = []
@@ -486,6 +573,7 @@ def validate_contract(root: Path, manifest: dict[str, Any]) -> list[str]:
     failures.extend(_validate_gpu_harness_policy(root, manifest, tests))
     failures.extend(_validate_visual_acceptance(root, manifest))
     failures.extend(_validate_workflow_policy(root, manifest))
+    failures.extend(_validate_lifetime_accounting_proof_schema(manifest))
     return failures
 
 
@@ -1225,12 +1313,169 @@ def validate_candidate(
     return failures
 
 
+def _coerce_lifetime_stdout_lines(stdout_artifact_or_path: Any) -> list[str]:
+    if stdout_artifact_or_path is None:
+        return []
+    if isinstance(stdout_artifact_or_path, (list, tuple)):
+        return [str(line) for line in stdout_artifact_or_path]
+    if isinstance(stdout_artifact_or_path, Path):
+        try:
+            return stdout_artifact_or_path.read_text(encoding="utf-8", errors="ignore").splitlines()
+        except OSError as exc:
+            raise RuntimeError(f"lifetime stdout artifact unreadable: {stdout_artifact_or_path} ({exc})") from exc
+    if isinstance(stdout_artifact_or_path, str):
+        candidate = Path(stdout_artifact_or_path)
+        # If it points at an existing file, treat as a path; otherwise treat as raw content.
+        if candidate.exists() and candidate.is_file():
+            try:
+                return candidate.read_text(encoding="utf-8", errors="ignore").splitlines()
+            except OSError as exc:
+                raise RuntimeError(f"lifetime stdout artifact unreadable: {candidate} ({exc})") from exc
+        return stdout_artifact_or_path.splitlines()
+    raise RuntimeError(f"lifetime stdout artifact has unsupported type: {type(stdout_artifact_or_path).__name__}")
+
+
+def _parse_lifetime_lines(marker: str, lines: Iterable[str]) -> tuple[list[dict[str, Any]], list[str]]:
+    entries: list[dict[str, Any]] = []
+    failures: list[str] = []
+    for raw_line in lines:
+        if not raw_line.startswith(marker):
+            continue
+        payload_text = raw_line[len(marker) :].strip()
+        if not payload_text:
+            continue
+        try:
+            payload = json.loads(payload_text)
+        except json.JSONDecodeError as exc:
+            failures.append(f"lifetime line is not valid JSON: {payload_text!r} ({exc})")
+            continue
+        if not isinstance(payload, dict):
+            failures.append(f"lifetime line payload must be a JSON object: {payload_text!r}")
+            continue
+        entries.append(payload)
+    return entries, failures
+
+
+def validate_lifetime_accounting_proof(
+    manifest_section: dict[str, Any],
+    stdout_artifact_or_path: Any,
+) -> tuple[bool, list[str]]:
+    """Validate [GS-LIFETIME] JSON lines emitted by the lifetime-proof fixture.
+
+    `manifest_section` is the `lifetime_accounting_proof` block from the manifest.
+    `stdout_artifact_or_path` may be a `Path`, a string containing either a
+    filesystem path or raw stdout, or an iterable of lines.
+
+    Returns `(passed, reasons)` where `reasons` is the list of human-readable
+    failure descriptions (empty when `passed=True`).
+    """
+    reasons: list[str] = []
+    if not isinstance(manifest_section, dict):
+        return False, ["lifetime_accounting_proof manifest section must be a JSON object"]
+
+    marker = manifest_section.get("stdout_marker")
+    if not isinstance(marker, str) or not marker:
+        return False, ["lifetime_accounting_proof.stdout_marker must be a non-empty string"]
+
+    required_scenarios = manifest_section.get("required_scenarios", [])
+    if not isinstance(required_scenarios, list) or not required_scenarios:
+        return False, ["lifetime_accounting_proof.required_scenarios must be a non-empty list"]
+
+    metric_fields = manifest_section.get("scenario_metric_fields", {}) or {}
+    thresholds_bytes = manifest_section.get("thresholds_bytes", {}) or {}
+    thresholds_counts = manifest_section.get("thresholds_counts", {}) or {}
+    advisory_fields = manifest_section.get("advisory_fields", []) or []
+    advisory_sentinel = manifest_section.get("advisory_sentinel_value")
+
+    try:
+        lines = _coerce_lifetime_stdout_lines(stdout_artifact_or_path)
+    except RuntimeError as exc:
+        return False, [str(exc)]
+
+    entries, parse_failures = _parse_lifetime_lines(marker, lines)
+    reasons.extend(parse_failures)
+
+    by_scenario: dict[str, list[dict[str, Any]]] = {}
+    for entry in entries:
+        scenario = entry.get("scenario")
+        if not isinstance(scenario, str) or not scenario:
+            reasons.append(f"lifetime entry missing scenario name: {entry!r}")
+            continue
+        by_scenario.setdefault(scenario, []).append(entry)
+
+    for scenario in required_scenarios:
+        if scenario not in by_scenario:
+            reasons.append(f"lifetime scenario missing from stdout: {scenario}")
+
+    for scenario, scenario_entries in by_scenario.items():
+        for entry in scenario_entries:
+            if entry.get("passed") is not True:
+                fail_reason = entry.get("fail_reason") or "no fail_reason reported"
+                reasons.append(f"lifetime scenario {scenario} reported passed=false: {fail_reason}")
+                # Continue with other checks so the failure surface is complete.
+
+            # Byte-threshold check using the scenario-specific metric field.
+            byte_threshold = thresholds_bytes.get(scenario)
+            if byte_threshold is not None:
+                metric_field = metric_fields.get(scenario)
+                if not metric_field:
+                    reasons.append(
+                        f"lifetime scenario {scenario} has bytes threshold but no scenario_metric_fields entry"
+                    )
+                else:
+                    metric_value = entry.get(metric_field)
+                    if metric_value is None:
+                        reasons.append(
+                            f"lifetime scenario {scenario} missing metric field {metric_field!r}"
+                        )
+                    elif not _is_json_number(metric_value):
+                        reasons.append(
+                            f"lifetime scenario {scenario} metric {metric_field} must be numeric, got {metric_value!r}"
+                        )
+                    elif metric_value > byte_threshold:
+                        reasons.append(
+                            f"lifetime scenario {scenario} {metric_field}={metric_value} exceeds threshold {byte_threshold}"
+                        )
+
+            # Advisory-field checks. -1 sentinel means "not measured this run".
+            for advisory_field in advisory_fields:
+                if advisory_field not in entry:
+                    continue
+                value = entry.get(advisory_field)
+                if advisory_sentinel is not None and value == advisory_sentinel:
+                    continue
+                # Map advisory field to a thresholds_counts key. The
+                # stringname_orphan_delta field is bounded by stringname_orphans_max.
+                if advisory_field == "stringname_orphan_delta":
+                    count_threshold = thresholds_counts.get("stringname_orphans_max")
+                else:
+                    count_threshold = thresholds_counts.get(advisory_field)
+                if count_threshold is None:
+                    continue
+                if not _is_json_number(value):
+                    reasons.append(
+                        f"lifetime scenario {scenario} advisory field {advisory_field} must be numeric, got {value!r}"
+                    )
+                    continue
+                if value > count_threshold:
+                    reasons.append(
+                        f"lifetime scenario {scenario} {advisory_field}={value} exceeds threshold {count_threshold}"
+                    )
+
+    return (not reasons), reasons
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--mode", choices=("contract", "candidate"), default="contract")
+    parser.add_argument("--mode", choices=("contract", "candidate", "lifetime"), default="contract")
     parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
     parser.add_argument("--candidate-evidence", default=None)
     parser.add_argument("--issues-json", default=None)
+    parser.add_argument(
+        "--lifetime-stdout",
+        default=None,
+        help="Path to stdout artifact containing [GS-LIFETIME] JSON lines (required for --mode lifetime).",
+    )
     return parser
 
 
@@ -1242,6 +1487,16 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.mode == "contract":
         failures = validate_contract(root, manifest)
+    elif args.mode == "lifetime":
+        if not args.lifetime_stdout:
+            print("--lifetime-stdout is required in lifetime mode", file=sys.stderr)
+            return 2
+        section = manifest.get("lifetime_accounting_proof")
+        if not isinstance(section, dict):
+            print("manifest is missing lifetime_accounting_proof section", file=sys.stderr)
+            return 2
+        passed, reasons = validate_lifetime_accounting_proof(section, Path(args.lifetime_stdout))
+        failures = reasons if not passed else []
     else:
         if not args.candidate_evidence:
             print("--candidate-evidence is required in candidate mode", file=sys.stderr)

--- a/tests/ci/check_renderer_release_gates.py
+++ b/tests/ci/check_renderer_release_gates.py
@@ -606,8 +606,35 @@ def _validate_lifetime_accounting_proof_schema(manifest: dict[str, Any]) -> list
     advisory_fields_set: set[str] = set()
     if isinstance(advisory_fields, list):
         advisory_fields_set = {name for name in advisory_fields if isinstance(name, str) and name}
+    required_scenarios_set: set[str] = set()
+    if isinstance(required_scenarios, list):
+        required_scenarios_set = {
+            name for name in required_scenarios if isinstance(name, str) and name
+        }
     for advisory_field, (required_scenario, count_threshold_key) in ADVISORY_FIELD_STRICT_BINDINGS.items():
         if advisory_field not in advisory_fields_set:
+            continue
+        # Codex P2 review on PR #390 (round 6, comment #3295080072): the
+        # bound scenario must appear in required_scenarios whenever the
+        # advisory field is listed. Otherwise removing the scenario from
+        # required_scenarios silently disables orphan-threshold
+        # enforcement even though advisory_fields_strict_for and
+        # thresholds_counts still validate: the runtime only walks
+        # advisory fields for scenarios that actually appear, so dropping
+        # the scenario from required_scenarios means the entry is never
+        # required to exist and the count threshold is never compared.
+        # Reject at contract-check time, parallel to the round-3/4/5
+        # invariants and reusing the same ADVISORY_FIELD_STRICT_BINDINGS
+        # source of truth.
+        if required_scenario not in required_scenarios_set:
+            failures.append(
+                f"lifetime_accounting_proof.required_scenarios must include "
+                f"{required_scenario!r} when advisory_fields lists "
+                f"{advisory_field!r}; otherwise the orphan-threshold "
+                f"enforcement is silently disabled by a manifest typo or "
+                f"accidental scenario removal (bound scenario not required "
+                f"(manifest invariant))"
+            )
             continue
         # Codex P2 review on PR #390: the count threshold must be declared
         # whenever the advisory field is listed. A missing threshold would

--- a/tests/ci/test_renderer_release_gates.py
+++ b/tests/ci/test_renderer_release_gates.py
@@ -196,6 +196,37 @@ def _base_manifest(root: Path) -> dict[str, Any]:
             "required_groups": ["linux_release_archive", "known_limitations_page"],
             "each_artifact_requires": ["path", "sha256", "godot_binary_commit", "godot_binary_mtime_utc"],
         },
+        "lifetime_accounting_proof": {
+            "stdout_marker": "[GS-LIFETIME] ",
+            "required_scenarios": [
+                "renderer_instance",
+                "failed_init",
+                "scene_director_reload",
+                "asset_attach_detach",
+                "stringname_orphans",
+            ],
+            "scenario_metric_fields": {
+                "renderer_instance": "rd_bytes_leaked",
+                "failed_init": "rd_bytes_leaked",
+                "scene_director_reload": "rd_bytes_leaked",
+                "asset_attach_detach": "rd_bytes_leaked",
+            },
+            "thresholds_bytes": {
+                "renderer_instance": 4194304,
+                "failed_init": 4194304,
+                "scene_director_reload": 262144,
+                "asset_attach_detach": 65536,
+            },
+            "thresholds_counts": {
+                "stringname_orphans_max": 5,
+            },
+            "test_binary_lane": "GaussianSplatting [Lifetime]",
+            "gpu_harness_batch": "Lifetime",
+            "advisory_fields": ["stringname_orphan_delta"],
+            "advisory_sentinel_value": -1,
+            "source_prs": [386, 389],
+            "owner_issue": 352,
+        },
     }
 
 
@@ -1228,6 +1259,180 @@ class RendererReleaseGateTests(unittest.TestCase):
             issues = [{"number": 350, "state": "OPEN", "labels": [{"name": "release blocker"}]}]
             failures = checker.validate_candidate(root, manifest, evidence, issues)
             self.assertTrue(any("issue #350 is still blocking" in item for item in failures))
+
+
+def _lifetime_stdout_all_pass() -> str:
+    return "\n".join(
+        [
+            '[GS-LIFETIME] {"scenario":"renderer_instance","passed":true,"rd_bytes_leaked":131072,'
+            '"rdm_owned_leaked":0,"rdm_tracked_leaked":0,"teardown_sync":true,'
+            '"threshold_bytes":4194304,"stringname_orphan_delta":-1,"fail_reason":""}',
+            '[GS-LIFETIME] {"scenario":"failed_init","passed":true,"rd_bytes_leaked":0,'
+            '"rdm_owned_leaked":0,"rdm_tracked_leaked":0,"teardown_sync":false,'
+            '"threshold_bytes":4194304,"stringname_orphan_delta":-1,"fail_reason":""}',
+            '[GS-LIFETIME] {"scenario":"scene_director_reload","passed":true,"rd_bytes_leaked":0,'
+            '"rdm_owned_leaked":0,"rdm_tracked_leaked":0,"teardown_sync":true,'
+            '"threshold_bytes":262144,"stringname_orphan_delta":-1,"fail_reason":""}',
+            '[GS-LIFETIME] {"scenario":"asset_attach_detach","passed":true,"rd_bytes_leaked":32768,'
+            '"rdm_owned_leaked":0,"rdm_tracked_leaked":0,"teardown_sync":true,'
+            '"threshold_bytes":65536,"stringname_orphan_delta":-1,"fail_reason":""}',
+            '[GS-LIFETIME] {"scenario":"stringname_orphans","passed":true,'
+            '"stringname_orphan_delta":0,"threshold_orphans":5,"fail_reason":""}',
+        ]
+    )
+
+
+def _lifetime_manifest_section() -> dict[str, Any]:
+    return {
+        "stdout_marker": "[GS-LIFETIME] ",
+        "required_scenarios": [
+            "renderer_instance",
+            "failed_init",
+            "scene_director_reload",
+            "asset_attach_detach",
+            "stringname_orphans",
+        ],
+        "scenario_metric_fields": {
+            "renderer_instance": "rd_bytes_leaked",
+            "failed_init": "rd_bytes_leaked",
+            "scene_director_reload": "rd_bytes_leaked",
+            "asset_attach_detach": "rd_bytes_leaked",
+        },
+        "thresholds_bytes": {
+            "renderer_instance": 4194304,
+            "failed_init": 4194304,
+            "scene_director_reload": 262144,
+            "asset_attach_detach": 65536,
+        },
+        "thresholds_counts": {"stringname_orphans_max": 5},
+        "advisory_fields": ["stringname_orphan_delta"],
+        "advisory_sentinel_value": -1,
+    }
+
+
+class LifetimeAccountingProofTests(unittest.TestCase):
+    def test_lifetime_accounting_proof_all_pass(self) -> None:
+        section = _lifetime_manifest_section()
+        passed, reasons = checker.validate_lifetime_accounting_proof(section, _lifetime_stdout_all_pass())
+        self.assertTrue(passed, reasons)
+        self.assertEqual([], reasons)
+
+    def test_lifetime_accounting_proof_missing_scenario(self) -> None:
+        section = _lifetime_manifest_section()
+        stdout_lines = [
+            line for line in _lifetime_stdout_all_pass().splitlines() if "stringname_orphans" not in line
+        ]
+        passed, reasons = checker.validate_lifetime_accounting_proof(section, "\n".join(stdout_lines))
+        self.assertFalse(passed)
+        self.assertTrue(any("stringname_orphans" in reason and "missing" in reason for reason in reasons))
+
+    def test_lifetime_accounting_proof_scenario_failed(self) -> None:
+        section = _lifetime_manifest_section()
+        stdout = (
+            '[GS-LIFETIME] {"scenario":"renderer_instance","passed":false,"rd_bytes_leaked":131072,'
+            '"stringname_orphan_delta":-1,"fail_reason":"owned RD resources retained at teardown"}\n'
+            '[GS-LIFETIME] {"scenario":"failed_init","passed":true,"rd_bytes_leaked":0,'
+            '"stringname_orphan_delta":-1,"fail_reason":""}\n'
+            '[GS-LIFETIME] {"scenario":"scene_director_reload","passed":true,"rd_bytes_leaked":0,'
+            '"stringname_orphan_delta":-1,"fail_reason":""}\n'
+            '[GS-LIFETIME] {"scenario":"asset_attach_detach","passed":true,"rd_bytes_leaked":0,'
+            '"stringname_orphan_delta":-1,"fail_reason":""}\n'
+            '[GS-LIFETIME] {"scenario":"stringname_orphans","passed":true,'
+            '"stringname_orphan_delta":0,"fail_reason":""}\n'
+        )
+        passed, reasons = checker.validate_lifetime_accounting_proof(section, stdout)
+        self.assertFalse(passed)
+        self.assertTrue(
+            any(
+                "renderer_instance" in reason and "passed=false" in reason and "owned RD" in reason
+                for reason in reasons
+            )
+        )
+
+    def test_lifetime_accounting_proof_threshold_exceeded(self) -> None:
+        section = _lifetime_manifest_section()
+        stdout = _lifetime_stdout_all_pass().replace(
+            '"scenario":"asset_attach_detach","passed":true,"rd_bytes_leaked":32768',
+            '"scenario":"asset_attach_detach","passed":true,"rd_bytes_leaked":1048576',
+        )
+        passed, reasons = checker.validate_lifetime_accounting_proof(section, stdout)
+        self.assertFalse(passed)
+        self.assertTrue(
+            any(
+                "asset_attach_detach" in reason and "exceeds threshold" in reason
+                for reason in reasons
+            )
+        )
+
+    def test_lifetime_accounting_proof_advisory_sentinel(self) -> None:
+        section = _lifetime_manifest_section()
+        passed, reasons = checker.validate_lifetime_accounting_proof(section, _lifetime_stdout_all_pass())
+        self.assertTrue(passed, reasons)
+        # The renderer_instance scenario reports stringname_orphan_delta=-1; it
+        # must not be counted as an orphan-threshold violation.
+        self.assertFalse(any("stringname_orphan_delta" in reason for reason in reasons))
+
+    def test_lifetime_accounting_proof_advisory_real_value(self) -> None:
+        section = _lifetime_manifest_section()
+        stdout = _lifetime_stdout_all_pass().replace(
+            '"scenario":"stringname_orphans","passed":true,'
+            '"stringname_orphan_delta":0,"threshold_orphans":5',
+            '"scenario":"stringname_orphans","passed":true,'
+            '"stringname_orphan_delta":99,"threshold_orphans":5',
+        )
+        passed, reasons = checker.validate_lifetime_accounting_proof(section, stdout)
+        self.assertFalse(passed)
+        self.assertTrue(
+            any(
+                "stringname_orphans" in reason
+                and "stringname_orphan_delta=99" in reason
+                and "exceeds threshold 5" in reason
+                for reason in reasons
+            )
+        )
+
+    def test_lifetime_accounting_proof_manifest_schema_valid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            failures = checker.validate_contract(root, manifest)
+            self.assertEqual(
+                [],
+                [failure for failure in failures if "lifetime_accounting_proof" in failure],
+            )
+
+    def test_lifetime_accounting_proof_manifest_schema_missing_required_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            manifest["lifetime_accounting_proof"].pop("required_scenarios")
+            failures = checker.validate_contract(root, manifest)
+            self.assertTrue(
+                any(
+                    "lifetime_accounting_proof.required_scenarios" in failure
+                    for failure in failures
+                )
+            )
+
+    def test_lifetime_accounting_proof_reads_from_file_path(self) -> None:
+        section = _lifetime_manifest_section()
+        with tempfile.TemporaryDirectory() as tmp:
+            stdout_path = Path(tmp) / "lifetime.log"
+            stdout_path.write_text(_lifetime_stdout_all_pass() + "\n", encoding="utf-8")
+            passed, reasons = checker.validate_lifetime_accounting_proof(section, stdout_path)
+            self.assertTrue(passed, reasons)
+
+    def test_lifetime_accounting_proof_rejects_invalid_json_payload(self) -> None:
+        section = _lifetime_manifest_section()
+        stdout = _lifetime_stdout_all_pass() + "\n[GS-LIFETIME] {not valid json"
+        passed, reasons = checker.validate_lifetime_accounting_proof(section, stdout)
+        self.assertFalse(passed)
+        self.assertTrue(any("is not valid JSON" in reason for reason in reasons))
+
+    def test_lifetime_accounting_proof_missing_manifest_section(self) -> None:
+        manifest = {"schema_version": 1}
+        failures = checker._validate_lifetime_accounting_proof_schema(manifest)
+        self.assertTrue(any("lifetime_accounting_proof section is missing" in failure for failure in failures))
 
 
 if __name__ == "__main__":

--- a/tests/ci/test_renderer_release_gates.py
+++ b/tests/ci/test_renderer_release_gates.py
@@ -1937,6 +1937,124 @@ class LifetimeAccountingProofTests(unittest.TestCase):
                 f"expected error to name the missing bound scenario, got: {output!r}",
             )
 
+    def test_schema_rejects_duplicate_required_scenarios(self) -> None:
+        """Codex P2 review on PR #390 (comment #3295128412).
+
+        The element-type loop in _validate_lifetime_accounting_proof_schema
+        only checked that each required_scenarios entry was a non-empty
+        string, so a typo replacing "failed_init" with a second
+        "renderer_instance" was accepted silently. The runtime then walked
+        scenarios via membership in required_scenarios, matched the
+        duplicated entry twice while never requiring failed_init to appear
+        in stdout, and validate_lifetime_accounting_proof returned success
+        for an stdout artifact that never reported the dropped scenario --
+        disabling coverage for failed_init while every other gate still
+        returned success.
+
+        Schema must reject duplicates at contract time and the failure
+        message must name the duplicate so the operator can locate the
+        typo immediately.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            section = manifest["lifetime_accounting_proof"]
+            # The bot's exploit recipe: replace failed_init with a second
+            # copy of renderer_instance, leaving every other invariant
+            # intact (strict map + thresholds + advisory fields).
+            self.assertIn("renderer_instance", section["required_scenarios"])
+            self.assertIn("failed_init", section["required_scenarios"])
+            section["required_scenarios"] = [
+                "renderer_instance" if name == "failed_init" else name
+                for name in section["required_scenarios"]
+            ]
+            failures = checker._validate_lifetime_accounting_proof_schema(manifest)
+            self.assertTrue(
+                any(
+                    "required_scenarios" in failure
+                    and "duplicate" in failure
+                    and "renderer_instance" in failure
+                    for failure in failures
+                ),
+                f"expected duplicate-required-scenarios to be rejected with the duplicate "
+                f"value named, got: {failures!r}",
+            )
+
+    def test_lifetime_mode_rejects_duplicate_required_scenarios(self) -> None:
+        """Round-4 wired the schema check into --mode lifetime so standalone
+        lifetime runs cannot bypass invariants. The duplicate-rejection
+        invariant added for Codex comment #3295128412 must therefore also
+        fail lifetime mode, with exit_code != 0 before
+        validate_lifetime_accounting_proof is invoked.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path = root / "docs" / "reference" / "renderer_release_gate_manifest.json"
+            manifest_path.parent.mkdir(parents=True, exist_ok=True)
+            section = _lifetime_manifest_section()
+            # Same exploit as the schema test: drop failed_init by
+            # duplicating renderer_instance. Pre-fix, the lifetime gate
+            # would accept this because the runtime never required
+            # failed_init to appear in the stdout artifact.
+            section["required_scenarios"] = [
+                "renderer_instance" if name == "failed_init" else name
+                for name in section["required_scenarios"]
+            ]
+            manifest = {"lifetime_accounting_proof": section}
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+            stdout_path = root / "lifetime.log"
+            # Mirror the manifest: drop failed_init from stdout too.
+            # Without the new invariant, the gate would silently pass.
+            stdout_lines = [
+                line for line in _lifetime_stdout_all_pass().splitlines()
+                if "failed_init" not in line
+            ]
+            stdout_path.write_text("\n".join(stdout_lines) + "\n", encoding="utf-8")
+
+            from contextlib import redirect_stdout
+            import io
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                exit_code = checker.main(
+                    [
+                        "--mode",
+                        "lifetime",
+                        "--manifest",
+                        str(manifest_path),
+                        "--lifetime-stdout",
+                        str(stdout_path),
+                    ]
+                )
+            output = buf.getvalue()
+            self.assertNotEqual(
+                exit_code,
+                0,
+                f"--mode lifetime must reject a manifest whose required_scenarios "
+                f"contains duplicates; got exit_code={exit_code} output={output!r}",
+            )
+            self.assertIn(
+                "lifetime schema check failed",
+                output,
+                f"expected schema-failure header in lifetime mode output, got: {output!r}",
+            )
+            self.assertIn(
+                "required_scenarios",
+                output,
+                f"expected error to name the required_scenarios field, got: {output!r}",
+            )
+            self.assertIn(
+                "duplicate",
+                output,
+                f"expected error to mention duplicates, got: {output!r}",
+            )
+            self.assertIn(
+                "renderer_instance",
+                output,
+                f"expected error to name the duplicated value, got: {output!r}",
+            )
+
     def test_schema_requires_bytes_threshold_for_metric_scenario(self) -> None:
         """Codex P2 review on PR #390 (schema side, byte thresholds).
 

--- a/tests/ci/test_renderer_release_gates.py
+++ b/tests/ci/test_renderer_release_gates.py
@@ -1527,6 +1527,99 @@ class LifetimeAccountingProofTests(unittest.TestCase):
                 f"expected non-object to be rejected, got: {failures!r}",
             )
 
+    def test_lifetime_accounting_proof_strict_binding_required_when_advisory_listed(self) -> None:
+        """Cross-field schema invariant (Codex P2 review on PR #390).
+
+        When advisory_fields lists stringname_orphan_delta and
+        thresholds_counts declares stringname_orphans_max, the schema MUST
+        require advisory_fields_strict_for to map
+        stringname_orphans -> [stringname_orphan_delta]. Otherwise the
+        manifest can silently drop the field from the entry at runtime and
+        the orphan-count threshold is never enforced (the runtime fix in
+        commit c3ec582e14 only catches it when the map is actually present).
+
+        Covers both failure modes:
+          (a) advisory_fields_strict_for missing entirely.
+          (b) advisory_fields_strict_for exists but does not list
+              stringname_orphans -> [stringname_orphan_delta].
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+
+            # (a) advisory_fields_strict_for missing entirely.
+            manifest = _base_manifest(root)
+            section = manifest["lifetime_accounting_proof"]
+            self.assertIn(
+                "stringname_orphan_delta",
+                section["advisory_fields"],
+                "test precondition: base manifest lists the advisory field",
+            )
+            self.assertIn(
+                "stringname_orphans_max",
+                section["thresholds_counts"],
+                "test precondition: base manifest declares the count threshold",
+            )
+            del section["advisory_fields_strict_for"]
+            failures = checker._validate_lifetime_accounting_proof_schema(manifest)
+            self.assertTrue(
+                any(
+                    "advisory_fields_strict_for" in failure
+                    and "stringname_orphan_delta" in failure
+                    and "stringname_orphans" in failure
+                    and "silently disablable" in failure
+                    for failure in failures
+                ),
+                f"expected missing strict map to be rejected, got: {failures!r}",
+            )
+
+            # (b) advisory_fields_strict_for exists but does not list
+            # stringname_orphans -> [stringname_orphan_delta]. Use a different
+            # (placeholder) scenario so the map is structurally valid.
+            manifest = _base_manifest(root)
+            section = manifest["lifetime_accounting_proof"]
+            section["advisory_fields_strict_for"] = {
+                "renderer_instance": ["stringname_orphan_delta"],
+            }
+            failures = checker._validate_lifetime_accounting_proof_schema(manifest)
+            self.assertTrue(
+                any(
+                    "advisory_fields_strict_for" in failure
+                    and "stringname_orphan_delta" in failure
+                    and "stringname_orphans" in failure
+                    and "silently disablable" in failure
+                    for failure in failures
+                ),
+                f"expected wrong-scenario strict map to be rejected, got: {failures!r}",
+            )
+
+            # (b') strict map lists the right scenario but the wrong field.
+            manifest = _base_manifest(root)
+            section = manifest["lifetime_accounting_proof"]
+            section["advisory_fields_strict_for"] = {
+                "stringname_orphans": ["some_other_advisory_field"],
+            }
+            failures = checker._validate_lifetime_accounting_proof_schema(manifest)
+            self.assertTrue(
+                any(
+                    "advisory_fields_strict_for" in failure
+                    and "stringname_orphan_delta" in failure
+                    and "stringname_orphans" in failure
+                    and "silently disablable" in failure
+                    for failure in failures
+                ),
+                f"expected wrong-field strict map to be rejected, got: {failures!r}",
+            )
+
+            # Positive control: the base manifest (which DOES bind the field
+            # correctly) must still pass cleanly.
+            manifest = _base_manifest(root)
+            failures = checker._validate_lifetime_accounting_proof_schema(manifest)
+            self.assertEqual(
+                failures,
+                [],
+                f"base manifest must satisfy the new cross-field invariant, got: {failures!r}",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ci/test_renderer_release_gates.py
+++ b/tests/ci/test_renderer_release_gates.py
@@ -1817,6 +1817,126 @@ class LifetimeAccountingProofTests(unittest.TestCase):
                 f"expected error to name the bound advisory field, got: {output!r}",
             )
 
+    def test_schema_requires_strict_scenario_in_required_scenarios(self) -> None:
+        """Codex P2 review on PR #390 (round 6, comment #3295080072).
+
+        Rounds 3, 4, and 5 added schema invariants for the strict map and
+        the count threshold, but none of them required the bound scenario
+        itself to appear in required_scenarios. Removing
+        stringname_orphans from required_scenarios silently disables
+        orphan-threshold enforcement even when advisory_fields_strict_for
+        still maps it and thresholds_counts still declares the bound
+        threshold: the runtime only walks scenarios that actually appear
+        in required_scenarios, so dropping it means the entry is never
+        required to exist and the count threshold is never compared.
+
+        Schema must reject at contract time, reusing the same
+        ADVISORY_FIELD_STRICT_BINDINGS source of truth as the round-3/4/5
+        invariants.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            section = manifest["lifetime_accounting_proof"]
+            # Preconditions: every other invariant is satisfied. The
+            # exploit is specifically removing the scenario from
+            # required_scenarios while keeping the rest intact.
+            self.assertIn("stringname_orphan_delta", section["advisory_fields"])
+            self.assertEqual(
+                section["advisory_fields_strict_for"].get("stringname_orphans"),
+                ["stringname_orphan_delta"],
+                "test precondition: strict map binds the field to the scenario",
+            )
+            self.assertIn("stringname_orphans_max", section["thresholds_counts"])
+            self.assertIn("stringname_orphans", section["required_scenarios"])
+            # Drop only the scenario from required_scenarios.
+            section["required_scenarios"] = [
+                name for name in section["required_scenarios"] if name != "stringname_orphans"
+            ]
+            failures = checker._validate_lifetime_accounting_proof_schema(manifest)
+            self.assertTrue(
+                any(
+                    "required_scenarios" in failure
+                    and "stringname_orphans" in failure
+                    and "stringname_orphan_delta" in failure
+                    and "bound scenario not required" in failure
+                    for failure in failures
+                ),
+                f"expected missing-scenario-despite-advisory to be rejected, got: {failures!r}",
+            )
+
+    def test_lifetime_mode_rejects_missing_strict_scenario_in_required_scenarios(self) -> None:
+        """Round-6 schema invariant must trip --mode lifetime too.
+
+        Round 4 wired schema checks into the lifetime entrypoint so
+        standalone lifetime runs cannot bypass invariants. The round-6
+        invariant must therefore also fail lifetime mode when the bound
+        scenario is missing from required_scenarios, with exit_code != 0
+        before validate_lifetime_accounting_proof is even invoked.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path = root / "docs" / "reference" / "renderer_release_gate_manifest.json"
+            manifest_path.parent.mkdir(parents=True, exist_ok=True)
+            section = _lifetime_manifest_section()
+            # Drop stringname_orphans from required_scenarios while keeping
+            # everything else intact (strict map + count threshold + advisory
+            # field listed). Pre-fix, this would slip past the lifetime
+            # gate because the runtime never walks the absent scenario.
+            section["required_scenarios"] = [
+                name for name in section["required_scenarios"] if name != "stringname_orphans"
+            ]
+            manifest = {"lifetime_accounting_proof": section}
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+            stdout_path = root / "lifetime.log"
+            # Use a stdout artifact that also omits the scenario, matching
+            # the manifest. Without the new invariant, the gate would
+            # silently pass.
+            stdout_lines = [
+                line for line in _lifetime_stdout_all_pass().splitlines() if "stringname_orphans" not in line
+            ]
+            stdout_path.write_text("\n".join(stdout_lines) + "\n", encoding="utf-8")
+
+            from contextlib import redirect_stdout
+            import io
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                exit_code = checker.main(
+                    [
+                        "--mode",
+                        "lifetime",
+                        "--manifest",
+                        str(manifest_path),
+                        "--lifetime-stdout",
+                        str(stdout_path),
+                    ]
+                )
+            output = buf.getvalue()
+            self.assertNotEqual(
+                exit_code,
+                0,
+                f"--mode lifetime must reject a manifest whose required_scenarios "
+                f"omits the bound strict scenario; got exit_code={exit_code} "
+                f"output={output!r}",
+            )
+            self.assertIn(
+                "lifetime schema check failed",
+                output,
+                f"expected schema-failure header in lifetime mode output, got: {output!r}",
+            )
+            self.assertIn(
+                "required_scenarios",
+                output,
+                f"expected error to name the missing scenarios field, got: {output!r}",
+            )
+            self.assertIn(
+                "stringname_orphans",
+                output,
+                f"expected error to name the missing bound scenario, got: {output!r}",
+            )
+
     def test_schema_requires_bytes_threshold_for_metric_scenario(self) -> None:
         """Codex P2 review on PR #390 (schema side, byte thresholds).
 

--- a/tests/ci/test_renderer_release_gates.py
+++ b/tests/ci/test_renderer_release_gates.py
@@ -1620,6 +1620,130 @@ class LifetimeAccountingProofTests(unittest.TestCase):
                 f"base manifest must satisfy the new cross-field invariant, got: {failures!r}",
             )
 
+    def test_lifetime_accounting_proof_rejects_duplicate_required_scenario(self) -> None:
+        """Codex P1 review on PR #390: required scenarios must appear EXACTLY
+        once. Two passing stringname_orphans entries -- as would result from
+        concatenated or stale logs from a previous run -- must trip the gate.
+
+        Without this check, an old successful run could contribute a
+        stringname_orphans line even when the current run omitted the
+        scenario, and required coverage would be silently satisfied.
+        """
+        section = _lifetime_manifest_section()
+        duplicate_line = (
+            '[GS-LIFETIME] {"scenario":"stringname_orphans","passed":true,'
+            '"stringname_orphan_delta":0,"threshold_orphans":5,"fail_reason":""}'
+        )
+        stdout = _lifetime_stdout_all_pass() + "\n" + duplicate_line
+        passed, reasons = checker.validate_lifetime_accounting_proof(section, stdout)
+        self.assertFalse(
+            passed,
+            "duplicate required-scenario entries must fail the gate",
+        )
+        self.assertTrue(
+            any(
+                "stringname_orphans" in reason
+                and "2 entries" in reason
+                and "exactly one" in reason
+                and ("duplicate" in reason or "stale" in reason)
+                for reason in reasons
+            ),
+            f"expected duplicate-scenario error citing the count, got: {reasons!r}",
+        )
+
+    def test_lifetime_accounting_proof_rejects_duplicate_with_mixed_pass_fail(self) -> None:
+        """Strictest interpretation of Codex P1: duplicates with any mix of
+        passed=true/false are rejected. The bot's concern is mixed-run
+        artifacts, so any duplicate is suspect even when one entry happens
+        to be failing.
+        """
+        section = _lifetime_manifest_section()
+        duplicate_failing_line = (
+            '[GS-LIFETIME] {"scenario":"stringname_orphans","passed":false,'
+            '"stringname_orphan_delta":0,"threshold_orphans":5,'
+            '"fail_reason":"stale log from previous run"}'
+        )
+        stdout = _lifetime_stdout_all_pass() + "\n" + duplicate_failing_line
+        passed, reasons = checker.validate_lifetime_accounting_proof(section, stdout)
+        self.assertFalse(passed)
+        self.assertTrue(
+            any(
+                "stringname_orphans" in reason
+                and "2 entries" in reason
+                and "exactly one" in reason
+                for reason in reasons
+            ),
+            f"expected duplicate-scenario error even with mixed passed flags, got: {reasons!r}",
+        )
+
+    def test_lifetime_accounting_proof_schema_requires_orphan_threshold_when_advisory_listed(self) -> None:
+        """Codex P2 review on PR #390 (schema side).
+
+        When advisory_fields lists stringname_orphan_delta, the schema MUST
+        require thresholds_counts to declare stringname_orphans_max.
+        Otherwise a manifest typo or accidental key removal silently
+        disables the orphan-count guard while still letting the runtime
+        accept arbitrarily large deltas (passed=true with no enforcement).
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            section = manifest["lifetime_accounting_proof"]
+            # Precondition: base manifest lists the advisory field.
+            self.assertIn("stringname_orphan_delta", section["advisory_fields"])
+            # Remove the orphan-count threshold from thresholds_counts.
+            section["thresholds_counts"] = {}
+            failures = checker._validate_lifetime_accounting_proof_schema(manifest)
+            self.assertTrue(
+                any(
+                    "thresholds_counts" in failure
+                    and "stringname_orphans_max" in failure
+                    and "stringname_orphan_delta" in failure
+                    and "silently disabled" in failure
+                    for failure in failures
+                ),
+                f"expected missing-threshold-despite-advisory to be rejected, got: {failures!r}",
+            )
+
+    def test_lifetime_accounting_proof_runtime_rejects_delta_without_threshold(self) -> None:
+        """Codex P2 review on PR #390 (runtime defense-in-depth side).
+
+        Even if someone edits the schema check out, the runtime must refuse
+        to silently skip orphan-delta enforcement when no threshold is
+        declared. An entry that reports a real (non-sentinel) delta with no
+        threshold in thresholds_counts must fail the lifetime gate instead
+        of passing because count_threshold is None.
+        """
+        section = _lifetime_manifest_section()
+        # Remove the threshold from the manifest section so the runtime
+        # lookup returns None even though stringname_orphan_delta is in
+        # the entry. The schema validator would normally reject this; we
+        # are testing the runtime fallback behaviour.
+        section["thresholds_counts"] = {}
+        # Use a real (non-sentinel) value so the sentinel-skip branch
+        # does not short-circuit the check.
+        stdout = _lifetime_stdout_all_pass().replace(
+            '"scenario":"stringname_orphans","passed":true,'
+            '"stringname_orphan_delta":0,"threshold_orphans":5',
+            '"scenario":"stringname_orphans","passed":true,'
+            '"stringname_orphan_delta":42,"threshold_orphans":5',
+        )
+        passed, reasons = checker.validate_lifetime_accounting_proof(section, stdout)
+        self.assertFalse(
+            passed,
+            "runtime must refuse to silently skip enforcement when threshold is missing",
+        )
+        self.assertTrue(
+            any(
+                "stringname_orphans" in reason
+                and "stringname_orphan_delta=42" in reason
+                and "stringname_orphans_max" in reason
+                and "not declared" in reason
+                for reason in reasons
+            ),
+            f"expected runtime defense-in-depth error citing the missing threshold, got: {reasons!r}",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ci/test_renderer_release_gates.py
+++ b/tests/ci/test_renderer_release_gates.py
@@ -1817,6 +1817,148 @@ class LifetimeAccountingProofTests(unittest.TestCase):
                 f"expected error to name the bound advisory field, got: {output!r}",
             )
 
+    def test_schema_requires_bytes_threshold_for_metric_scenario(self) -> None:
+        """Codex P2 review on PR #390 (schema side, byte thresholds).
+
+        The bot's exploit recipe: remove asset_attach_detach from
+        thresholds_bytes while still listing it in required_scenarios and
+        scenario_metric_fields, then feed a huge rd_bytes_leaked value --
+        validate_lifetime_accounting_proof returned success because the
+        runtime check at `if byte_threshold is not None` silently fell
+        through, disabling the byte-leak guard for that scenario.
+
+        The schema validator must reject such a manifest at contract time:
+        every required scenario that declares a metric field MUST also
+        declare a thresholds_bytes entry. Mirrors the orphan-count
+        threshold enforcement added in 54fab045a8 but for byte thresholds.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            section = manifest["lifetime_accounting_proof"]
+            # Precondition: base manifest binds asset_attach_detach to
+            # a metric field AND a byte threshold.
+            self.assertIn("asset_attach_detach", section["required_scenarios"])
+            self.assertIn("asset_attach_detach", section["scenario_metric_fields"])
+            self.assertIn("asset_attach_detach", section["thresholds_bytes"])
+            # The bot's exploit: drop the threshold while keeping the
+            # metric-field binding and required-scenario membership.
+            del section["thresholds_bytes"]["asset_attach_detach"]
+            failures = checker._validate_lifetime_accounting_proof_schema(manifest)
+            self.assertTrue(
+                any(
+                    "thresholds_bytes" in failure
+                    and "asset_attach_detach" in failure
+                    and "scenario_metric_fields" in failure
+                    and "byte threshold not declared" in failure
+                    for failure in failures
+                ),
+                f"expected missing-byte-threshold-despite-metric-field to be rejected, got: {failures!r}",
+            )
+
+    def test_lifetime_mode_rejects_metric_scenario_without_byte_threshold(self) -> None:
+        """Codex P2 review on PR #390 (schema side, byte thresholds) via the
+        --mode lifetime entrypoint added in f6932de597.
+
+        Same exploit as test_schema_requires_bytes_threshold_for_metric_scenario,
+        but routed through the lifetime-mode CLI. The schema-first guard
+        added in f6932de597 means standalone lifetime runs must satisfy the
+        same invariants -- removing a required byte threshold must fail
+        with exit_code != 0 before validate_lifetime_accounting_proof is
+        even invoked.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path = root / "docs" / "reference" / "renderer_release_gate_manifest.json"
+            manifest_path.parent.mkdir(parents=True, exist_ok=True)
+            section = _lifetime_manifest_section()
+            # Bot's exploit: drop asset_attach_detach from thresholds_bytes
+            # while keeping it in required_scenarios + scenario_metric_fields.
+            del section["thresholds_bytes"]["asset_attach_detach"]
+            manifest = {"lifetime_accounting_proof": section}
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+            # Use a huge leak value, matching the bot's verification recipe.
+            stdout_path = root / "lifetime.log"
+            stdout_text = _lifetime_stdout_all_pass().replace(
+                '"scenario":"asset_attach_detach","passed":true,"rd_bytes_leaked":32768',
+                '"scenario":"asset_attach_detach","passed":true,"rd_bytes_leaked":999999999',
+            )
+            stdout_path.write_text(stdout_text + "\n", encoding="utf-8")
+
+            from contextlib import redirect_stdout
+            import io
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                exit_code = checker.main(
+                    [
+                        "--mode",
+                        "lifetime",
+                        "--manifest",
+                        str(manifest_path),
+                        "--lifetime-stdout",
+                        str(stdout_path),
+                    ]
+                )
+            output = buf.getvalue()
+            self.assertNotEqual(
+                exit_code,
+                0,
+                f"--mode lifetime must reject a manifest missing a required byte "
+                f"threshold; got exit_code={exit_code} output={output!r}",
+            )
+            self.assertIn(
+                "lifetime schema check failed",
+                output,
+                f"expected schema-failure header in lifetime mode output, got: {output!r}",
+            )
+            self.assertIn(
+                "thresholds_bytes",
+                output,
+                f"expected error to name the missing threshold map, got: {output!r}",
+            )
+            self.assertIn(
+                "asset_attach_detach",
+                output,
+                f"expected error to name the offending scenario, got: {output!r}",
+            )
+
+    def test_runtime_rejects_real_bytes_without_threshold(self) -> None:
+        """Codex P2 review on PR #390 (runtime defense-in-depth, byte side).
+
+        Even if someone edits the schema check out, the runtime must refuse
+        to silently skip byte-threshold enforcement when no threshold is
+        declared but the entry reports a real numeric rd_bytes_leaked
+        value. Without this, the bot's exploit -- huge leak value with no
+        threshold -- passes the gate.
+        """
+        section = _lifetime_manifest_section()
+        # Bot's exploit: drop the threshold while keeping the metric-field
+        # binding so the scenario still attempts byte enforcement.
+        del section["thresholds_bytes"]["asset_attach_detach"]
+        # Feed a huge non-sentinel leak value -- the exact recipe the bot
+        # verified experimentally.
+        stdout = _lifetime_stdout_all_pass().replace(
+            '"scenario":"asset_attach_detach","passed":true,"rd_bytes_leaked":32768',
+            '"scenario":"asset_attach_detach","passed":true,"rd_bytes_leaked":999999999',
+        )
+        passed, reasons = checker.validate_lifetime_accounting_proof(section, stdout)
+        self.assertFalse(
+            passed,
+            "runtime must refuse to silently skip byte enforcement when threshold is missing",
+        )
+        self.assertTrue(
+            any(
+                "asset_attach_detach" in reason
+                and "rd_bytes_leaked=999999999" in reason
+                and "thresholds_bytes.asset_attach_detach" in reason
+                and "not declared" in reason
+                for reason in reasons
+            ),
+            f"expected runtime defense-in-depth error citing the missing byte threshold, got: {reasons!r}",
+        )
+
     def test_main_lifetime_mode_passes_on_valid_manifest(self) -> None:
         """Positive control for the new schema-first guard: a structurally
         valid manifest with a passing stdout artifact must still exit 0

--- a/tests/ci/test_renderer_release_gates.py
+++ b/tests/ci/test_renderer_release_gates.py
@@ -1744,6 +1744,117 @@ class LifetimeAccountingProofTests(unittest.TestCase):
             f"expected runtime defense-in-depth error citing the missing threshold, got: {reasons!r}",
         )
 
+    def test_main_lifetime_mode_validates_schema_before_runtime(self) -> None:
+        """Codex P2 review on PR #390 (comment #3294976919).
+
+        main()'s --mode lifetime branch must run schema validation BEFORE
+        calling validate_lifetime_accounting_proof, so a manifest missing
+        advisory_fields_strict_for cannot silently pass standalone lifetime
+        runs. Pre-fix, the runtime treated stringname_orphan_delta as
+        optional and returned passed=True for such manifests, disabling
+        the orphan-count guard while still exiting 0.
+
+        Strict interpretation: there is no opt-out flag -- any workflow
+        that invokes --mode lifetime must satisfy the same schema
+        invariants that --mode contract enforces.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # main() computes root = manifest_path.parents[2], so place
+            # the manifest two directories deep so the resolved root points
+            # at the tempdir. The lifetime path does not read other files
+            # from root, so the tempdir itself can stay empty.
+            manifest_path = root / "docs" / "reference" / "renderer_release_gate_manifest.json"
+            manifest_path.parent.mkdir(parents=True, exist_ok=True)
+            section = _lifetime_manifest_section()
+            # Drop advisory_fields_strict_for entirely while leaving
+            # advisory_fields listing stringname_orphan_delta. Pre-fix,
+            # the schema check did not run in lifetime mode and the
+            # runtime accepted the manifest because the missing strict
+            # map silently disabled the bound enforcement.
+            section.pop("advisory_fields_strict_for", None)
+            manifest = {"lifetime_accounting_proof": section}
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+            stdout_path = root / "lifetime.log"
+            stdout_path.write_text(_lifetime_stdout_all_pass() + "\n", encoding="utf-8")
+
+            from contextlib import redirect_stdout
+            import io
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                exit_code = checker.main(
+                    [
+                        "--mode",
+                        "lifetime",
+                        "--manifest",
+                        str(manifest_path),
+                        "--lifetime-stdout",
+                        str(stdout_path),
+                    ]
+                )
+            output = buf.getvalue()
+            self.assertNotEqual(
+                exit_code,
+                0,
+                f"lifetime mode must reject a manifest missing advisory_fields_strict_for; "
+                f"got exit_code={exit_code} output={output!r}",
+            )
+            self.assertIn(
+                "lifetime schema check failed",
+                output,
+                f"expected schema-failure header in lifetime mode output, got: {output!r}",
+            )
+            self.assertIn(
+                "advisory_fields_strict_for",
+                output,
+                f"expected error to name the missing schema field, got: {output!r}",
+            )
+            self.assertIn(
+                "stringname_orphan_delta",
+                output,
+                f"expected error to name the bound advisory field, got: {output!r}",
+            )
+
+    def test_main_lifetime_mode_passes_on_valid_manifest(self) -> None:
+        """Positive control for the new schema-first guard: a structurally
+        valid manifest with a passing stdout artifact must still exit 0
+        under --mode lifetime. Without this control, a regression that
+        accidentally rejects all manifests would go undetected.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path = root / "docs" / "reference" / "renderer_release_gate_manifest.json"
+            manifest_path.parent.mkdir(parents=True, exist_ok=True)
+            manifest = {"lifetime_accounting_proof": _lifetime_manifest_section()}
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+            stdout_path = root / "lifetime.log"
+            stdout_path.write_text(_lifetime_stdout_all_pass() + "\n", encoding="utf-8")
+
+            from contextlib import redirect_stdout
+            import io
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                exit_code = checker.main(
+                    [
+                        "--mode",
+                        "lifetime",
+                        "--manifest",
+                        str(manifest_path),
+                        "--lifetime-stdout",
+                        str(stdout_path),
+                    ]
+                )
+            self.assertEqual(
+                exit_code,
+                0,
+                f"valid lifetime manifest must still pass; got exit_code={exit_code} "
+                f"output={buf.getvalue()!r}",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ci/test_renderer_release_gates.py
+++ b/tests/ci/test_renderer_release_gates.py
@@ -224,6 +224,9 @@ def _base_manifest(root: Path) -> dict[str, Any]:
             "gpu_harness_batch": "Lifetime",
             "advisory_fields": ["stringname_orphan_delta"],
             "advisory_sentinel_value": -1,
+            "advisory_fields_strict_for": {
+                "stringname_orphans": ["stringname_orphan_delta"],
+            },
             "source_prs": [386, 389],
             "owner_issue": 352,
         },
@@ -1307,6 +1310,9 @@ def _lifetime_manifest_section() -> dict[str, Any]:
         "thresholds_counts": {"stringname_orphans_max": 5},
         "advisory_fields": ["stringname_orphan_delta"],
         "advisory_sentinel_value": -1,
+        "advisory_fields_strict_for": {
+            "stringname_orphans": ["stringname_orphan_delta"],
+        },
     }
 
 
@@ -1391,6 +1397,64 @@ class LifetimeAccountingProofTests(unittest.TestCase):
             )
         )
 
+    def test_lifetime_accounting_proof_missing_required_advisory_field(self) -> None:
+        """A strict-required advisory field MUST be present in its scenario.
+
+        Regression guard for PR #390 review: when stringname_orphans drops the
+        stringname_orphan_delta field entirely, the validator previously
+        passed silently and the count threshold was never enforced.
+        """
+        section = _lifetime_manifest_section()
+        # Replace the stringname_orphans line with one that drops the
+        # advisory field entirely (mirrors the bot-supplied bad-stdout).
+        stdout = _lifetime_stdout_all_pass().replace(
+            '[GS-LIFETIME] {"scenario":"stringname_orphans","passed":true,'
+            '"stringname_orphan_delta":0,"threshold_orphans":5,"fail_reason":""}',
+            '[GS-LIFETIME] {"scenario":"stringname_orphans","passed":true,"fail_reason":""}',
+        )
+        passed, reasons = checker.validate_lifetime_accounting_proof(section, stdout)
+        self.assertFalse(passed, "missing strict-required advisory field must fail the gate")
+        self.assertTrue(
+            any(
+                "stringname_orphans" in reason
+                and "stringname_orphan_delta" in reason
+                and "required advisory field" in reason
+                for reason in reasons
+            ),
+            f"expected a clear missing-required-advisory failure, got: {reasons!r}",
+        )
+
+    def test_lifetime_accounting_proof_sentinel_in_non_strict_scenario_still_passes(self) -> None:
+        """The renderer_instance scenario reports stringname_orphan_delta=-1
+        as the sentinel ("not measured this run"). It is NOT listed in
+        advisory_fields_strict_for, so the sentinel must continue to pass
+        without regressing the existing tolerated-sentinel contract.
+        """
+        section = _lifetime_manifest_section()
+        passed, reasons = checker.validate_lifetime_accounting_proof(section, _lifetime_stdout_all_pass())
+        self.assertTrue(passed, reasons)
+        self.assertFalse(
+            any("renderer_instance" in reason and "stringname_orphan_delta" in reason for reason in reasons),
+            f"sentinel in non-strict scenario must not trip the gate, got: {reasons!r}",
+        )
+
+    def test_lifetime_accounting_proof_strict_scenario_tolerates_sentinel(self) -> None:
+        """For a strict-required scenario, the field MUST be present, but the
+        sentinel value (-1, "not measured this run") is still tolerated as
+        long as the field itself is reported. This preserves the ability of
+        the lifetime fixture to emit the field even when the orphan probe is
+        skipped, while closing the silent-skip hole.
+        """
+        section = _lifetime_manifest_section()
+        stdout = _lifetime_stdout_all_pass().replace(
+            '[GS-LIFETIME] {"scenario":"stringname_orphans","passed":true,'
+            '"stringname_orphan_delta":0,"threshold_orphans":5,"fail_reason":""}',
+            '[GS-LIFETIME] {"scenario":"stringname_orphans","passed":true,'
+            '"stringname_orphan_delta":-1,"threshold_orphans":5,"fail_reason":""}',
+        )
+        passed, reasons = checker.validate_lifetime_accounting_proof(section, stdout)
+        self.assertTrue(passed, reasons)
+
     def test_lifetime_accounting_proof_manifest_schema_valid(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -1433,6 +1497,35 @@ class LifetimeAccountingProofTests(unittest.TestCase):
         manifest = {"schema_version": 1}
         failures = checker._validate_lifetime_accounting_proof_schema(manifest)
         self.assertTrue(any("lifetime_accounting_proof section is missing" in failure for failure in failures))
+
+    def test_lifetime_accounting_proof_advisory_fields_strict_for_schema(self) -> None:
+        """Schema validation must reject malformed advisory_fields_strict_for."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = _base_manifest(root)
+            # Map value must be a non-empty list of strings.
+            manifest["lifetime_accounting_proof"]["advisory_fields_strict_for"] = {
+                "stringname_orphans": [],
+            }
+            failures = checker._validate_lifetime_accounting_proof_schema(manifest)
+            self.assertTrue(
+                any(
+                    "advisory_fields_strict_for" in failure
+                    and "stringname_orphans" in failure
+                    and "non-empty list" in failure
+                    for failure in failures
+                ),
+                f"expected empty-list to be rejected, got: {failures!r}",
+            )
+            manifest["lifetime_accounting_proof"]["advisory_fields_strict_for"] = "not-an-object"
+            failures = checker._validate_lifetime_accounting_proof_schema(manifest)
+            self.assertTrue(
+                any(
+                    "advisory_fields_strict_for must be a JSON object" in failure
+                    for failure in failures
+                ),
+                f"expected non-object to be rejected, got: {failures!r}",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Context

**PR 7 of work package #352** (Renderer Lifetime Proof). Adds the gate-side consumer for the `[GS-LIFETIME]` JSON lines emitted by #386 (renderer lifetime-proof fixture) and #389 (orphan-`StringName` CI guard). This PR is independent of the stacked Wave 2/3 PRs and can land first; until #386 and #389 merge, the end-to-end `--mode lifetime` check will simply find no `[GS-LIFETIME]` lines and the schema-only `--mode contract` validation runs against the new manifest section.

## What was already done by #374

- `tests/ci/run_module_tests.py` line 544 defines `_run_renderer_release_gate_guard()`, which calls `check_renderer_release_gates.py --mode contract` and `test_renderer_release_gates.py`.
- That guard is already in the `_run_ci_guard_steps` tuple at line 903.
- `--guard-only` / `--guards-only` argparse already exists.
- `check_renderer_release_gates.py` already exposes `--mode contract` and `--mode candidate`.

So this PR only adds the missing criterion + parser; the wiring is already in place.

## What this PR adds

1. **`lifetime_accounting_proof` section** in `docs/reference/renderer_release_gate_manifest.json`:

   ```json
   "lifetime_accounting_proof": {
     "stdout_marker": "[GS-LIFETIME] ",
     "required_scenarios": [
       "renderer_instance",
       "failed_init",
       "scene_director_reload",
       "asset_attach_detach",
       "stringname_orphans"
     ],
     "scenario_metric_fields": {
       "renderer_instance": "rd_bytes_leaked",
       "failed_init": "rd_bytes_leaked",
       "scene_director_reload": "rd_bytes_leaked",
       "asset_attach_detach": "rd_bytes_leaked"
     },
     "thresholds_bytes": {
       "renderer_instance": 4194304,
       "failed_init": 4194304,
       "scene_director_reload": 262144,
       "asset_attach_detach": 65536
     },
     "thresholds_counts": { "stringname_orphans_max": 5 },
     "test_binary_lane": "GaussianSplatting [Lifetime]",
     "gpu_harness_batch": "Lifetime",
     "advisory_fields": ["stringname_orphan_delta"],
     "advisory_sentinel_value": -1,
     "source_prs": [386, 389],
     "owner_issue": 352
   }
   ```

2. **`validate_lifetime_accounting_proof(section, stdout)`** + **`_validate_lifetime_accounting_proof_schema(manifest)`** + **`--mode lifetime`** CLI in `tests/ci/check_renderer_release_gates.py`. The schema validator is wired into `validate_contract`, so `--guard-only` runs now automatically check the new manifest section for correctness without needing a `[GS-LIFETIME]` log.

3. **11 new test cases** in `tests/ci/test_renderer_release_gates.py` covering all-pass, missing scenario, scenario failed, byte-threshold exceeded, advisory sentinel tolerated, advisory real-value exceeded, manifest-schema-valid, manifest-schema-missing-required-field, file-path input mode, invalid JSON payload, and missing-section detection.

4. **Documentation** in `docs/reference/renderer-release-gates.md`: new "Lifetime Accounting Proof" section describing scenarios, thresholds, the advisory-sentinel behavior, example stdout line, how to run both modes, and how to extend with new scenarios.

## Manifest schema choice

Kept `schema_version=1`. The pre-existing validator iterated over known top-level keys without rejecting unknown ones, so adding `lifetime_accounting_proof` as a new top-level key is backward-compatible with old consumers. The new `_validate_lifetime_accounting_proof_schema` is appended to `validate_contract`, making the section a hard requirement going forward (a manifest missing the section fails the contract check). No bump needed because the change is additive at the field level under a single policy revision.

## Contract-mode tolerance

`--mode contract` tolerated the new section as expected, then the appended schema validator started enforcing the section's shape. The pre-existing `_base_manifest()` helper in `test_renderer_release_gates.py` was updated to include the section so the existing 65 tests still pass (they would otherwise hit the new "section is missing" failure).

## Verification

```text
CONTRACT_EXIT=0   Renderer release gate contract check passed
TEST_EXIT=0       Ran 76 tests in 7.825s -- OK
GUARD_EXIT=0      Renderer guard checks passed.
LIFETIME_MODE_EXIT=0  Renderer release gate lifetime check passed
```

A sanity-check run with a deliberately bad stdout (one scenario, passed=false, rd_bytes_leaked far above threshold) reported the right failures and exited 1:

```text
- lifetime scenario missing from stdout: failed_init
- lifetime scenario missing from stdout: scene_director_reload
- lifetime scenario missing from stdout: asset_attach_detach
- lifetime scenario missing from stdout: stringname_orphans
- lifetime scenario renderer_instance reported passed=false: intentional
- lifetime scenario renderer_instance rd_bytes_leaked=99999999 exceeds threshold 4194304
```

## What comes next

PR 8 will add (a) the `GaussianSplatting [Lifetime]` strict lane to `MODULE_TEST_FILTERS` in `run_module_tests.py` so scenario B exercises in the standalone `--test` mode, and (b) a `Lifetime` batch in `run_gpu_harness.py` so scenarios A/C/D exercise on the GPU. With #386, #389, #387, this PR, and PR 8 all merged, `run_module_tests.py --guard-only` will fail-fast on any renderer-lifetime regression.

## Out of scope

- No changes to `run_module_tests.py` (PR 8 owns the strict lane addition).
- No changes to `run_gpu_harness.py` (PR 8 owns the Lifetime batch).
- No `[GS-LIFETIME]` emitter changes (PRs #386 and #389 own the producers).
- `--mode candidate` was not extended to require a lifetime-stdout artifact yet; that follow-up can land after PR 8 plumbs the artifact path into the candidate evidence bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)