### PR TITLE
gaussian_splatting: fix Linux ENAMETOOLONG in _coerce_lifetime_stdout_lines (master CI hotfix)

### DIFF
--- a/tests/ci/check_renderer_release_gates.py
+++ b/tests/ci/check_renderer_release_gates.py
@@ -1494,13 +1494,30 @@ def _coerce_lifetime_stdout_lines(stdout_artifact_or_path: Any) -> list[str]:
         except OSError as exc:
             raise RuntimeError(f"lifetime stdout artifact unreadable: {stdout_artifact_or_path} ({exc})") from exc
     if isinstance(stdout_artifact_or_path, str):
-        candidate = Path(stdout_artifact_or_path)
-        # If it points at an existing file, treat as a path; otherwise treat as raw content.
-        if candidate.exists() and candidate.is_file():
+        # A file path cannot contain newlines and cannot have a component
+        # longer than NAME_MAX (255 on Linux); strings that violate either
+        # are definitely raw content. Skip the path probe in those cases so
+        # we don't trip OSError [Errno 36] ENAMETOOLONG on Linux, which is
+        # what Path.exists() does when the argument is too long to stat
+        # (Windows tolerates this silently, masking the bug locally).
+        looks_like_path = (
+            "\n" not in stdout_artifact_or_path
+            and all(len(part) <= 255 for part in stdout_artifact_or_path.split("/"))
+            and all(len(part) <= 255 for part in stdout_artifact_or_path.split("\\"))
+        )
+        if looks_like_path:
             try:
-                return candidate.read_text(encoding="utf-8", errors="ignore").splitlines()
-            except OSError as exc:
-                raise RuntimeError(f"lifetime stdout artifact unreadable: {candidate} ({exc})") from exc
+                candidate = Path(stdout_artifact_or_path)
+                if candidate.exists() and candidate.is_file():
+                    try:
+                        return candidate.read_text(encoding="utf-8", errors="ignore").splitlines()
+                    except OSError as exc:
+                        raise RuntimeError(f"lifetime stdout artifact unreadable: {candidate} ({exc})") from exc
+            except OSError:
+                # Defensive: any other path-probe error (permissions,
+                # weird filesystem state) — treat as content rather than
+                # surfacing a confusing path-related error for raw stdout.
+                pass
         return stdout_artifact_or_path.splitlines()
     raise RuntimeError(f"lifetime stdout artifact has unsupported type: {type(stdout_artifact_or_path).__name__}")
 


### PR DESCRIPTION
## Summary

Hotfix for master CI Linux failure that surfaced immediately after #386 landed (run [26384204113](https://github.com/klausi3D/godotGS/actions/runs/26384204113)).

\`_coerce_lifetime_stdout_lines\` in \`check_renderer_release_gates.py\` accepted either a \`Path\` or raw stdout string and disambiguated by calling \`Path(arg).exists()\`. Multi-line stdout strings (which several unit tests pass directly) exceed Linux's \`NAME_MAX\` (255), and \`Path.exists()\` → \`os.stat()\` raises \`OSError [Errno 36] File name too long\`. **Windows tolerates the long argument silently** and returns False, which is exactly why local dev on Windows + every PR's CI green on the Windows-only GPU lane missed this — only the Linux CPU lane on master surfaced it.

## Fix

Skip the path probe when the string:
- contains a newline, or
- has any \`/\`/\`\\`-separated component longer than 255 chars

In those cases treat as raw content directly. Defensive \`try/except OSError\` around the path probe catches anything else weird (permissions etc).

## Verification

- \`python tests/ci/test_renderer_release_gates.py\` → 94/94 pass
- Specifically \`test_lifetime_accounting_proof_advisory_real_value\` (the failing case in CI) passes
- \`python tests/ci/check_renderer_release_gates.py --mode contract\` → exit 0

## Test plan

- [ ] CI runs on this branch (especially the Linux CPU lane)
- [ ] Merge unblocks master CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)