### PR TITLE
gaussian_splatting: REQUIRE_WORKER_THREAD_POOL guard for lifetime scenarios A/D (fixes #392)

### DIFF
--- a/modules/gaussian_splatting/tests/test_macros.h
+++ b/modules/gaussian_splatting/tests/test_macros.h
@@ -10,6 +10,7 @@
 #include "tests/test_macros.h"
 
 // Additional test utilities specific to Gaussian Splatting
+#include "core/object/worker_thread_pool.h"
 #include "core/os/os.h"
 #include "servers/rendering_server.h"
 #include "servers/rendering/rendering_device.h"
@@ -139,6 +140,37 @@ public:
             MESSAGE("Skipping test - streaming unavailable");                \
             return;                                                          \
         }                                                                    \
+    } while (0)
+
+// Issue #392: helper for tests that exercise renderer/manager paths which
+// transitively dispatch work through WorkerThreadPool (e.g. the Lifetime
+// scenarios A/D in test_renderer_lifetime_proof.h, which call into
+// GaussianSplatManager::register_gaussian_buffer /
+// _request_primary_local_device). The `--gs-gpu-test` runner
+// (gs_gpu_test_runner.cpp) provisions a RenderingDevice via Main::test_setup()
+// but does NOT call WorkerThreadPool::get_singleton()->init(), so the pool's
+// `TightLocalVector<ThreadData> threads` is empty (size 0). Any code path that
+// indexes that vector (`threads[i]`) by a thread index derived from
+// thread-local state therefore OOBs the LocalVector — STATUS_STACK_BUFFER_OVERRUN
+// (#392 scenarios A/D crash signature).
+//
+// The probe is `get_singleton()` non-null AND `get_thread_count() > 0`. The
+// singleton itself is created by register_core_types() (which test_setup()
+// calls) so the null check is a belt-and-braces guard — the load-bearing
+// gate is the thread-count check. In a normally bootstrapped runner
+// (tests/test_main.cpp:242 calls `init()`) this passes cleanly; in the
+// `--gs-gpu-test` runner it skips with a clear reason instead of crashing.
+//
+// Use this AFTER REQUIRE_GPU_DEVICE() in scenarios that need both a device
+// and a usable pool: device first (so headless lanes skip first with the
+// existing "RenderingDevice unavailable" reason), pool second.
+#define REQUIRE_WORKER_THREAD_POOL()                                          \
+    do {                                                                      \
+        WorkerThreadPool *_gs_wtp_probe = WorkerThreadPool::get_singleton();  \
+        if (_gs_wtp_probe == nullptr || _gs_wtp_probe->get_thread_count() <= 0) { \
+            MESSAGE("Skipping test - worker thread pool unavailable");        \
+            return;                                                           \
+        }                                                                     \
     } while (0)
 
 // Performance baseline checking

--- a/modules/gaussian_splatting/tests/test_renderer_lifetime_proof.h
+++ b/modules/gaussian_splatting/tests/test_renderer_lifetime_proof.h
@@ -539,6 +539,17 @@ TEST_CASE("[GaussianSplatting][Renderer][Lifetime][RequiresGPU] renderer_instanc
 	REQUIRE_GPU_DEVICE();
 	// `rd` is published by the macro above; reuse it as the
 	// authoritative device the renderer was constructed against.
+	// Issue #392: renderer.instantiate(rd) -> GaussianSplatRenderer ctor
+	// transitively calls into GaussianSplatManager::register_gaussian_buffer
+	// / _request_primary_local_device, both of which index into
+	// WorkerThreadPool::ThreadData via a derived thread index. The
+	// `--gs-gpu-test` runner provisions an RD but not the pool (see
+	// gs_gpu_test_runner.cpp's Main::test_setup() invocation, which does
+	// not call WorkerThreadPool::get_singleton()->init() the way
+	// tests/test_main.cpp:242 does), so the pool's threads LocalVector is
+	// empty (size 0) and the indexed access OOBs → STATUS_STACK_BUFFER_OVERRUN.
+	// Skip cleanly here if the pool isn't usable instead of crashing.
+	REQUIRE_WORKER_THREAD_POOL();
 
 	RendererLifetimeFixture fixture("renderer_instance", rd);
 	fixture.capture_baseline();
@@ -812,6 +823,13 @@ TEST_CASE("[GaussianSplatting][Renderer][Lifetime][RequiresGPU] scene_director_r
 // ---------------------------------------------------------------------------
 TEST_CASE("[GaussianSplatting][Renderer][Lifetime][RequiresGPU] asset_attach_detach lifetime proof") {
 	REQUIRE_GPU_DEVICE();
+	// Issue #392: same WorkerThreadPool dependency as scenario A
+	// (renderer.instantiate(rd) inside the cycle loop transitively indexes
+	// the empty ThreadData LocalVector). Skip cleanly when the pool isn't
+	// usable instead of crashing with STATUS_STACK_BUFFER_OVERRUN under
+	// `--gs-gpu-test`. See REQUIRE_WORKER_THREAD_POOL() comment in
+	// test_macros.h for the full rationale.
+	REQUIRE_WORKER_THREAD_POOL();
 
 	RendererLifetimeFixture fixture("asset_attach_detach", rd);
 	// Monotonicity threshold for the asset cycle delta-of-deltas. Configured


### PR DESCRIPTION
## Summary
Closes #392.

Adds `REQUIRE_WORKER_THREAD_POOL()` guard to scenarios A/D in `test_renderer_lifetime_proof.h`. The harness's `--gs-gpu-test` runner provisions a `RenderingDevice` without `WorkerThreadPool`, which made these two scenarios trip an OOB `LocalVector<WorkerThreadPool::ThreadData>::operator[]` access -> `STATUS_STACK_BUFFER_OVERRUN`. The new macro skips cleanly if the pool isn't usable.

### Probe choice
`WorkerThreadPool::get_singleton()` non-null AND `get_thread_count() > 0`. The singleton is created by `register_core_types()` (which `Main::test_setup()` calls), so the null check is belt-and-braces -- the load-bearing gate is the thread-count check. `init()` is what populates the `TightLocalVector<ThreadData> threads` member, and only `tests/test_main.cpp:242` calls it. `gs_gpu_test_runner.cpp::gs_gpu_test_main()` never does, so the pool's vector stays size 0 and any indexed access OOBs.

## Verification

Build: `bin/godot.windows.editor.dev.x86_64.console.exe`, mtime `2026-05-25 08:48`, `SCONS_EXIT=0`.

**Headless Lifetime lane (matches `run_module_tests.py` filter — excludes `[RequiresGPU]`):**
```
[doctest] test cases:  5 |  5 passed | 0 failed | 1773 skipped
[doctest] assertions: 44 | 44 passed | 0 failed |
[doctest] Status: SUCCESS!
```

**GPU harness path (direct `--gs-gpu-test` with `*Lifetime*RequiresGPU*` filter — what `--batch Lifetime` would invoke):**
```
TEST CASE:  [GaussianSplatting][Renderer][Lifetime][RequiresGPU] renderer_instance lifetime proof
MESSAGE: Skipping test - worker thread pool unavailable

TEST CASE:  [GaussianSplatting][Renderer][Lifetime][RequiresGPU] asset_attach_detach lifetime proof
MESSAGE: Skipping test - worker thread pool unavailable

[doctest] test cases: 3 | 3 passed | 0 failed | 1775 skipped
[doctest] assertions: 5 | 5 passed | 0 failed |
[doctest] Status: SUCCESS!
```

Scenarios A and D skip cleanly with the new "worker thread pool unavailable" reason instead of crashing with `STATUS_STACK_BUFFER_OVERRUN`. Scenario C (`scene_director_reload`) runs cleanly via its existing graceful-degradation path. No OOB crash.

**Full module test suite (`python tests/ci/run_module_tests.py ...`):** doctest `Ran 94 tests in 4.226s OK`. The supervisor's overall exit=1 is pre-existing (`StringName orphan guard failed to run: FileNotFoundError` for `scripts/repo/history_artifact_audit.py` — the script doesn't exist on master HEAD either; unrelated to this change).

## Test plan

- [x] `run_module_tests.py` Lifetime lane still passes (A/C/D excluded headless by `[RequiresGPU]` filter; the 5 pure-arithmetic Lifetime probes pass)
- [x] Direct `--gs-gpu-test --test-case=*Lifetime*RequiresGPU*` no longer crashes (A/D skip with the new message; C runs cleanly)
- [ ] Follow-up: re-add `Lifetime` to `BATCHES` in `run_gpu_harness.py` once we confirm the typical CI GPU lane initializes `WorkerThreadPool` (separate PR; out of scope here)
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)