### PR TITLE
gaussian_splatting: reclaim the dead GPUBufferManager gaussian_buffer (S1)

### DIFF
--- a/modules/gaussian_splatting/renderer/gpu_buffer_manager.cpp
+++ b/modules/gaussian_splatting/renderer/gpu_buffer_manager.cpp
@@ -44,7 +44,7 @@ GPUBufferManager::~GPUBufferManager() {
 }
 
 void GPUBufferManager::_bind_methods() {
-    ClassDB::bind_method(D_METHOD("initialize", "rendering_device", "max_gaussians"), &GPUBufferManager::initialize, DEFVAL(2000000));
+    ClassDB::bind_method(D_METHOD("initialize", "rendering_device", "max_gaussians", "allocate_gaussian_buffer"), &GPUBufferManager::initialize, DEFVAL(2000000), DEFVAL(true));
     ClassDB::bind_method(D_METHOD("upload_gaussian_data", "data"), &GPUBufferManager::upload_gaussian_data);
     ClassDB::bind_method(D_METHOD("begin_frame"), &GPUBufferManager::begin_frame);
     ClassDB::bind_method(D_METHOD("end_frame"), &GPUBufferManager::end_frame);
@@ -103,7 +103,7 @@ void GPUBufferManager::_reset_state(bool p_reset_handles) {
     }
 }
 
-Error GPUBufferManager::initialize(RenderingDevice *p_rd, uint32_t p_max_gaussians) {
+Error GPUBufferManager::initialize(RenderingDevice *p_rd, uint32_t p_max_gaussians, bool p_allocate_gaussian_buffer) {
     ERR_FAIL_NULL_V(p_rd, ERR_INVALID_PARAMETER);
 
     if (buffers_created) {
@@ -112,6 +112,7 @@ Error GPUBufferManager::initialize(RenderingDevice *p_rd, uint32_t p_max_gaussia
 
     rd = p_rd;
     max_gaussians = p_max_gaussians;
+    allocate_gaussian_buffer = p_allocate_gaussian_buffer;
 
     return create_buffers();
 }
@@ -143,13 +144,21 @@ Error GPUBufferManager::_create_buffer_set(BufferSet &r_set, uint32_t p_gaussian
         r_set.reset();
     };
 
-    empty_data.resize(p_gaussian_size);
-    r_set.gaussian_buffer = device->storage_buffer_create(p_gaussian_size, empty_data);
-    if (!r_set.gaussian_buffer.is_valid()) {
-        rollback_set();
-        return ERR_CANT_CREATE;
+    // The gaussian_buffer is the largest allocation (144 B x max_gaussians) and is
+    // DEAD on the instance pipeline (the render path binds the instance atlas, not
+    // this buffer; upload_gaussian_data has no production caller). Skip it unless the
+    // legacy painterly/manual-upload path needs it (allocate_gaussian_buffer=true).
+    // A null gaussian_buffer is handled everywhere via is_valid() guards; the live
+    // sort_key/sorted_indices buffers below are always allocated.
+    if (allocate_gaussian_buffer) {
+        empty_data.resize(p_gaussian_size);
+        r_set.gaussian_buffer = device->storage_buffer_create(p_gaussian_size, empty_data);
+        if (!r_set.gaussian_buffer.is_valid()) {
+            rollback_set();
+            return ERR_CANT_CREATE;
+        }
+        device->set_resource_name(r_set.gaussian_buffer, "GS_GPUBufferManager_GaussianBuffer");
     }
-    device->set_resource_name(r_set.gaussian_buffer, "GS_GPUBufferManager_GaussianBuffer");
 
     empty_data.resize(p_sort_key_size);
     r_set.sort_key_buffer = device->storage_buffer_create(p_sort_key_size, empty_data);
@@ -625,6 +634,11 @@ RID GPUBufferManager::get_current_write_buffer() const {
 Error GPUBufferManager::upload_gaussian_data(const Ref<::GaussianData> &p_data) {
     ERR_FAIL_COND_V(!p_data.is_valid(), ERR_INVALID_PARAMETER);
     ERR_FAIL_COND_V(!buffers_created, ERR_UNCONFIGURED);
+    // The manual-upload path needs the gaussian_buffer; it is skipped when the
+    // instance pipeline initialized with allocate_gaussian_buffer=false. Fail loudly
+    // rather than issue a buffer_update on a null RID.
+    ERR_FAIL_COND_V_MSG(!allocate_gaussian_buffer, ERR_UNCONFIGURED,
+            "upload_gaussian_data requires the gaussian_buffer; initialize with allocate_gaussian_buffer=true.");
 
     bool frame_was_active = frame_active;
     GS_LOG_GPU_MEMORY_DEBUG(vformat("[BUFFER-DBG] upload_gaussian_data: frame_active=%d read_idx=%d write_idx=%d count=%d",
@@ -721,6 +735,8 @@ void GPUBufferManager::clear_gaussian_data() {
 }
 
 RID GPUBufferManager::get_gaussian_buffer() const {
+    // Returns a null RID when initialized with allocate_gaussian_buffer=false (the
+    // instance pipeline never samples this buffer). Callers must check is_valid().
     return get_current_read_buffer();
 }
 
@@ -815,9 +831,11 @@ float GPUBufferManager::get_memory_usage_mb() const {
     }
 
     uint64_t total_bytes = 0;
-    total_bytes += sizeof(PackedGaussian) * max_gaussians * BUFFER_COUNT;
-    total_bytes += sizeof(SortKey) * max_gaussians * BUFFER_COUNT;
-    total_bytes += sizeof(uint32_t) * max_gaussians * BUFFER_COUNT;
+    if (allocate_gaussian_buffer) {
+        total_bytes += uint64_t(sizeof(PackedGaussian)) * max_gaussians * BUFFER_COUNT;
+    }
+    total_bytes += uint64_t(sizeof(SortKey)) * max_gaussians * BUFFER_COUNT;
+    total_bytes += uint64_t(sizeof(uint32_t)) * max_gaussians * BUFFER_COUNT;
     total_bytes += 256; // Uniform buffer
 
     return total_bytes / (1024.0f * 1024.0f);

--- a/modules/gaussian_splatting/renderer/gpu_buffer_manager.cpp
+++ b/modules/gaussian_splatting/renderer/gpu_buffer_manager.cpp
@@ -146,9 +146,11 @@ Error GPUBufferManager::_create_buffer_set(BufferSet &r_set, uint32_t p_gaussian
 
     // The gaussian_buffer is the largest allocation (144 B x max_gaussians) and is
     // DEAD on the instance pipeline (the render path binds the instance atlas, not
-    // this buffer; upload_gaussian_data has no production caller). Skip it unless the
-    // legacy painterly/manual-upload path needs it (allocate_gaussian_buffer=true).
-    // A null gaussian_buffer is handled everywhere via is_valid() guards; the live
+    // this buffer; upload_gaussian_data has no production caller). Skip it unless a
+    // caller explicitly opts into the manual-upload path (allocate_gaussian_buffer=true).
+    // A null gaussian_buffer is handled everywhere via is_valid() guards — even the
+    // painterly renderer probes get_gaussian_handle() defensively and falls through to
+    // instance/stream data — so this is a reclaim, not a behavior change. The live
     // sort_key/sorted_indices buffers below are always allocated.
     if (allocate_gaussian_buffer) {
         empty_data.resize(p_gaussian_size);

--- a/modules/gaussian_splatting/renderer/gpu_buffer_manager.h
+++ b/modules/gaussian_splatting/renderer/gpu_buffer_manager.h
@@ -148,7 +148,8 @@ private:
     // largest allocation) is NOT allocated. The instance pipeline never samples it
     // (it binds the instance atlas), so production passes false and reclaims it; the
     // live sort_key/sorted_indices buffers are always allocated. Default true keeps
-    // the legacy painterly/manual-upload path and existing tests unchanged.
+    // explicit manual-upload callers and existing tests unchanged (the painterly
+    // renderer tolerates a null gaussian_buffer and falls through to instance/stream).
     bool allocate_gaussian_buffer = true;
     LocalVector<uint32_t> sequential_index_cache;
 

--- a/modules/gaussian_splatting/renderer/gpu_buffer_manager.h
+++ b/modules/gaussian_splatting/renderer/gpu_buffer_manager.h
@@ -144,6 +144,12 @@ private:
     uint32_t current_count = 0;
     uint32_t current_visible_count = 0;
     bool buffers_created = false;
+    // When false, the per-buffer-set `gaussian_buffer` (144 B x max_gaussians, the
+    // largest allocation) is NOT allocated. The instance pipeline never samples it
+    // (it binds the instance atlas), so production passes false and reclaims it; the
+    // live sort_key/sorted_indices buffers are always allocated. Default true keeps
+    // the legacy painterly/manual-upload path and existing tests unchanged.
+    bool allocate_gaussian_buffer = true;
     LocalVector<uint32_t> sequential_index_cache;
 
     // Submission batching (Issue #142)
@@ -176,7 +182,7 @@ public:
     GPUBufferManager();
     ~GPUBufferManager();
 
-    Error initialize(RenderingDevice *p_rd, uint32_t p_max_gaussians = 2000000);
+    Error initialize(RenderingDevice *p_rd, uint32_t p_max_gaussians = 2000000, bool p_allocate_gaussian_buffer = true);
     Error upload_gaussian_data(const Ref<::GaussianData> &p_data);
     void clear_gaussian_data();
 

--- a/modules/gaussian_splatting/renderer/render_resource_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_resource_orchestrator.cpp
@@ -164,8 +164,13 @@ void RenderResourceOrchestrator::create_gpu_resources_safe() {
 	if (resource_state.buffer_manager.is_valid() && (!resource_state.buffer_manager_initialized || needs_buffer_resize)) {
 		GS_STARTUP_SCOPE("gpu_buffer_manager_init");
 		int max_splats_for_buffer = local_performance_settings.max_splats;
+		// Skip the dead gaussian_buffer (144 B x max_splats x2, the largest allocation):
+		// the instance pipeline binds the instance atlas, never this buffer, and
+		// upload_gaussian_data has no production caller. The live sort_key/sorted_indices
+		// buffers are still allocated. (Legacy painterly / tests use the default-true 2-arg
+		// initialize and keep allocating it.)
 		Error err = resource_state.buffer_manager->initialize(
-				device_state->rd, max_splats_for_buffer);
+				device_state->rd, max_splats_for_buffer, /*p_allocate_gaussian_buffer=*/ false);
 		if (err == OK) {
 			resource_state.buffer_manager_initialized = true;
 		} else {
@@ -176,9 +181,14 @@ void RenderResourceOrchestrator::create_gpu_resources_safe() {
 	}
 
 	if (resource_state.buffer_manager.is_valid() && resource_state.buffer_manager_initialized) {
-		RID test_buffer = resource_state.buffer_manager->get_current_read_buffer();
-		if (!test_buffer.is_valid()) {
-			GS_LOG_WARN_DEFAULT("[GPU Buffer] GPU buffer manager initialized without a readable buffer RID");
+		// Validate readiness on the LIVE sort buffers (sort_key + sorted_indices) — NOT on
+		// get_current_read_buffer(), which returns the now-skipped gaussian_buffer. With the
+		// gaussian_buffer gone, keying off it would wrongly mark the (otherwise ready) manager
+		// uninitialized; the manager IS ready as long as its sort buffers exist.
+		const RID sort_key_rid = resource_state.buffer_manager->get_sort_key_buffer();
+		const RID sorted_indices_rid = resource_state.buffer_manager->get_sorted_indices_buffer();
+		if (!sort_key_rid.is_valid() || !sorted_indices_rid.is_valid()) {
+			GS_LOG_WARN_DEFAULT("[GPU Buffer] GPU buffer manager initialized without sort buffers");
 			buffer_manager_ready = false;
 			resource_state.buffer_manager_initialized = false;
 		}

--- a/modules/gaussian_splatting/tests/test_gpu_buffer_manager_lifetime.h
+++ b/modules/gaussian_splatting/tests/test_gpu_buffer_manager_lifetime.h
@@ -42,6 +42,15 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] GPUBufferManager cleanup frees parti
 // reclaim it (~144 B x max_splats x BUFFER_COUNT). The live sort_key/sorted_indices buffers
 // must always remain allocated (the sort pipeline adopts them as external buffers). The
 // default (2-arg initialize) keeps the gaussian_buffer for the legacy painterly + test paths.
+//
+// This case locks the CONTRACT that RenderResourceOrchestrator::create_gpu_resources_safe()
+// depends on: after a flag=false init the readiness check there keys off get_sort_key_buffer()
+// + get_sorted_indices_buffer() (NOT get_current_read_buffer(), which now returns the skipped
+// gaussian_buffer). The assertions below mirror exactly that getter set, so a regression that
+// stopped allocating the sort buffers under flag=false would fail here. The orchestrator-level
+// wiring itself is exercised by the real-game render gate (no sort fallback, byte-identical
+// output); it is not unit-tested because create_gpu_resources_safe() needs the full device/
+// shader/pipeline Dependencies and would only run under [RequiresGPU] anyway.
 TEST_CASE("[GaussianSplatting][RequiresGPU] GPUBufferManager allocate_gaussian_buffer flag gates the dead buffer + memory") {
 	RenderingServer *rs = RenderingServer::get_singleton();
 	if (!rs) {

--- a/modules/gaussian_splatting/tests/test_gpu_buffer_manager_lifetime.h
+++ b/modules/gaussian_splatting/tests/test_gpu_buffer_manager_lifetime.h
@@ -37,6 +37,61 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] GPUBufferManager cleanup frees parti
 	}
 }
 
+// S1: the instance pipeline never samples the GPUBufferManager gaussian_buffer (it binds
+// the instance atlas), so production initializes with allocate_gaussian_buffer=false to
+// reclaim it (~144 B x max_splats x BUFFER_COUNT). The live sort_key/sorted_indices buffers
+// must always remain allocated (the sort pipeline adopts them as external buffers). The
+// default (2-arg initialize) keeps the gaussian_buffer for the legacy painterly + test paths.
+TEST_CASE("[GaussianSplatting][RequiresGPU] GPUBufferManager allocate_gaussian_buffer flag gates the dead buffer + memory") {
+	RenderingServer *rs = RenderingServer::get_singleton();
+	if (!rs) {
+		return; // Skip in headless test mode (tag: [RequiresGPU])
+	}
+	RenderingDevice *rd = rs->create_local_rendering_device();
+	bool owns_rd = true;
+	if (!rd) {
+		rd = rs->get_rendering_device();
+		owns_rd = false;
+	}
+	if (!rd) {
+		return; // Skip in headless test mode (tag: [RequiresGPU])
+	}
+
+	Ref<GPUBufferManager> bm;
+	bm.instantiate();
+	const uint32_t kCap = 4096;
+
+	// Default path (flag defaults true): legacy/manual-upload path allocates everything.
+	REQUIRE(bm->initialize(rd, kCap) == OK);
+	CHECK(bm->get_current_read_buffer().is_valid()); // gaussian_buffer present
+	CHECK(bm->get_current_read_handle().is_valid());
+	CHECK(bm->get_sort_key_buffer().is_valid());
+	CHECK(bm->get_sorted_indices_buffer().is_valid());
+	const float mem_with = bm->get_memory_usage_mb();
+
+	// Instance path (flag=false): gaussian_buffer skipped, live sort buffers kept.
+	REQUIRE(bm->initialize(rd, kCap, /*allocate_gaussian_buffer=*/ false) == OK);
+	CHECK_FALSE(bm->get_current_read_buffer().is_valid()); // gaussian_buffer skipped
+	CHECK_FALSE(bm->get_current_read_handle().is_valid());
+	CHECK(bm->get_sort_key_buffer().is_valid()); // live sort buffers still allocated
+	CHECK(bm->get_sorted_indices_buffer().is_valid());
+	CHECK(bm->get_sort_key_handle().is_valid()); // -> get_sort_external_buffer_state would be valid
+	CHECK(bm->get_sorted_indices_handle().is_valid());
+	const float mem_without = bm->get_memory_usage_mb();
+
+	// The reclaimed amount matches sizeof(PackedGaussian) x kCap x BUFFER_COUNT(2).
+	CHECK(mem_without < mem_with);
+	const float expected_delta_mb = float(uint64_t(sizeof(PackedGaussian)) * kCap * 2u) / (1024.0f * 1024.0f);
+	CHECK(mem_with - mem_without == doctest::Approx(expected_delta_mb).epsilon(0.02));
+
+	// Release the manager (frees its buffers via ~GPUBufferManager) BEFORE deleting the
+	// local device — otherwise the destructor would run cleanup on a freed device.
+	bm.unref();
+	if (owns_rd) {
+		memdelete(rd);
+	}
+}
+
 } // namespace TestGaussianSplatting
 
 #endif // TESTS_ENABLED


### PR DESCRIPTION
## S1 — reclaim the dead GPUBufferManager `gaussian_buffer`

On the instance pipeline (the production path) the `GPUBufferManager.gaussian_buffer`
(144 B × `max_splats` × `BUFFER_COUNT`=2) is allocated but **never read**:
`get_gaussian_buffer`/`upload_gaussian_data` have zero non-test callers and
`current_count` stays 0 in production. It is pure dead VRAM.

### Change
- add an `allocate_gaussian_buffer` flag (default **true** — preserves existing behaviour);
- production (`render_resource_orchestrator`) initialises with the flag **false**;
- **MANDATORY trap handled**: the resource-validity check is redirected off
  `get_current_read_buffer()` (which returns the now-absent `gaussian_buffer`) onto
  the live `sort_key`/`sorted_indices` buffers — otherwise the global sort silently
  falls back to pipeline-local buffers and the win evaporates;
- `get_memory_usage_mb` gates the gaussian term (+ uint64 overflow fix);
  `upload_gaussian_data` is guarded.

### Verification (runtime, real game)
`buffer_manager_memory_mb` **148.77 → 11.44 MiB** at `max_splats`=500K
(exactly 144 × 500K × 2 = −137.3 MiB; **−1373 MiB at 5M**), render **byte-identical**
(visible=8334, no sort fallback). Claude + codex dual-reviewed (codex caught a test
use-after-free — fixed). The `[RequiresGPU]` doctest skips in the degraded
`--gs-gpu-test` context, so verified via the real game instead.

Follow-up (separate): the kept ~12 MiB `sort_key`/`indices` are also unused on the
resident path (it uses pipeline-local sort buffers) — non-blocking.
