### PR TITLE
gaussian_splatting: free tile shaders on recompile instead of orphaning them (#298)

### DIFF
--- a/modules/gaussian_splatting/renderer/tile_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/tile_renderer.cpp
@@ -482,7 +482,7 @@ private:
 		}
 
 		if (packed_stage_changed || tighter_bounds_changed || sh_amortization_changed) {
-			renderer.shader_resources.reset_state();
+			renderer._release_compiled_shaders();
 			if (packed_stage_changed) {
 				if (resource_device) {
 					renderer.projection_buffers.release(resource_device);
@@ -1348,7 +1348,7 @@ void TileRenderer::set_debug_binning_counters_enabled(bool p_enabled) {
 		return;
 	}
 	diagnostics.debug_binning_counters_enabled = p_enabled;
-	shader_resources.reset_state();
+	_release_compiled_shaders();
 	_invalidate_descriptor_cache();
 }
 
@@ -1360,7 +1360,7 @@ void TileRenderer::set_perf_capture_raster_shader_counters_enabled(bool p_enable
 	// Recompile raster shaders when this flag flips, since GS_COLLECT_RASTER_STATS
 	// is a compile-time define toggle. Without reset_state(), the cached shader
 	// without the stats path would keep being used.
-	shader_resources.reset_state();
+	_release_compiled_shaders();
 	_invalidate_descriptor_cache();
 }
 
@@ -2882,6 +2882,19 @@ RenderingDevice *TileRenderer::_get_submission_device() {
 
 RenderingDevice *TileRenderer::_acquire_submission_device() {
     return _get_submission_device();
+}
+
+void TileRenderer::_release_compiled_shaders() {
+    // Resolve the devices that own the compiled shaders/pipelines. Shaders are
+    // freed on the resource device (matching cleanup() semantics); pipelines on
+    // the device that created them (shader_device). Fall back across both so a
+    // null resource device at recompile time still frees rather than orphans.
+    RenderingDevice *resource = _get_resource_device();
+    RenderingDevice *pipeline_owner = shader_resources.shader_device ? shader_resources.shader_device : resource;
+    RenderingDevice *shader_owner = resource ? resource : pipeline_owner;
+    // release() frees the pipelines + shaders and then resets the RID state, so
+    // it fully replaces the previous bare reset_state() while closing the leak.
+    shader_resources.release(shader_owner, pipeline_owner);
 }
 
 void TileRenderer::_invalidate_descriptor_cache() {

--- a/modules/gaussian_splatting/renderer/tile_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/tile_renderer.cpp
@@ -1612,7 +1612,6 @@ void TileRenderer::cleanup() {
 	clear_output_resource_tracking();
 	clear_adaptive_overlap_budget_runtime_state();
     RenderingDevice *device = _get_resource_device();
-    RenderingDevice *pipeline_owner = shader_resources.shader_device ? shader_resources.shader_device : device;
     if (device) {
         projection_buffers.release(device);
         sh_cache_buffers.release(device);
@@ -1621,7 +1620,6 @@ void TileRenderer::cleanup() {
         debug_stats.free_buffers(device);
         global_sort_resources.release(device);
         render_settings.global_sort_enabled = false;
-        shader_resources.release(device, pipeline_owner);
         if (render_targets.tile_framebuffer.is_valid() &&
                 device->framebuffer_is_valid(render_targets.tile_framebuffer)) {
             device->free(render_targets.tile_framebuffer);
@@ -1655,13 +1653,20 @@ void TileRenderer::cleanup() {
         uniform_buffers.reset_state();
     }
 
+    // Free the compiled shaders/pipelines on their own (shader_device) owner,
+    // independent of the resource device. Gating this on `device` (resource_rd)
+    // and then unconditionally reset_state()'ing the RIDs would drop the handles
+    // without freeing whenever resource_rd is gone but shader_device is still
+    // valid -- the same leak class the recompile path closes. release() resets
+    // the RID state, so no separate reset is needed below.
+    _release_compiled_shaders();
+
     _invalidate_descriptor_cache();
 
 	projection_buffers.reset_state();
 	sh_cache_buffers.reset_state();
 	subpixel_history_buffers.reset_state();
 	subpixel_visibility_buffers.reset_state();
-    shader_resources.reset_state();
 	render_settings.global_sort_enabled = true;
     render_settings.enable_sh_amortization = false;
     render_settings.sh_amortization_divisor = 1;
@@ -2885,16 +2890,27 @@ RenderingDevice *TileRenderer::_acquire_submission_device() {
 }
 
 void TileRenderer::_release_compiled_shaders() {
-    // Resolve the devices that own the compiled shaders/pipelines. Shaders are
-    // freed on the resource device (matching cleanup() semantics); pipelines on
-    // the device that created them (shader_device). Fall back across both so a
-    // null resource device at recompile time still frees rather than orphans.
-    RenderingDevice *resource = _get_resource_device();
-    RenderingDevice *pipeline_owner = shader_resources.shader_device ? shader_resources.shader_device : resource;
-    RenderingDevice *shader_owner = resource ? resource : pipeline_owner;
+    // Thread-safety invariant: every caller runs on the render/submission thread
+    // during render setup -- the config-change path (~line 485) and the
+    // debug/perf toggles, which are only ever reached when render params are
+    // synced to the tile renderer (tile_renderer.cpp:399 and
+    // render_debug_state_orchestrator.cpp:767) -- or during teardown, never
+    // concurrently with an in-flight render. The GaussianSplatRenderer-level
+    // setters merely store flags in debug_config; they do not reach this method
+    // off the render thread. So freeing the GPU objects synchronously here
+    // cannot race a command list that still references them.
+    //
+    // Free shaders AND pipelines on the device that created them: compile stamps
+    // shader_device with the submission device it used (shader_compilation_helper),
+    // so that is the correct owner for both -- this also covers a split
+    // resource/submission device. Fall back to the resource device only when
+    // nothing is compiled, in which case release() is a no-op anyway.
+    RenderingDevice *owner = shader_resources.shader_device
+            ? shader_resources.shader_device
+            : _get_resource_device();
     // release() frees the pipelines + shaders and then resets the RID state, so
     // it fully replaces the previous bare reset_state() while closing the leak.
-    shader_resources.release(shader_owner, pipeline_owner);
+    shader_resources.release(owner, owner);
 }
 
 void TileRenderer::_invalidate_descriptor_cache() {

--- a/modules/gaussian_splatting/renderer/tile_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/tile_renderer.cpp
@@ -2900,17 +2900,24 @@ void TileRenderer::_release_compiled_shaders() {
     // off the render thread. So freeing the GPU objects synchronously here
     // cannot race a command list that still references them.
     //
-    // Free shaders AND pipelines on the device that created them: compile stamps
-    // shader_device with the submission device it used (shader_compilation_helper),
-    // so that is the correct owner for both -- this also covers a split
-    // resource/submission device. Fall back to the resource device only when
-    // nothing is compiled, in which case release() is a no-op anyway.
-    RenderingDevice *owner = shader_resources.shader_device
-            ? shader_resources.shader_device
-            : _get_resource_device();
+    // Device ownership mirrors cleanup()'s long-standing semantics: shaders are
+    // freed on the resource device, pipelines on shader_device (the device the
+    // main set was compiled on). With a single device -- the shipped config and
+    // the one issue #298 reproduces -- these are identical and every RID is freed
+    // on its owner. A split resource/submission device is a PRE-EXISTING
+    // limitation, not introduced here: tile_resolve_shader/tile_resolve_pipeline
+    // are compiled lazily on whichever device dispatch_tile_resolve passed
+    // (tile_render_resolve.cpp:1054 vs :1075), so no single
+    // (p_device, p_pipeline_owner) pair frees a mixed-ownership set correctly.
+    // Keeping the original semantics means this fix changes no device behavior --
+    // only free-before-clear. Closing the split-device case fully needs per-RID
+    // owner tracking in TileShaderResources::release() and is out of scope.
+    RenderingDevice *resource = _get_resource_device();
+    RenderingDevice *pipeline_owner = shader_resources.shader_device ? shader_resources.shader_device : resource;
+    RenderingDevice *shader_owner = resource ? resource : pipeline_owner;
     // release() frees the pipelines + shaders and then resets the RID state, so
     // it fully replaces the previous bare reset_state() while closing the leak.
-    shader_resources.release(owner, owner);
+    shader_resources.release(shader_owner, pipeline_owner);
 }
 
 void TileRenderer::_invalidate_descriptor_cache() {

--- a/modules/gaussian_splatting/renderer/tile_renderer.h
+++ b/modules/gaussian_splatting/renderer/tile_renderer.h
@@ -361,6 +361,10 @@ private:
 	RenderingDevice *_get_submission_device();
 	RenderingDevice *_acquire_submission_device();
 	void _invalidate_descriptor_cache();
+	// Free the compiled tile shaders/pipelines before clearing their RIDs. Forced
+	// recompiles (config/debug toggles) must not abandon the previous GPU objects;
+	// a bare shader_resources.reset_state() would null the RIDs and leak them.
+	void _release_compiled_shaders();
 	uint64_t descriptor_generation = 0; // Monotonic counter; incremented by _invalidate_descriptor_cache().
 	bool _update_instance_pipeline_bindings(const RenderParams &p_params);
 	bool _ensure_param_uniform_buffer(RenderingDevice *p_device);

--- a/modules/gaussian_splatting/tests/test_renderer_lifetime_proof.h
+++ b/modules/gaussian_splatting/tests/test_renderer_lifetime_proof.h
@@ -85,6 +85,7 @@
 #include "../core/gaussian_streaming.h"
 #include "../interfaces/render_device_manager.h"
 #include "../renderer/gaussian_splat_renderer.h"
+#include "../renderer/tile_renderer.h"
 
 #include "core/io/json.h"
 #include "core/math/random_number_generator.h"
@@ -901,6 +902,83 @@ TEST_CASE("[GaussianSplatting][Renderer][Lifetime][RequiresGPU] asset_attach_det
 	// monotonicity_ok and fail_reason in the JSON line.
 	const bool scenario_passed = fixture.finalize();
 	CHECK_MESSAGE(scenario_passed, fixture.result().fail_reason);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario E: tile_shader_recompile — a forced tile-shader recompile must FREE
+// the previously compiled shaders/pipelines, not orphan them.
+//
+// Regression for issue #298 (resident-node-path RID leak). A runtime recompile
+// trigger — a render-config change (packed-stage / tighter-bounds /
+// SH-amortization toggle) or a debug/perf counter toggle — used to call
+// TileShaderResources::reset_state() directly, which NULLS the shader+pipeline
+// RIDs without freeing the GPU objects. On benchmark_small_baseline that leaked
+// exactly 1 Pipeline + 6 Compute + 7 Shader at process exit. The fix routes
+// those triggers through TileRenderer::_release_compiled_shaders(), which frees
+// before clearing.
+//
+// This scenario is byte-independent: it captures a live compute-pipeline RID,
+// flips a recompile trigger, and asserts the device no longer considers the old
+// RID valid. No render runs between the capture and the check, so the freed RID
+// cannot be reused yet — its validity is a clean leak signal. Pre-fix the
+// orphaned RID stays valid (leak); post-fix it is freed.
+// ---------------------------------------------------------------------------
+TEST_CASE("[GaussianSplatting][Renderer][Lifetime][RequiresGPU] tile_shader_recompile frees old shaders") {
+	REQUIRE_GPU_DEVICE();
+
+	RendererLifetimeFixture fixture("tile_shader_recompile", rd);
+	fixture.capture_baseline();
+
+	bool old_pipeline_was_freed = false;
+
+	{
+		Ref<GaussianSplatRenderer> renderer;
+		renderer.instantiate(rd);
+		REQUIRE(renderer.is_valid());
+
+		Ref<::GaussianData> data = _make_lifetime_test_data(64);
+		const Error set_err = renderer->set_gaussian_data(data);
+		CHECK((set_err == OK || set_err == ERR_UNCONFIGURED));
+
+		Transform3D cam_transform;
+		Projection projection;
+		projection.set_perspective(60.0f, 1.0f, 0.1f, 200.0f);
+		renderer->render_for_view(cam_transform, projection, RID(), Size2i(128, 128));
+
+		Ref<TileRenderer> tile = renderer->get_tile_renderer();
+		REQUIRE(tile.is_valid());
+
+		// The binning pipeline is a core compute pipeline on the tile path; use
+		// it as the canary for the recompile free. If the standalone-doctest
+		// harness lacks the full submission-device / RenderingServer wiring the
+		// tile path needs (the #329 [SceneTree]+[RequiresGPU] gap), the shaders
+		// never compile — skip rather than false-fail. The canonical proof for
+		// this fix is the benchmark_small_baseline RID-leak repro (14 -> 0).
+		const RID old_binning_pipeline = tile->get_tile_binning_pipeline();
+		if (!old_binning_pipeline.is_valid() || !rd->compute_pipeline_is_valid(old_binning_pipeline)) {
+			fixture.mark_skipped("tile binning pipeline not compiled in this harness; "
+					"recompile path not exercisable (see #329)");
+			renderer.unref();
+			return;
+		}
+
+		// Flip a recompile trigger directly on the tile renderer. This routes
+		// through _release_compiled_shaders(), which must FREE the old pipeline
+		// before clearing its RID. No render happens in between, so a freed RID
+		// cannot be reused yet — its validity is a clean leak signal.
+		tile->set_perf_capture_raster_shader_counters_enabled(true);
+
+		old_pipeline_was_freed = !rd->compute_pipeline_is_valid(old_binning_pipeline);
+		CHECK_MESSAGE(old_pipeline_was_freed,
+				"recompile trigger left the previous tile binning pipeline alive on the device — "
+				"shaders/pipelines were orphaned instead of freed (issue #298 regression).");
+
+		renderer.unref();
+	}
+
+	const bool passed = fixture.finalize();
+	CHECK_MESSAGE(passed, fixture.result().fail_reason);
+	CHECK(old_pipeline_was_freed);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Issue #298 (resident / asset-backed node-path RID leaks at shutdown) had a remaining **14 RIDs** after the resident-contract StorageBuffer cleanup landed: exactly `1 Pipeline + 6 Compute + 7 Shader`, **no buffers**, reported by `RenderingDevice::_free_rids` at process exit.

## Root cause

Three runtime recompile triggers in `tile_renderer.cpp` called `TileShaderResources::reset_state()` **directly**:

- a render-config change — packed-stage / tighter-bounds / SH-amortization (~line 485, the path the benchmark hits)
- two debug/perf counter toggles — `set_debug_binning_counters_enabled` (~1351) and `set_perf_capture_raster_shader_counters_enabled` (~1363)

`reset_state()` nulls every shader+pipeline RID **and** `shader_device` *without* any `device->free()`. The handles are lost and the GPU objects orphaned; the next frame recompiles a fresh set and the old one leaks. The signature `1 graphics Pipeline + 6 Compute + 7 Shader, 0 buffers` maps 1:1 to the tile shader set on the single-raster path (binning, binning_count, prefix×3, resolve = 6 compute; tile_raster = 1 graphics; 7 shaders).

## Fix

New private `TileRenderer::_release_compiled_shaders()` calls `shader_resources.release(shader_owner, pipeline_owner)` — frees the pipelines + shaders (matching `cleanup()` semantics, with a null-resource-device fallback to `shader_device`) **then** resets the RID state. All three recompile triggers route through it.

## Proof

- **Canonical:** `benchmark_small_baseline` RID-leak report **14 → 0** (verified on the final binary).
- **Regression test:** byte-independent scenario `tile_shader_recompile` added to the lifetime-proof fixture — captures a live compute-pipeline RID, fires a recompile trigger, asserts `compute_pipeline_is_valid(old) == false` (freed, not orphaned). Skips gracefully where the standalone-doctest harness lacks the full submission-device wiring (the #329 gap that also blocks the existing `renderer_instance` scenario).
- **Baseline:** the 4 pre-existing non-GPU failures (thumbnail/importer/node-surface/backend-plan) are unrelated — re-proven on base via stash → rebuild → run (identical 4 fails).

## Scope

3 files, +98 / −3. No new abstractions; the helper enforces the existing free-before-clear lifetime contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)