### PR TITLE
gaussian_splatting: performance, measurement honesty & export fixes

### DIFF
--- a/modules/gaussian_splatting/core/performance_monitors.cpp
+++ b/modules/gaussian_splatting/core/performance_monitors.cpp
@@ -546,18 +546,25 @@ float GaussianSplattingPerformanceMonitors::_get_gpu_cull_time_ms() const {
 }
 
 float GaussianSplattingPerformanceMonitors::_get_gpu_sort_time_ms() const {
+    // Prefer the REAL GPU overlap-sort timestamp (timing_state.last_overlap_sort_gpu_ms, resolved
+    // from the dedicated sort timestamp via resolve_gpu_timestamps_async). The streaming snapshot's
+    // stage/frame_sort_time_ms is the CPU command-SUBMIT time (sub-0.1ms), which massively
+    // under-reports: the overlap sort is the dominant GPU pass (measured ~7.8ms at 1.7M splats),
+    // and surfacing the submit time here was the metric-aliasing bug.
+    // Gate the direct GPU value on its validity flag (per codex review): on a frame with no sort
+    // dispatch (empty view, early-exit), last_overlap_sort_gpu_ms keeps its previous value, so an
+    // un-gated read could let a stale ~7.8ms win over the current fallback. When invalid, fall back.
+    const float direct = (active_renderer && active_renderer->is_last_gpu_overlap_sort_time_valid())
+            ? active_renderer->get_last_gpu_overlap_sort_time_ms()
+            : 0.0f;
     GaussianSplatRenderer *renderer = _get_active_splat_renderer(false);
     if (!renderer) {
-        return 0.0f;
+        return _sanitize_ms(direct);
     }
-
     const GaussianSplatRenderer::MonitorStreamingSnapshot snapshot =
             _streaming_snapshot_for_monitors(renderer);
-    if (snapshot.stage_metrics_valid) {
-        return _sanitize_ms(snapshot.stage_sort_time_ms);
-    }
-
-    return _sanitize_ms(snapshot.frame_sort_time_ms);
+    const float fallback = snapshot.stage_metrics_valid ? snapshot.stage_sort_time_ms : snapshot.frame_sort_time_ms;
+    return _prefer_direct_or_fallback(direct, fallback);
 }
 
 float GaussianSplattingPerformanceMonitors::_get_gpu_overlap_count_time_ms() const {

--- a/modules/gaussian_splatting/core/performance_monitors.cpp
+++ b/modules/gaussian_splatting/core/performance_monitors.cpp
@@ -219,6 +219,8 @@ void GaussianSplattingPerformanceMonitors::_register_monitor_definitions(Perform
                 callable_mp(this, &GaussianSplattingPerformanceMonitors::_get_gpu_cull_time_ms) },
         { "gaussian_splatting/gpu_time_sort_ms",
                 callable_mp(this, &GaussianSplattingPerformanceMonitors::_get_gpu_sort_time_ms) },
+        { "gaussian_splatting/gpu_time_overlap_count_ms",
+                callable_mp(this, &GaussianSplattingPerformanceMonitors::_get_gpu_overlap_count_time_ms) },
         { "gaussian_splatting/gpu_time_binning_ms",
                 callable_mp(this, &GaussianSplattingPerformanceMonitors::_get_gpu_binning_time_ms) },
         { "gaussian_splatting/gpu_time_prefix_ms",
@@ -277,6 +279,14 @@ void GaussianSplattingPerformanceMonitors::_register_monitor_definitions(Perform
         // Rendering Configuration Monitors
         { "gaussian_splatting/tile_count",
                 callable_mp(this, &GaussianSplattingPerformanceMonitors::_get_tile_count) },
+
+        // Honest device-level VRAM (real RenderingDevice allocation, includes sort/projection/atlas/textures)
+        { "gaussian_splatting/vram_device_total_mb",
+                callable_mp(this, &GaussianSplattingPerformanceMonitors::_get_vram_device_total_mb) },
+        { "gaussian_splatting/vram_device_buffers_mb",
+                callable_mp(this, &GaussianSplattingPerformanceMonitors::_get_vram_device_buffers_mb) },
+        { "gaussian_splatting/vram_device_textures_mb",
+                callable_mp(this, &GaussianSplattingPerformanceMonitors::_get_vram_device_textures_mb) },
 
         // VRAM Budget Regulation Monitors (Phase 1)
         { "gaussian_splatting/vram_current_usage_mb",
@@ -550,6 +560,13 @@ float GaussianSplattingPerformanceMonitors::_get_gpu_sort_time_ms() const {
     return _sanitize_ms(snapshot.frame_sort_time_ms);
 }
 
+float GaussianSplattingPerformanceMonitors::_get_gpu_overlap_count_time_ms() const {
+    // Real GPU time of the overlap-COUNT pass. Captured before the mid-frame buffer_get_data flush,
+    // so (unlike the post-flush passes) it resolves reliably in steady state. Surfacing it de-aliases
+    // the dashboard: binning/emit and count are distinct passes, not the same number.
+    return active_renderer ? _sanitize_ms(active_renderer->get_last_gpu_overlap_count_time_ms()) : 0.0f;
+}
+
 float GaussianSplattingPerformanceMonitors::_get_gpu_binning_time_ms() const {
     const float direct = active_renderer ? active_renderer->get_last_gpu_binning_time_ms() : 0.0f;
     GaussianSplatRenderer *renderer = _get_active_splat_renderer(false);
@@ -783,6 +800,34 @@ int GaussianSplattingPerformanceMonitors::_get_aggregated_count() const {
 
 int GaussianSplattingPerformanceMonitors::_get_tile_count() const {
     return active_renderer ? (int)active_renderer->get_tile_count() : 0;
+}
+
+// ============================================================================
+// Honest Device-Level VRAM Monitor Getters
+// Real RenderingDevice::get_memory_usage — the FULL GPU allocation on the device
+// (sort buffers + projection + resident atlas + textures), not just the streaming
+// regulator's atlas estimate exposed by vram_current_usage_mb.
+// ============================================================================
+
+float GaussianSplattingPerformanceMonitors::_get_vram_device_total_mb() const {
+    if (!active_renderer) return 0.0f;
+    RenderingDevice *rd = active_renderer->get_active_device();
+    if (!rd) return 0.0f;
+    return (float)((double)rd->get_memory_usage(RenderingDevice::MEMORY_TOTAL) / (1024.0 * 1024.0));
+}
+
+float GaussianSplattingPerformanceMonitors::_get_vram_device_buffers_mb() const {
+    if (!active_renderer) return 0.0f;
+    RenderingDevice *rd = active_renderer->get_active_device();
+    if (!rd) return 0.0f;
+    return (float)((double)rd->get_memory_usage(RenderingDevice::MEMORY_BUFFERS) / (1024.0 * 1024.0));
+}
+
+float GaussianSplattingPerformanceMonitors::_get_vram_device_textures_mb() const {
+    if (!active_renderer) return 0.0f;
+    RenderingDevice *rd = active_renderer->get_active_device();
+    if (!rd) return 0.0f;
+    return (float)((double)rd->get_memory_usage(RenderingDevice::MEMORY_TEXTURES) / (1024.0 * 1024.0));
 }
 
 // ============================================================================

--- a/modules/gaussian_splatting/core/performance_monitors.h
+++ b/modules/gaussian_splatting/core/performance_monitors.h
@@ -104,6 +104,7 @@ private:
     float _get_gpu_frame_time_ms() const;
     float _get_gpu_cull_time_ms() const;
     float _get_gpu_sort_time_ms() const;
+    float _get_gpu_overlap_count_time_ms() const; // real, pre-flush COUNT pass (de-aliased from binning/emit)
     float _get_gpu_binning_time_ms() const;
     float _get_gpu_prefix_time_ms() const;
     float _get_gpu_raster_time_ms() const;
@@ -132,6 +133,12 @@ private:
     int _get_aggregated_count() const;
 
     int _get_tile_count() const;
+
+    // Honest device-level VRAM (RenderingDevice::get_memory_usage) — full GPU allocation, not just
+    // the streaming atlas estimate that vram_current_usage_mb reports.
+    float _get_vram_device_total_mb() const;
+    float _get_vram_device_buffers_mb() const;
+    float _get_vram_device_textures_mb() const;
 
     // VRAM Budget Regulation Monitors (Phase 1)
     float _get_vram_current_usage_mb() const;

--- a/modules/gaussian_splatting/editor/gaussian_import_dialog.cpp
+++ b/modules/gaussian_splatting/editor/gaussian_import_dialog.cpp
@@ -961,7 +961,10 @@ void GaussianImportDialog::configure_for_file(const String &p_source_path, const
     } else if (baseline_options.has(StringName("quality/preset"))) {
         target_preset = String(baseline_options[StringName("quality/preset")]).to_lower();
     } else {
-        target_preset = gaussian_get_import_preset_by_index(1).id; // default to desktop/high
+        // Resolve the manual-dialog default by name, not by list index: the .ply/.spz
+        // importer now seeds "ultra" at index 0 (its Godot default), which shifts every
+        // positional index. "desktop" is the balanced dialog fallback regardless of order.
+        target_preset = gaussian_get_import_preset_by_name("desktop").id;
     }
 
     _apply_preset_defaults(gaussian_get_import_preset_by_name(target_preset));

--- a/modules/gaussian_splatting/io/gaussian_import_preset.cpp
+++ b/modules/gaussian_splatting/io/gaussian_import_preset.cpp
@@ -9,7 +9,7 @@ static Vector<GaussianImportPresetDefinition> &_gaussian_import_presets() {
     if (presets.is_empty()) {
         GaussianImportPresetDefinition mobile;
         mobile.id = "mobile";
-        mobile.display_name = TTR("Mobile");
+        mobile.display_name = RTR("Mobile");
         mobile.max_splats = 250000;
         mobile.density_multiplier = 0.4;
         mobile.enable_lod = true;
@@ -28,7 +28,7 @@ static Vector<GaussianImportPresetDefinition> &_gaussian_import_presets() {
 
         GaussianImportPresetDefinition desktop;
         desktop.id = "desktop";
-        desktop.display_name = TTR("Desktop");
+        desktop.display_name = RTR("Desktop");
         desktop.max_splats = 750000;
         desktop.density_multiplier = 0.7;
         desktop.enable_lod = true;
@@ -47,7 +47,7 @@ static Vector<GaussianImportPresetDefinition> &_gaussian_import_presets() {
 
         GaussianImportPresetDefinition high;
         high.id = "high";
-        high.display_name = TTR("High Quality");
+        high.display_name = RTR("High Quality");
         high.max_splats = 1000000;
         high.density_multiplier = 1.0;
         high.enable_lod = true;
@@ -66,7 +66,7 @@ static Vector<GaussianImportPresetDefinition> &_gaussian_import_presets() {
 
         GaussianImportPresetDefinition ultra;
         ultra.id = "ultra";
-        ultra.display_name = TTR("Ultra Quality");
+        ultra.display_name = RTR("Ultra Quality");
         ultra.max_splats = 0;
         ultra.density_multiplier = 1.0;
         ultra.enable_lod = true;
@@ -85,7 +85,7 @@ static Vector<GaussianImportPresetDefinition> &_gaussian_import_presets() {
 
         GaussianImportPresetDefinition development;
         development.id = "development";
-        development.display_name = TTR("Development");
+        development.display_name = RTR("Development");
         development.max_splats = 0;
         development.density_multiplier = 1.0;
         development.enable_lod = false;

--- a/modules/gaussian_splatting/io/gaussian_import_preset.cpp
+++ b/modules/gaussian_splatting/io/gaussian_import_preset.cpp
@@ -7,6 +7,30 @@
 static Vector<GaussianImportPresetDefinition> &_gaussian_import_presets() {
     static Vector<GaussianImportPresetDefinition> presets;
     if (presets.is_empty()) {
+        // Ultra is intentionally FIRST so it is the default preset for new
+        // .ply/.spz imports — Godot uses preset index 0 as the default options
+        // for a freshly imported file. Ultra keeps every splat
+        // (max_splats = 0, density_multiplier = 1.0), so imported assets are not
+        // pruned unless the user explicitly picks a lighter preset per asset.
+        GaussianImportPresetDefinition ultra;
+        ultra.id = "ultra";
+        ultra.display_name = RTR("Ultra Quality");
+        ultra.max_splats = 0;
+        ultra.density_multiplier = 1.0;
+        ultra.enable_lod = true;
+        ultra.optimize_for_gpu = true;
+        ultra.quantize_positions = false;
+        ultra.quantize_colors = false;
+        ultra.quantize_scales = false;
+        ultra.quantize_rotations = false;
+        ultra.pack_opacity = false;
+        ultra.thumbnail_style = 2; // normals style
+        ultra.include_statistics = true;
+        ultra.include_memory_estimate = true;
+        ultra.default_thumbnail_size = 192;
+        ultra.default_asset_type = 0;
+        presets.push_back(ultra);
+
         GaussianImportPresetDefinition mobile;
         mobile.id = "mobile";
         mobile.display_name = RTR("Mobile");
@@ -64,25 +88,6 @@ static Vector<GaussianImportPresetDefinition> &_gaussian_import_presets() {
         high.default_asset_type = 0;
         presets.push_back(high);
 
-        GaussianImportPresetDefinition ultra;
-        ultra.id = "ultra";
-        ultra.display_name = RTR("Ultra Quality");
-        ultra.max_splats = 0;
-        ultra.density_multiplier = 1.0;
-        ultra.enable_lod = true;
-        ultra.optimize_for_gpu = true;
-        ultra.quantize_positions = false;
-        ultra.quantize_colors = false;
-        ultra.quantize_scales = false;
-        ultra.quantize_rotations = false;
-        ultra.pack_opacity = false;
-        ultra.thumbnail_style = 2; // normals style
-        ultra.include_statistics = true;
-        ultra.include_memory_estimate = true;
-        ultra.default_thumbnail_size = 192;
-        ultra.default_asset_type = 0;
-        presets.push_back(ultra);
-
         GaussianImportPresetDefinition development;
         development.id = "development";
         development.display_name = RTR("Development");
@@ -129,7 +134,7 @@ const GaussianImportPresetDefinition &gaussian_get_import_preset_by_index(int p_
 const GaussianImportPresetDefinition &gaussian_get_import_preset_by_name(const String &p_name) {
     int idx = gaussian_find_import_preset_index(p_name);
     if (idx < 0) {
-        return gaussian_get_import_preset_by_index(1); // fallback to desktop/high
+        return gaussian_get_import_preset_by_index(0); // fallback to the default (ultra) — never prune on an unknown id
     }
     return gaussian_get_import_preset_by_index(idx);
 }

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -1494,13 +1494,11 @@ void GaussianSplatNode3D::_sync_renderer_splat_counts(int asset_splat_count, int
     const int expected_total = asset_splat_count > 0 ? asset_splat_count : procedural_splat_count;
     total_splat_count = expected_total > 0 ? (uint32_t)expected_total : 0;
 
-    Dictionary stats = renderer->get_render_stats();
-    uint32_t renderer_visible = 0;
-    if (stats.has("visible_splats")) {
-        renderer_visible = (uint32_t)(int64_t)stats["visible_splats"];
-    } else {
-        renderer_visible = renderer->get_visible_splat_count();
-    }
+    // Item 1 (perf): do NOT build the full multi-subsystem render-stats Dictionary every frame
+    // per node just to read one integer. get_render_stats() allocated a large Dictionary x active
+    // nodes/frame (a measured CPU-bound hotspot). The atomic visible-splat counter is the
+    // authoritative, allocation-free source (it was already the fallback path here).
+    uint32_t renderer_visible = renderer->get_visible_splat_count();
 
     if (total_splat_count == 0) {
         visible_splat_count = 0;

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
@@ -1402,19 +1402,39 @@ void GaussianSplatNodeRendererHelper::apply_renderer_settings() {
     {
         GaussianStreamingSystem::ConfigOverrides overrides;
 
+        // Item 1 (perf): VRAMBudgetConfig/LODConfig::load_from_project_settings() each do ~19 string-keyed
+        // ProjectSettings lookups. They were called every frame PER NODE (~19 x active-nodes/frame), a
+        // measured CPU-bound hotspot. These read GLOBAL project settings (identical for every node), so we
+        // cache the project-settings-derived base and refresh it at most once per REFRESH_FRAMES frames,
+        // then layer the per-node overrides on top. Staleness for live project-setting edits is therefore
+        // bounded to REFRESH_FRAMES frames REGARDLESS of node count (a frame-based gate, not a call counter
+        // — relevant only in-editor; gameplay project settings are fixed).
+        static thread_local VRAMBudgetConfig cached_vram_base;
+        static thread_local LODConfig cached_lod_base;
+        static thread_local uint64_t cached_settings_frame = 0;
+        static thread_local bool cached_settings_valid = false;
+        constexpr uint64_t REFRESH_FRAMES = 30;
+        const uint64_t now_frame = Engine::get_singleton()->get_process_frames();
+        if (!cached_settings_valid || (now_frame - cached_settings_frame) >= REFRESH_FRAMES) {
+            cached_vram_base = VRAMBudgetConfig::load_from_project_settings();
+            cached_lod_base = LODConfig();
+            cached_lod_base.load_from_project_settings();
+            cached_settings_frame = now_frame;
+            cached_settings_valid = true;
+        }
+
         overrides.override_prefetch = true;
         overrides.predictive_prefetch_enabled = owner.streaming_config.enable_predictive_loading;
         overrides.prefetch_lookahead_distance = owner.streaming_config.load_ahead_distance;
 
-        VRAMBudgetConfig vram_config = VRAMBudgetConfig::load_from_project_settings();
+        VRAMBudgetConfig vram_config = cached_vram_base;
         uint32_t budget_mb = uint32_t(owner.streaming_config.max_gpu_memory / (1024 * 1024));
         vram_config.budget_mb = MAX(64u, budget_mb);
         vram_config.min_chunks = MIN(vram_config.min_chunks, vram_config.max_chunks);
         overrides.override_vram_budget = true;
         overrides.vram_budget_config = vram_config;
 
-        LODConfig lod_override;
-        lod_override.load_from_project_settings();
+        LODConfig lod_override = cached_lod_base;
         lod_override.enabled = owner.streaming_config.enable_adaptive_quality;
         lod_override.num_levels = CLAMP((int)owner.streaming_config.num_lod_levels, 2, 8);
         lod_override.base_threshold = MAX(1.0f, owner.lod_config.lod0_distance);

--- a/modules/gaussian_splatting/renderer/gpu_sorting_config.cpp
+++ b/modules/gaussian_splatting/renderer/gpu_sorting_config.cpp
@@ -280,10 +280,14 @@ void GPUSortingConfig::print_config_summary() const {
     GS_LOG_GPU_SORT_INFO(vformat("[GPU Sorting Config] Active Preset: %s", get_current_preset_name()));
     GS_LOG_GPU_SORT_INFO(vformat("[GPU Sorting Config] Performance Target: %.1f ms per sort (instance/depth max %d elements)",
             target_sort_time_ms, max_sort_elements));
-    // Calculate VRAM usage for overlap record buffers: keys (8 bytes each for 64-bit) + values (4 bytes each)
-    const float overlap_vram_mb = float(max_overlap_records) * 12.0f / (1024.0f * 1024.0f);
-    GS_LOG_GPU_SORT_INFO(vformat("[GPU Sorting Config] Overlap Budget: %d records (~%.0f MB VRAM for key+value buffers)",
-            max_overlap_records, overlap_vram_mb));
+    // VRAM for overlap record buffers. Per record we allocate BOTH the primary key+value AND an
+    // equal-sized radix ping-pong temp (temp_keys + temp_values, see gpu_sorter.cpp). 64-bit keys
+    // store an 8-byte key (uvec2), 32-bit keys a 4-byte key; values are always 4 bytes.
+    const uint32_t key_bytes = (key_bits > 32) ? 8u : 4u;
+    const uint32_t bytes_per_record = (key_bytes + 4u) * 2u; // primary + radix temp
+    const float overlap_vram_mb = float(max_overlap_records) * float(bytes_per_record) / (1024.0f * 1024.0f);
+    GS_LOG_GPU_SORT_INFO(vformat("[GPU Sorting Config] Overlap Budget: %d records (~%.0f MB VRAM, %d B/record incl. radix ping-pong temp)",
+            max_overlap_records, overlap_vram_mb, bytes_per_record));
     GS_LOG_GPU_SORT_INFO(vformat("[GPU Sorting Config] Raster Tile Cap: %d splats/tile", max_raster_splats_per_tile));
     GS_LOG_GPU_SORT_INFO(vformat("[GPU Sorting Config] Radix Configuration: %d-bit radix, workgroup size %d",
             radix_bits, workgroup_size));

--- a/modules/gaussian_splatting/renderer/gpu_sorting_config.cpp
+++ b/modules/gaussian_splatting/renderer/gpu_sorting_config.cpp
@@ -63,6 +63,22 @@ void GPUSortingConfig::load_from_project_settings() {
             validate_sorted_output = ps->get_setting(VALIDATE_SORTED_OUTPUT_PATH, validate_sorted_output);
             enable_stage_timestamps = ps->get_setting(ENABLE_STAGE_TIMESTAMPS_PATH, enable_stage_timestamps);
             subgroup_prefix_mode = static_cast<uint8_t>(ps->get_setting(SUBGROUP_PREFIX_MODE_PATH, int(subgroup_prefix_mode)));
+            // Honor an EXPLICITLY-overridden project max_overlap_records even
+            // under a named preset. The preset supplies the per-tile overlap-sort
+            // budget as a DEFAULT, but a value the project author set on purpose
+            // is intentional and must win — otherwise the preset silently
+            // over-sizes the overlap sort buffers (the "high" default of 100M
+            // records is ~0.76 GB of keys alone, ~2 GB across keys/values/radix
+            // scratch). max_overlap_records is GLOBAL_DEF'd (default 100M, see
+            // register_project_settings), so has_setting() is always true;
+            // detect an explicit project override by comparing against that
+            // default so preset users who do NOT set the key keep their preset's
+            // budget unchanged.
+            const int64_t max_overlap_global_default = 100000000;
+            const int64_t project_overlap = ps->get_setting(MAX_OVERLAP_RECORDS_PATH, max_overlap_global_default);
+            if (project_overlap != max_overlap_global_default && project_overlap > 0) {
+                max_overlap_records = ps->get_setting(MAX_OVERLAP_RECORDS_PATH, max_overlap_records);
+            }
             if (enable_performance_logging) {
                 print_config_summary();
             }

--- a/modules/gaussian_splatting/renderer/gpu_sorting_config.cpp
+++ b/modules/gaussian_splatting/renderer/gpu_sorting_config.cpp
@@ -66,18 +66,18 @@ void GPUSortingConfig::load_from_project_settings() {
             // Honor an EXPLICITLY-overridden project max_overlap_records even
             // under a named preset. The preset supplies the per-tile overlap-sort
             // budget as a DEFAULT, but a value the project author set on purpose
-            // is intentional and must win — otherwise the preset silently
-            // over-sizes the overlap sort buffers (the "high" default of 100M
+            // is intentional and must win — otherwise the preset silently over- or
+            // under-sizes the overlap sort buffers (the "high" budget of 100M
             // records is ~0.76 GB of keys alone, ~2 GB across keys/values/radix
-            // scratch). max_overlap_records is GLOBAL_DEF'd (default 100M, see
-            // register_project_settings), so has_setting() is always true;
-            // detect an explicit project override by comparing against that
-            // default so preset users who do NOT set the key keep their preset's
-            // budget unchanged.
-            const int64_t max_overlap_global_default = 100000000;
-            const int64_t project_overlap = ps->get_setting(MAX_OVERLAP_RECORDS_PATH, max_overlap_global_default);
-            if (project_overlap != max_overlap_global_default && project_overlap > 0) {
-                max_overlap_records = ps->get_setting(MAX_OVERLAP_RECORDS_PATH, max_overlap_records);
+            // scratch). max_overlap_records is GLOBAL_DEF'd with a 0 "auto"
+            // sentinel (see initialize_gpu_sorting_config): 0 keeps the preset's
+            // budget, any positive value is an explicit override. Detecting
+            // explicitness by sentinel — not by value-equality against 100M — lets
+            // a project pin ANY budget, including exactly 100M, on top of a preset
+            // whose budget differs.
+            const int64_t project_overlap = ps->get_setting(MAX_OVERLAP_RECORDS_PATH, 0);
+            if (project_overlap > 0) {
+                max_overlap_records = uint32_t(project_overlap);
             }
             if (enable_performance_logging) {
                 print_config_summary();
@@ -90,9 +90,12 @@ void GPUSortingConfig::load_from_project_settings() {
     // Load individual settings (custom configuration)
     target_sort_time_ms = gs::sorting_settings::get_target_sort_time_ms(ps, 2.0f);
     bool has_elements = ps->has_setting(MAX_ELEMENTS_PATH);
-    bool has_overlap = ps->has_setting(MAX_OVERLAP_RECORDS_PATH);
+    // 0 is the "auto" sentinel (see initialize_gpu_sorting_config); a project
+    // that does not pin a budget falls back to the historical 100M default.
+    const int64_t overlap_setting = ps->get_setting(MAX_OVERLAP_RECORDS_PATH, 0);
+    bool has_overlap = (overlap_setting > 0);
     max_sort_elements = ps->get_setting(MAX_ELEMENTS_PATH, 50000000);
-    max_overlap_records = ps->get_setting(MAX_OVERLAP_RECORDS_PATH, 100000000);
+    max_overlap_records = has_overlap ? uint32_t(overlap_setting) : 100000000u;
     max_raster_splats_per_tile = ps->get_setting(MAX_RASTER_SPLATS_PER_TILE_PATH, 65536);
     GS_LOG_GPU_SORT_INFO(vformat("[GPUSortingConfig] LOADED: max_sort_elements=%d max_overlap_records=%d (has_elements=%d has_overlap=%d)",
             max_sort_elements, max_overlap_records, int(has_elements), int(has_overlap)));
@@ -545,7 +548,10 @@ void initialize_gpu_sorting_config() {
 	GLOBAL_DEF(GPUSortingConfig::GPU_PRESET_PATH, "high");
 	gs::sorting_settings::register_canonical_target_sort_time_setting(ps, 2.0f);
 	GLOBAL_DEF(GPUSortingConfig::MAX_ELEMENTS_PATH, 50000000);
-    GLOBAL_DEF(GPUSortingConfig::MAX_OVERLAP_RECORDS_PATH, 100000000);
+    // max_overlap_records uses 0 as an "auto" sentinel: 0 inherits the active
+    // gpu_preset's overlap budget; any positive value is an explicit project
+    // override that wins even under a named preset (see load_from_project_settings).
+    GLOBAL_DEF(GPUSortingConfig::MAX_OVERLAP_RECORDS_PATH, 0);
     GLOBAL_DEF(GPUSortingConfig::MAX_RASTER_SPLATS_PER_TILE_PATH, 65536);
     GLOBAL_DEF(GPUSortingConfig::RADIX_BITS_PATH, GPUSortingConstants::DEFAULT_RADIX_BITS);
     GLOBAL_DEF(GPUSortingConfig::WORKGROUP_SIZE_PATH, GPUSortingConstants::DEFAULT_WORKGROUP_SIZE);

--- a/modules/gaussian_splatting/renderer/tile_render_resources.cpp
+++ b/modules/gaussian_splatting/renderer/tile_render_resources.cpp
@@ -640,9 +640,15 @@ void TileProjectionBuffers::ensure_projection_buffer(uint32_t p_visible_count) {
 	}
 	const uint32_t required_bytes = uint32_t(required_bytes64);
 
-	const bool should_shrink = projection_buffer.is_valid() && projection_buffer_size > 0 &&
-			projection_buffer_size > required_bytes * 8u;
-	const bool needs_resize = !projection_buffer.is_valid() || projection_buffer_size < required_bytes || should_shrink;
+	// Only-grow policy: never shrink the projection buffer within a renderer's
+	// lifetime. The visible-splat count oscillates by ~15x as the camera sweeps
+	// (e.g. 250K..3.74M), and an 8x shrink hysteresis was not wide enough to
+	// prevent grow/shrink cycling — it caused this >1 GB buffer to be freed and
+	// recreated hundreds of times per session, stalling the driver (stutter) and
+	// transiently double-allocating during the realloc. Growing to the session
+	// high-water mark and holding converges after the first full-scene frame.
+	// The buffer is released wholesale on renderer teardown / scene change.
+	const bool needs_resize = !projection_buffer.is_valid() || projection_buffer_size < required_bytes;
 
 	if (!needs_resize) {
 #ifdef DEV_ENABLED

--- a/modules/gaussian_splatting/renderer/tile_render_types.h
+++ b/modules/gaussian_splatting/renderer/tile_render_types.h
@@ -269,6 +269,17 @@ struct TileTimingState {
 	bool frame_gpu_timing_valid = false;
 	uint64_t gpu_timing_frame_serial = 0;
 	uint64_t gpu_timing_frames_behind = 0;
+	// Frame serial at which each per-pass GPU time was last successfully resolved. Used to bound the
+	// staleness of the "sticky last-known" per-pass timings (see _update_timing_metrics): a pass that
+	// legitimately stops dispatching (e.g. raster compute/fragment switch, skipped resolve, empty
+	// view) must not keep reporting a frozen value forever — its valid flag is cleared after it has
+	// not resolved for GPU_PASS_STALE_FRAMES.
+	uint64_t last_overlap_count_resolved_serial = 0;
+	uint64_t last_overlap_emit_resolved_serial = 0;
+	uint64_t last_overlap_sort_resolved_serial = 0;
+	uint64_t last_raster_resolved_serial = 0;
+	uint64_t last_prefix_resolved_serial = 0;
+	uint64_t last_resolve_resolved_serial = 0;
 };
 
 struct TilePerformanceMetrics {

--- a/modules/gaussian_splatting/renderer/tile_render_types.h
+++ b/modules/gaussian_splatting/renderer/tile_render_types.h
@@ -269,6 +269,11 @@ struct TileTimingState {
 	bool frame_gpu_timing_valid = false;
 	uint64_t gpu_timing_frame_serial = 0;
 	uint64_t gpu_timing_frames_behind = 0;
+	// Monotonic counter advanced on EVERY _update_timing_metrics call (work AND no-work frames).
+	// The sticky-timing staleness ages against this, NOT the rasterizer's current_frame_serial:
+	// that serial freezes on the empty/no-dispatch path (which returns before rasterization) while
+	// resolve_gpu_timestamps_async() still runs, so aging against it would never expire on an empty view.
+	uint64_t gpu_timing_age_serial = 0;
 	// Frame serial at which each per-pass GPU time was last successfully resolved. Used to bound the
 	// staleness of the "sticky last-known" per-pass timings (see _update_timing_metrics): a pass that
 	// legitimately stops dispatching (e.g. raster compute/fragment switch, skipped resolve, empty

--- a/modules/gaussian_splatting/renderer/tile_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/tile_renderer.cpp
@@ -2582,28 +2582,77 @@ void TileRenderer::_update_timing_metrics(const GpuTimestampDurations &p_duratio
         return;
     }
 
-	timing_state.last_overlap_count_gpu_ms = (float)p_durations.count_ms;
-	timing_state.last_overlap_emit_gpu_ms = (float)p_durations.bin_ms;
-	timing_state.last_binning_gpu_ms = timing_state.last_overlap_emit_gpu_ms;
-	timing_state.last_overlap_sort_gpu_ms = (float)p_durations.overlap_sort_ms;
-	timing_state.last_raster_gpu_ms = (float)p_durations.raster_ms;
-	timing_state.last_prefix_gpu_ms = (float)p_durations.prefix_ms;
-	timing_state.last_resolve_gpu_ms = (float)p_durations.resolve_ms;
-	timing_state.overlap_count_gpu_timing_valid = p_durations.count_valid;
-	timing_state.overlap_emit_gpu_timing_valid = p_durations.bin_valid;
-	timing_state.overlap_sort_gpu_timing_valid = p_durations.overlap_sort_valid;
-	timing_state.raster_gpu_timing_valid = p_durations.raster_valid;
-	timing_state.prefix_gpu_timing_valid = p_durations.prefix_valid;
-	timing_state.resolve_gpu_timing_valid = p_durations.resolve_valid;
-	float fallback_total = 0.0f;
-	fallback_total += p_durations.count_valid ? (float)p_durations.count_ms : 0.0f;
-	fallback_total += p_durations.prefix_valid ? (float)p_durations.prefix_ms : 0.0f;
-	fallback_total += p_durations.bin_valid ? (float)p_durations.bin_ms : 0.0f;
-	fallback_total += p_durations.overlap_sort_valid ? (float)p_durations.overlap_sort_ms : 0.0f;
-	fallback_total += p_durations.raster_valid ? (float)p_durations.raster_ms : 0.0f;
-	fallback_total += p_durations.resolve_valid ? (float)p_durations.resolve_ms : 0.0f;
-	timing_state.last_frame_gpu_ms = (float)(p_durations.total_valid ? p_durations.total_ms : fallback_total);
-	timing_state.frame_gpu_timing_valid = p_durations.total_valid || fallback_total > 0.0f;
+	// Per-pass GPU timestamps resolve only INTERMITTENTLY: the mid-frame buffer_get_data flush
+	// (prefix stage) wipes the main-submission markers on most frames, so only the sort — captured
+	// in its own GPU submission — survives every frame; count/binning/raster/prefix/resolve resolve
+	// only on frames where the flush timing happens to align. Therefore DON'T clobber a previously
+	// resolved per-pass value with 0 on a frame where that pass didn't resolve: keep the last-known
+	// GPU time and a sticky valid flag, so the monitors show stable real values instead of flickering
+	// to 0. (_reset_timestamp_tracking() zeros these when timestamp capture is disabled.)
+	const uint64_t cur_serial = frame_state.current_frame_serial;
+	if (p_durations.count_valid) {
+		timing_state.last_overlap_count_gpu_ms = (float)p_durations.count_ms;
+		timing_state.overlap_count_gpu_timing_valid = true;
+		timing_state.last_overlap_count_resolved_serial = cur_serial;
+	}
+	if (p_durations.bin_valid) {
+		timing_state.last_overlap_emit_gpu_ms = (float)p_durations.bin_ms;
+		timing_state.last_binning_gpu_ms = timing_state.last_overlap_emit_gpu_ms;
+		timing_state.overlap_emit_gpu_timing_valid = true;
+		timing_state.last_overlap_emit_resolved_serial = cur_serial;
+	}
+	if (p_durations.overlap_sort_valid) {
+		timing_state.last_overlap_sort_gpu_ms = (float)p_durations.overlap_sort_ms;
+		timing_state.overlap_sort_gpu_timing_valid = true;
+		timing_state.last_overlap_sort_resolved_serial = cur_serial;
+	}
+	if (p_durations.raster_valid) {
+		timing_state.last_raster_gpu_ms = (float)p_durations.raster_ms;
+		timing_state.raster_gpu_timing_valid = true;
+		timing_state.last_raster_resolved_serial = cur_serial;
+	}
+	if (p_durations.prefix_valid) {
+		timing_state.last_prefix_gpu_ms = (float)p_durations.prefix_ms;
+		timing_state.prefix_gpu_timing_valid = true;
+		timing_state.last_prefix_resolved_serial = cur_serial;
+	}
+	if (p_durations.resolve_valid) {
+		timing_state.last_resolve_gpu_ms = (float)p_durations.resolve_ms;
+		timing_state.resolve_gpu_timing_valid = true;
+		timing_state.last_resolve_resolved_serial = cur_serial;
+	}
+	// Staleness bound (per dual review): a pass that legitimately STOPS dispatching (raster
+	// compute/fragment switch, skipped resolve, empty view) must not report a frozen value forever.
+	// Clear a sticky per-pass valid flag once it has not resolved for GPU_PASS_STALE_FRAMES; passes
+	// that keep resolving intermittently stay valid.
+	constexpr uint64_t GPU_PASS_STALE_FRAMES = 120; // ~2s at 60fps
+	auto expire_stale = [cur_serial](bool &r_valid, float &r_value, uint64_t p_resolved_serial) {
+		if (r_valid && cur_serial > p_resolved_serial && (cur_serial - p_resolved_serial) > GPU_PASS_STALE_FRAMES) {
+			r_valid = false;
+			r_value = 0.0f;
+		}
+	};
+	expire_stale(timing_state.overlap_count_gpu_timing_valid, timing_state.last_overlap_count_gpu_ms, timing_state.last_overlap_count_resolved_serial);
+	expire_stale(timing_state.overlap_emit_gpu_timing_valid, timing_state.last_overlap_emit_gpu_ms, timing_state.last_overlap_emit_resolved_serial);
+	if (!timing_state.overlap_emit_gpu_timing_valid) {
+		timing_state.last_binning_gpu_ms = 0.0f; // binning mirrors emit
+	}
+	expire_stale(timing_state.overlap_sort_gpu_timing_valid, timing_state.last_overlap_sort_gpu_ms, timing_state.last_overlap_sort_resolved_serial);
+	expire_stale(timing_state.raster_gpu_timing_valid, timing_state.last_raster_gpu_ms, timing_state.last_raster_resolved_serial);
+	expire_stale(timing_state.prefix_gpu_timing_valid, timing_state.last_prefix_gpu_ms, timing_state.last_prefix_resolved_serial);
+	expire_stale(timing_state.resolve_gpu_timing_valid, timing_state.last_resolve_gpu_ms, timing_state.last_resolve_resolved_serial);
+	// Frame total from the (sticky) last-known per-pass values, so it reflects the full pipeline
+	// (~13ms) rather than just whichever passes happened to resolve this frame (which made it read
+	// ~8ms = sort only). The GaussianSplat_ total marker is itself flush-discarded, so don't rely on it.
+	float frame_total = 0.0f;
+	frame_total += timing_state.overlap_count_gpu_timing_valid ? timing_state.last_overlap_count_gpu_ms : 0.0f;
+	frame_total += timing_state.prefix_gpu_timing_valid ? timing_state.last_prefix_gpu_ms : 0.0f;
+	frame_total += timing_state.overlap_emit_gpu_timing_valid ? timing_state.last_overlap_emit_gpu_ms : 0.0f;
+	frame_total += timing_state.overlap_sort_gpu_timing_valid ? timing_state.last_overlap_sort_gpu_ms : 0.0f;
+	frame_total += timing_state.raster_gpu_timing_valid ? timing_state.last_raster_gpu_ms : 0.0f;
+	frame_total += timing_state.resolve_gpu_timing_valid ? timing_state.last_resolve_gpu_ms : 0.0f;
+	timing_state.last_frame_gpu_ms = frame_total;
+	timing_state.frame_gpu_timing_valid = frame_total > 0.0f;
 	timing_state.gpu_timing_frame_serial = p_durations.serial;
     timing_state.gpu_timing_frames_behind = (frame_state.current_frame_serial > p_durations.serial)
             ? (frame_state.current_frame_serial - p_durations.serial)

--- a/modules/gaussian_splatting/renderer/tile_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/tile_renderer.cpp
@@ -2590,7 +2590,9 @@ void TileRenderer::_update_timing_metrics(const GpuTimestampDurations &p_duratio
 	// resolved per-pass value with 0 on a frame where that pass didn't resolve: keep the last-known
 	// GPU time and a sticky valid flag, so the monitors show stable real values instead of flickering
 	// to 0. (_reset_timestamp_tracking() zeros these when timestamp capture is disabled.)
-	const uint64_t cur_serial = frame_state.current_frame_serial;
+	// Age against a per-resolve counter, not the rasterizer frame serial (which freezes on the
+	// empty/no-dispatch path), so sticky timings expire on an empty view (Codex follow-up on #397).
+	const uint64_t cur_serial = ++timing_state.gpu_timing_age_serial;
 	if (p_durations.count_valid) {
 		timing_state.last_overlap_count_gpu_ms = (float)p_durations.count_ms;
 		timing_state.overlap_count_gpu_timing_valid = true;

--- a/modules/gaussian_splatting/renderer/tile_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/tile_renderer.cpp
@@ -2578,9 +2578,10 @@ TileRenderer::GpuTimestampDurations TileRenderer::_compute_stage_durations(const
 }
 
 void TileRenderer::_update_timing_metrics(const GpuTimestampDurations &p_durations) {
-    if (!p_durations.has_data) {
-        return;
-    }
+	// Runs on EVERY call, including the no-data frames resolve_gpu_timestamps_async() forwards
+	// when a scene stops dispatching: per-pass ingestion self-skips without fresh data (all
+	// *_valid are false), but the staleness pass below MUST still run so sticky timings age out
+	// instead of reporting a previous scene's GPU cost forever.
 
 	// Per-pass GPU timestamps resolve only INTERMITTENTLY: the mid-frame buffer_get_data flush
 	// (prefix stage) wipes the main-submission markers on most frames, so only the sort — captured
@@ -2653,10 +2654,14 @@ void TileRenderer::_update_timing_metrics(const GpuTimestampDurations &p_duratio
 	frame_total += timing_state.resolve_gpu_timing_valid ? timing_state.last_resolve_gpu_ms : 0.0f;
 	timing_state.last_frame_gpu_ms = frame_total;
 	timing_state.frame_gpu_timing_valid = frame_total > 0.0f;
-	timing_state.gpu_timing_frame_serial = p_durations.serial;
-    timing_state.gpu_timing_frames_behind = (frame_state.current_frame_serial > p_durations.serial)
-            ? (frame_state.current_frame_serial - p_durations.serial)
-            : 0;
+	// Only fresh data advances the reported frame serial / frames-behind; a no-data ageing call
+	// must not stamp the default serial (UINT64_MAX) over the last real measurement.
+	if (p_durations.has_data) {
+		timing_state.gpu_timing_frame_serial = p_durations.serial;
+		timing_state.gpu_timing_frames_behind = (frame_state.current_frame_serial > p_durations.serial)
+				? (frame_state.current_frame_serial - p_durations.serial)
+				: 0;
+	}
 }
 
 void TileRenderer::resolve_gpu_timestamps_async() {
@@ -2677,6 +2682,9 @@ void TileRenderer::resolve_gpu_timestamps_async() {
         if (timing_state.gpu_timing_frame_serial > 0 && frame_state.current_frame_serial > timing_state.gpu_timing_frame_serial) {
             timing_state.gpu_timing_frames_behind = frame_state.current_frame_serial - timing_state.gpu_timing_frame_serial;
         }
+        // No fresh timestamps this frame (empty / no-dispatch view): still run the staleness pass
+        // so the sticky per-pass timings age out instead of reporting the last scene's cost forever.
+        _update_timing_metrics(GpuTimestampDurations());
         return;
     }
 

--- a/modules/gaussian_splatting/renderer/tile_renderer.h
+++ b/modules/gaussian_splatting/renderer/tile_renderer.h
@@ -117,6 +117,10 @@ public:
     // Note: tile_raster_pipeline is created lazily during first render (needs framebuffer format)
     // So we only check compute pipelines here. The raster shader must be valid though.
     bool is_initialized() const { return device_context.resource_rd != nullptr; }
+    // Honest device-level VRAM accounting: the RenderingDevice this renderer allocates against.
+    // Used by performance monitors to report real get_memory_usage() totals (the streaming
+    // regulator's vram_current_usage_mb only accounts for the streaming atlas, not sort/projection buffers).
+    RenderingDevice *get_active_device() const { return device_context.resource_rd; }
     RID get_tile_binning_pipeline() const { return shader_resources.tile_binning_pipeline; }
     RID get_tile_raster_pipeline() const { return shader_resources.tile_raster_pipeline; }
     uint64_t get_shader_defines_hash() const { return shader_resources.shader_defines_hash; }

--- a/modules/gaussian_splatting/tests/test_config_validation.h
+++ b/modules/gaussian_splatting/tests/test_config_validation.h
@@ -432,6 +432,54 @@ TEST_CASE("[GaussianSplatting][Config] Project settings apply preset layouts unl
 	g_gpu_sorting_config = previous_global_config;
 }
 
+TEST_CASE("[GaussianSplatting][Config] Explicit max_overlap_records overrides a named preset's budget") {
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	REQUIRE(project_settings != nullptr);
+
+	const GPUSortingConfig previous_global_config = g_gpu_sorting_config;
+	const String preset_path = GPUSortingConfig::GPU_PRESET_PATH;
+	const String overlap_path = GPUSortingConfig::MAX_OVERLAP_RECORDS_PATH;
+	ProjectSettingGuard preset_guard(project_settings, preset_path);
+	ProjectSettingGuard overlap_guard(project_settings, overlap_path);
+
+	// preset_low() pins a 10M overlap budget; the legacy/"high" budget is 100M.
+	const uint32_t kLowPresetOverlap = 10000000u;
+	const uint32_t kHighOverlap = 100000000u;
+
+	SUBCASE("0 sentinel keeps the preset's own overlap budget") {
+		project_settings->set_setting(preset_path, "low");
+		project_settings->set_setting(overlap_path, 0);
+		g_gpu_sorting_config.load_from_project_settings();
+		CHECK(g_gpu_sorting_config.max_overlap_records == kLowPresetOverlap);
+	}
+
+	SUBCASE("Explicit 100M wins over a preset whose budget is lower") {
+		// Regression for Codex P2 on #397: detecting explicitness by value-equality
+		// against the 100M default dropped a project that intentionally pinned
+		// exactly the legacy budget on top of the low-VRAM preset.
+		project_settings->set_setting(preset_path, "low");
+		project_settings->set_setting(overlap_path, 100000000);
+		g_gpu_sorting_config.load_from_project_settings();
+		CHECK(g_gpu_sorting_config.max_overlap_records == kHighOverlap);
+	}
+
+	SUBCASE("Explicit 100M wins over a preset whose budget is higher") {
+		project_settings->set_setting(preset_path, "ultra"); // preset_ultra() pins 150M
+		project_settings->set_setting(overlap_path, 100000000);
+		g_gpu_sorting_config.load_from_project_settings();
+		CHECK(g_gpu_sorting_config.max_overlap_records == kHighOverlap);
+	}
+
+	SUBCASE("Custom preset with the 0 sentinel falls back to the 100M default") {
+		project_settings->set_setting(preset_path, "custom");
+		project_settings->set_setting(overlap_path, 0);
+		g_gpu_sorting_config.load_from_project_settings();
+		CHECK(g_gpu_sorting_config.max_overlap_records == kHighOverlap);
+	}
+
+	g_gpu_sorting_config = previous_global_config;
+}
+
 TEST_CASE("[GaussianSplatting][Config] GPUSortingConfig validates tile/depth bit allocation") {
 	GPUSortingConfig config;
 	config.reset_to_defaults();


### PR DESCRIPTION
## Summary
CPU-side performance measurement + honest GPU/VRAM telemetry for the tile renderer, plus import-preset polish:
- **Item 1 CPU quick-win**: drop the per-node stats `Dictionary`, cache project settings (×N nodes) — the GrandmasHouse CPU-bound stutter.
- **Honest per-pass GPU timing** (sticky last-known + 120-frame staleness bound) and **real device-VRAM monitors** (`get_active_device()` → `get_memory_usage()`), instead of streaming-atlas-only accounting.
- Real GPU overlap-sort time surfaced in `gpu_time_sort_ms`.
- **Only-grow** the tile projection buffer (stop realloc churn).
- Default `.ply/.spz` import preset to **Ultra** (no pruning); `TTR→RTR` so import presets build in export templates.
- Honor an **explicit** project `max_overlap_records` under a named preset.

## Fixes in this revision (rebased onto master @ `ade097cc8d`)
- **Unblocks Module Build + Runtime Harness**: the ultra-at-index-0 reorder shifted the import dialog's positional default (`by_index(1)`) from `desktop` to `mobile`, failing the pre-existing `[Editor] Import dialog handles SPZ source paths` doctest. Resolved the dialog default **by name** (`desktop`) — robust to reordering, importer index-0 = ultra default intact.
- **Codex P2 (`gpu_sorting_config`)**: detect an explicit `max_overlap_records` override via a `0` "auto" sentinel instead of value-equality against 100M, so a project can pin *any* budget (incl. exactly 100M) over a preset whose budget differs (`preset_low`=10M, `preset_ultra`=150M). + `[Config]` regression test.

## Contract
- **Risk:** **R3** (escalated by `io/gaussian_import_preset.cpp` = import/persistence; renderer paths are R2).
- **Base SHA:** `ade097cc8d` (master).
- **Non-goals:** no rendering-math change; no on-disk PLY/SPZ format change (preset *defaults* only); no perf-threshold/baseline changes; telemetry monitors do not affect render output.
- **Validation:** `run_module_tests.py --guard-only` (release gate + guards) green locally; full Module Build + Runtime Harness, GPU QA, GPU Harness + Visual Gate run on self-hosted CI (this push).
- **Rollback:** revert the branch; no migration. The `0`-sentinel records only the key (no public-API/baseline shift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Update — Codex sticky-timing P2 (+ follow-up)
- **Age out sticky GPU timings on no-data frames**: `_update_timing_metrics` returned early when no fresh timestamps arrived (and `resolve_gpu_timestamps_async` skips the call entirely on captured-count 0), so the 120-frame staleness expiry never ran once a scene stopped dispatching — the per-pass `gpu_time_*` monitors reported the previous scene's cost forever. The expiry now runs on every call; a no-data update is forwarded from the empty-frame path.
- **Age against a per-resolve counter** (Codex follow-up): the expiry aged against `frame_state.current_frame_serial`, which freezes on the empty/no-dispatch path — so it never crossed the bound. Added a monotonic `gpu_timing_age_serial` advanced every `_update_timing_metrics` call, independent of rasterization.
