### PR TITLE
ci(agentic): guard self-hosted runners against untrusted fork PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -60,18 +60,19 @@ of public-alpha signoff.
 
 The self-hosted Windows/GPU runners are persistent and must never execute
 untrusted code from a fork pull request. All four workflows that use the
-self-hosted lane apply the same guard so that fork PRs are skipped on the
-self-hosted jobs while same-repo (maintainer) PRs, `push`, `schedule`,
-`workflow_dispatch`, and `merge_group` continue to run:
+self-hosted lane carry a fork guard so that fork PRs are skipped on the self-hosted
+jobs. Three of them use the guard below, which still lets **same-repo** (maintainer)
+PRs run the self-hosted job; `push`, `schedule`, `workflow_dispatch`, and
+`merge_group` also run:
 
 ```yaml
 if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 ```
 
-- `baseline_qa.yml` — `gpu-tests`, `gpu-harness` guarded.
-- `release_builds.yml` — `build_windows` guarded.
-- `gaussian_production_gates.yml` — `guards` and `module-validation` guarded.
-- `gaussian_shader_validation.yml` — `shader-validation` guarded.
+- `baseline_qa.yml` — `gpu-tests`, `gpu-harness` guarded (form above).
+- `gaussian_production_gates.yml` — `guards` and `module-validation` guarded (form above).
+- `gaussian_shader_validation.yml` — `shader-validation` guarded (form above).
+- `release_builds.yml` — `build_windows` uses the **stricter** `if: github.event_name != 'pull_request'`, which skips **all** pull requests (fork *and* same-repo); the Windows release lane runs on `push`/tag/schedule/dispatch only, not on PRs.
 
 `pull_request_target` is not used by any workflow, so fork PRs never get a
 privileged checkout. With the self-hosted lanes skipped on fork PRs, the fork-safe
@@ -84,7 +85,8 @@ before (or with) relying on this boundary. Note also that `baseline_qa.yml`'s Li
 (`if: github.event_name != 'pull_request'`), so it does **not** gate fork PRs.
 GPU/Windows validation of an external contribution happens only after a maintainer
 moves the change onto a same-repo branch. Any change that relaxes this boundary must
-be documented here and in `docs/governance/review-policy.md`.
+be documented here and in the review policy (`docs/governance/review-policy.md`,
+added by a sibling PR in this foundation series).
 
 ## Scheduled Triggers
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -77,18 +77,14 @@ if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.r
 - `release_builds.yml` — `build_windows` uses the **stricter** `if: github.event_name != 'pull_request'`, which skips **all** pull requests (fork *and* same-repo); the Windows release lane runs on `push`/tag/schedule/dispatch only, not on PRs.
 
 `pull_request_target` is not used by any workflow, so fork PRs never get a
-privileged checkout. With the self-hosted lanes skipped on fork PRs, the fork-safe
-GitHub-hosted blocking signal is the `agentic-pr-gate` check
-(`.github/workflows/agentic_pr_gate.yml`), added by a sibling PR in this
-agentic-foundation series. **Until that gate workflow is merged, fork PRs touching
-only these guarded workflows have no GitHub-hosted blocking gate** — merge the gate
-before (or with) relying on this boundary. Note also that `baseline_qa.yml`'s Linux
-`cpu-tests` job deliberately skips pull requests
-(`if: github.event_name != 'pull_request'`), so it does **not** gate fork PRs.
-GPU/Windows validation of an external contribution happens only after a maintainer
-moves the change onto a same-repo branch. Any change that relaxes this boundary must
-be documented here and in the review policy (`docs/governance/review-policy.md`,
-added by a sibling PR in this foundation series).
+privileged checkout. The security model is simply that **untrusted (fork) code never
+runs on the persistent self-hosted runners**: fork PRs and `merge_group` runs are
+skipped on the self-hosted lanes, and there is no fallback that executes their code
+on the runner (`baseline_qa.yml`'s Linux `cpu-tests` also skips pull requests). Fork
+PRs are therefore not "blocked then run elsewhere" — their GPU/Windows validation
+happens only after a maintainer reviews the change and moves it onto a same-repo
+branch. Any change that relaxes this boundary must be documented here and in the
+review policy (`docs/governance/review-policy.md`).
 
 ## Scheduled Triggers
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -62,8 +62,10 @@ The self-hosted Windows/GPU runners are persistent and must never execute
 untrusted code from a fork pull request. All four workflows that use the
 self-hosted lane carry a fork guard so that fork PRs are skipped on the self-hosted
 jobs. Three of them use the guard below, which still lets **same-repo** (maintainer)
-PRs run the self-hosted job; `push`, `schedule`, `workflow_dispatch`, and
-`merge_group` also run:
+PRs run the self-hosted job; `push`, `schedule`, and `workflow_dispatch` also run.
+**`merge_group` is excluded from the self-hosted lanes** — a merge-queue run builds
+a temporary branch containing the queued PR's code, which for a queued fork PR would
+otherwise run on the runner; the GitHub-hosted `agentic-pr-gate` covers `merge_group`:
 
 ```yaml
 if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -59,32 +59,33 @@ of public-alpha signoff.
 ## Runner Trust Boundary (fork PRs)
 
 The self-hosted Windows/GPU runners are persistent and must never execute
-untrusted code from a fork pull request. All four workflows that use the
-self-hosted lane carry a fork guard so that fork PRs are skipped on the self-hosted
-jobs. Three of them use the guard below, which still lets **same-repo** (maintainer)
-PRs run the self-hosted job; `push`, `schedule`, and `workflow_dispatch` also run.
-**`merge_group` is excluded from the self-hosted lanes** — a merge-queue run builds
-a temporary branch containing the queued PR's code, which for a queued fork PR would
-otherwise run on the runner; the GitHub-hosted `agentic-pr-gate` covers `merge_group`:
+untrusted code from a **fork pull request**. The self-hosted jobs carry a fork guard
+so fork PRs are skipped on those runners, while same-repo (maintainer) PRs, `push`,
+and `workflow_dispatch` still run:
 
 ```yaml
-if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name != 'merge_group' }}
+if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 ```
 
-- `baseline_qa.yml` — `gpu-tests`, `gpu-harness` guarded (form above).
-- `gaussian_production_gates.yml` — `guards` and `module-validation` guarded (form above).
-- `gaussian_shader_validation.yml` — `shader-validation` guarded (form above).
-- `release_builds.yml` — `build_windows` uses the **stricter** `if: github.event_name != 'pull_request'`, which skips **all** pull requests (fork *and* same-repo); the Windows release lane runs on `push`/tag/schedule/dispatch only, not on PRs.
+- `baseline_qa.yml` — `gpu-tests`, `gpu-harness` (form above).
+- `gaussian_production_gates.yml` — `guards`, `module-validation` (form above).
+- `gaussian_shader_validation.yml` — `shader-validation` (form above).
+- `release_builds.yml` — `build_windows` uses the **stricter** `if: github.event_name != 'pull_request'`, which skips **all** pull requests (fork *and* same-repo); the Windows release lane runs on `push`/tag/schedule/dispatch only.
 
-`pull_request_target` is not used by any workflow, so fork PRs never get a
-privileged checkout. The security model is simply that **untrusted (fork) code never
-runs on the persistent self-hosted runners**: fork PRs and `merge_group` runs are
-skipped on the self-hosted lanes, and there is no fallback that executes their code
-on the runner (`baseline_qa.yml`'s Linux `cpu-tests` also skips pull requests). Fork
-PRs are therefore not "blocked then run elsewhere" — their GPU/Windows validation
-happens only after a maintainer reviews the change and moves it onto a same-repo
-branch. Any change that relaxes this boundary must be documented here and in the
-review policy (`docs/governance/review-policy.md`).
+`pull_request_target` is not used by any workflow, so fork PRs never get a privileged
+checkout. A fork PR's GPU/Windows validation happens only after a maintainer reviews
+the change and moves it onto a same-repo branch.
+
+**Merge queue (`merge_group`).** These workflows also trigger on `merge_group`, where
+the self-hosted jobs run. Only users with write access can add a PR to the merge
+queue, so queued content is **maintainer-gated**: a queued fork PR's code would run on
+the self-hosted runner, which is an accepted maintainer-gated property (the same trust
+as merging). Restricting `merge_group` to same-repo-only queued PRs via a head-repo
+preflight is a possible future hardening; it is out of scope here, which keeps this
+change focused on the fork-`pull_request` boundary.
+
+Any change that relaxes this boundary must be documented here and in the review
+policy (`docs/governance/review-policy.md`).
 
 ## Scheduled Triggers
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -76,8 +76,11 @@ if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.re
 `pull_request_target` is not used by any workflow, so fork PRs never get a
 privileged checkout. With the self-hosted lanes skipped on fork PRs, the fork-safe
 GitHub-hosted blocking signal is the `agentic-pr-gate` check
-(`.github/workflows/agentic_pr_gate.yml`), added by this agentic-foundation series.
-Note that `baseline_qa.yml`'s Linux `cpu-tests` job deliberately skips pull requests
+(`.github/workflows/agentic_pr_gate.yml`), added by a sibling PR in this
+agentic-foundation series. **Until that gate workflow is merged, fork PRs touching
+only these guarded workflows have no GitHub-hosted blocking gate** — merge the gate
+before (or with) relying on this boundary. Note also that `baseline_qa.yml`'s Linux
+`cpu-tests` job deliberately skips pull requests
 (`if: github.event_name != 'pull_request'`), so it does **not** gate fork PRs.
 GPU/Windows validation of an external contribution happens only after a maintainer
 moves the change onto a same-repo branch. Any change that relaxes this boundary must

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -84,8 +84,8 @@ as merging). Restricting `merge_group` to same-repo-only queued PRs via a head-r
 preflight is a possible future hardening; it is out of scope here, which keeps this
 change focused on the fork-`pull_request` boundary.
 
-Any change that relaxes this boundary must be documented here and in the review
-policy (`docs/governance/review-policy.md`).
+Any change that relaxes this boundary must be documented here and approved by a
+maintainer (see the project governance docs under `docs/governance/`).
 
 ## Scheduled Triggers
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -59,7 +59,7 @@ of public-alpha signoff.
 ## Runner Trust Boundary (fork PRs)
 
 The self-hosted Windows/GPU runners are persistent and must never execute
-untrusted code from a fork pull request. All three workflows that use the
+untrusted code from a fork pull request. All four workflows that use the
 self-hosted lane apply the same guard so that fork PRs are skipped on the
 self-hosted jobs while same-repo (maintainer) PRs, `push`, `schedule`,
 `workflow_dispatch`, and `merge_group` continue to run:
@@ -71,6 +71,7 @@ if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.re
 - `baseline_qa.yml` — `gpu-tests`, `gpu-harness` guarded.
 - `release_builds.yml` — `build_windows` guarded.
 - `gaussian_production_gates.yml` — `guards` and `module-validation` guarded.
+- `gaussian_shader_validation.yml` — `shader-validation` guarded.
 
 `pull_request_target` is not used by any workflow, so fork PRs never get a
 privileged checkout. Fork PRs still receive a fork-safe blocking signal from

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -56,6 +56,29 @@ repo does not track a qlty configuration/log contract. If branch protection
 later requires qlty, update the manifest before treating a qlty result as part
 of public-alpha signoff.
 
+## Runner Trust Boundary (fork PRs)
+
+The self-hosted Windows/GPU runners are persistent and must never execute
+untrusted code from a fork pull request. All three workflows that use the
+self-hosted lane apply the same guard so that fork PRs are skipped on the
+self-hosted jobs while same-repo (maintainer) PRs, `push`, `schedule`,
+`workflow_dispatch`, and `merge_group` continue to run:
+
+```yaml
+if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+```
+
+- `baseline_qa.yml` — `gpu-tests`, `gpu-harness` guarded.
+- `release_builds.yml` — `build_windows` guarded.
+- `gaussian_production_gates.yml` — `guards` and `module-validation` guarded.
+
+`pull_request_target` is not used by any workflow, so fork PRs never get a
+privileged checkout. Fork PRs still receive a fork-safe blocking signal from
+GitHub-hosted lanes (e.g. `baseline_qa.yml`'s Linux `cpu-tests`); GPU/Windows
+validation of an external contribution happens only after a maintainer moves the
+change onto a same-repo branch. Any change that relaxes this boundary must be
+documented here and in `docs/governance/review-policy.md`.
+
 ## Scheduled Triggers
 
 | Workflow | Schedule (UTC) | Behavior |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -68,7 +68,7 @@ a temporary branch containing the queued PR's code, which for a queued fork PR w
 otherwise run on the runner; the GitHub-hosted `agentic-pr-gate` covers `merge_group`:
 
 ```yaml
-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name != 'merge_group' }}
 ```
 
 - `baseline_qa.yml` — `gpu-tests`, `gpu-harness` guarded (form above).

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -74,11 +74,14 @@ if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.re
 - `gaussian_shader_validation.yml` — `shader-validation` guarded.
 
 `pull_request_target` is not used by any workflow, so fork PRs never get a
-privileged checkout. Fork PRs still receive a fork-safe blocking signal from
-GitHub-hosted lanes (e.g. `baseline_qa.yml`'s Linux `cpu-tests`); GPU/Windows
-validation of an external contribution happens only after a maintainer moves the
-change onto a same-repo branch. Any change that relaxes this boundary must be
-documented here and in `docs/governance/review-policy.md`.
+privileged checkout. With the self-hosted lanes skipped on fork PRs, the fork-safe
+GitHub-hosted blocking signal is the `agentic-pr-gate` check
+(`.github/workflows/agentic_pr_gate.yml`), added by this agentic-foundation series.
+Note that `baseline_qa.yml`'s Linux `cpu-tests` job deliberately skips pull requests
+(`if: github.event_name != 'pull_request'`), so it does **not** gate fork PRs.
+GPU/Windows validation of an external contribution happens only after a maintainer
+moves the change onto a same-repo branch. Any change that relaxes this boundary must
+be documented here and in `docs/governance/review-policy.md`.
 
 ## Scheduled Triggers
 

--- a/.github/workflows/baseline_qa.yml
+++ b/.github/workflows/baseline_qa.yml
@@ -67,7 +67,9 @@ jobs:
     # and protects the persistent runner's scons cache, credential store,
     # and Actions runner token from arbitrary code in `tests/ci/*.py`,
     # `SConstruct`, `methods.py`, or any `SCsub` checked out from a fork.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # merge_group is skipped too: a merge-queue run builds the queued PR's code,
+    # which for a queued fork PR would otherwise run on the self-hosted runner.
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name != 'merge_group'
     runs-on: [self-hosted, Windows, X64, godotgs, gpu]
     timeout-minutes: 120
 
@@ -214,9 +216,11 @@ jobs:
     name: GPU Harness + Visual Gate (Windows Self-Hosted)
     # Same fork-PR gate as gpu-tests — never let an untrusted fork PR's
     # workflow files, SConstruct, methods.py, or test code run on the
-    # persistent self-hosted runner.
+    # persistent self-hosted runner. merge_group is skipped too (a queued fork
+    # PR's code would otherwise build here).
     if: |
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      github.event_name != 'merge_group' &&
       !cancelled()
     runs-on: [self-hosted, Windows, X64, godotgs, gpu]
     # Runs after gpu-tests so the two GPU jobs serialize on the shared runner

--- a/.github/workflows/baseline_qa.yml
+++ b/.github/workflows/baseline_qa.yml
@@ -67,9 +67,7 @@ jobs:
     # and protects the persistent runner's scons cache, credential store,
     # and Actions runner token from arbitrary code in `tests/ci/*.py`,
     # `SConstruct`, `methods.py`, or any `SCsub` checked out from a fork.
-    # merge_group is skipped too: a merge-queue run builds the queued PR's code,
-    # which for a queued fork PR would otherwise run on the self-hosted runner.
-    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name != 'merge_group'
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, Windows, X64, godotgs, gpu]
     timeout-minutes: 120
 
@@ -216,11 +214,9 @@ jobs:
     name: GPU Harness + Visual Gate (Windows Self-Hosted)
     # Same fork-PR gate as gpu-tests — never let an untrusted fork PR's
     # workflow files, SConstruct, methods.py, or test code run on the
-    # persistent self-hosted runner. merge_group is skipped too (a queued fork
-    # PR's code would otherwise build here).
+    # persistent self-hosted runner.
     if: |
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      github.event_name != 'merge_group' &&
       !cancelled()
     runs-on: [self-hosted, Windows, X64, godotgs, gpu]
     # Runs after gpu-tests so the two GPU jobs serialize on the shared runner

--- a/.github/workflows/gaussian_production_gates.yml
+++ b/.github/workflows/gaussian_production_gates.yml
@@ -95,7 +95,10 @@ jobs:
     # persistent runner's scons cache, credential store, and Actions runner
     # token from arbitrary code in `tests/ci/*.py`, `SConstruct`, `methods.py`,
     # or any `SCsub` checked out from a fork.
-    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && (inputs.run_openworld_proof_dev == true || inputs.run_openworld_proof_weekly == true)) }}
+    # merge_group is also skipped: a merge-queue run builds a temporary branch
+    # containing the queued PR's code, which for a queued fork PR would run on the
+    # self-hosted runner; the GitHub-hosted Agentic PR Gate covers merge_group.
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name != 'merge_group' && github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && (inputs.run_openworld_proof_dev == true || inputs.run_openworld_proof_weekly == true)) }}
     runs-on: [self-hosted, Windows, X64, godotgs]
     timeout-minutes: 10
     defaults:
@@ -230,7 +233,8 @@ jobs:
     # fork PR code (SConstruct, methods.py, tests/ci/*.py, SCsub) on the
     # persistent self-hosted Windows + GPU runner. `needs: guards` already
     # cascades the skip, but the explicit guard keeps each job self-describing.
-    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && (inputs.run_openworld_proof_dev == true || inputs.run_openworld_proof_weekly == true)) }}
+    # merge_group is skipped too (a queued fork PR's code would otherwise build here).
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name != 'merge_group' && github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && (inputs.run_openworld_proof_dev == true || inputs.run_openworld_proof_weekly == true)) }}
     runs-on: [self-hosted, Windows, X64, godotgs, gpu]
     needs:
       - guards

--- a/.github/workflows/gaussian_production_gates.yml
+++ b/.github/workflows/gaussian_production_gates.yml
@@ -89,16 +89,13 @@ jobs:
   guards:
     name: Guards (Render Path + Static Safety)
     # Never run self-hosted Windows on untrusted fork PR code. Same-repo
-    # branches (maintainer PRs) still trigger the gate; fork PRs are routed to
-    # the fork-safe ubuntu-latest "Agentic PR Gate" instead. Mirrors the guard
-    # already used in baseline_qa.yml / release_builds.yml and protects the
-    # persistent runner's scons cache, credential store, and Actions runner
-    # token from arbitrary code in `tests/ci/*.py`, `SConstruct`, `methods.py`,
-    # or any `SCsub` checked out from a fork.
-    # merge_group is also skipped: a merge-queue run builds a temporary branch
-    # containing the queued PR's code, which for a queued fork PR would run on the
-    # self-hosted runner; the GitHub-hosted Agentic PR Gate covers merge_group.
-    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name != 'merge_group' && github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && (inputs.run_openworld_proof_dev == true || inputs.run_openworld_proof_weekly == true)) }}
+    # branches (maintainer PRs) still trigger the gate; fork PRs are skipped.
+    # Mirrors the guard already used in baseline_qa.yml / release_builds.yml and
+    # protects the persistent runner's scons cache, credential store, and Actions
+    # runner token from arbitrary code in `tests/ci/*.py`, `SConstruct`,
+    # `methods.py`, or any `SCsub` checked out from a fork. (merge_group is
+    # maintainer-gated — see the README runner trust boundary.)
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && (inputs.run_openworld_proof_dev == true || inputs.run_openworld_proof_weekly == true)) }}
     runs-on: [self-hosted, Windows, X64, godotgs]
     timeout-minutes: 10
     defaults:
@@ -131,11 +128,7 @@ jobs:
 
   gpu-evidence-requirement:
     name: GPU Evidence Requirement
-    # Skip merge_group explicitly. This job only decides whether the self-hosted GPU
-    # lane is needed; both `guards` and `module-validation` skip merge_group, so the
-    # whole production gate is a consistent no-op on merge-queue runs (rather than
-    # this job being silently skipped because `needs: guards` was skipped).
-    if: ${{ github.event_name != 'merge_group' && github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && (inputs.run_openworld_proof_dev == true || inputs.run_openworld_proof_weekly == true)) }}
+    if: ${{ github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && (inputs.run_openworld_proof_dev == true || inputs.run_openworld_proof_weekly == true)) }}
     runs-on: ubuntu-latest
     needs: guards
     outputs:
@@ -237,8 +230,7 @@ jobs:
     # fork PR code (SConstruct, methods.py, tests/ci/*.py, SCsub) on the
     # persistent self-hosted Windows + GPU runner. `needs: guards` already
     # cascades the skip, but the explicit guard keeps each job self-describing.
-    # merge_group is skipped too (a queued fork PR's code would otherwise build here).
-    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name != 'merge_group' && github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && (inputs.run_openworld_proof_dev == true || inputs.run_openworld_proof_weekly == true)) }}
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && (inputs.run_openworld_proof_dev == true || inputs.run_openworld_proof_weekly == true)) }}
     runs-on: [self-hosted, Windows, X64, godotgs, gpu]
     needs:
       - guards

--- a/.github/workflows/gaussian_production_gates.yml
+++ b/.github/workflows/gaussian_production_gates.yml
@@ -88,7 +88,14 @@ env:
 jobs:
   guards:
     name: Guards (Render Path + Static Safety)
-    if: ${{ github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && (inputs.run_openworld_proof_dev == true || inputs.run_openworld_proof_weekly == true)) }}
+    # Never run self-hosted Windows on untrusted fork PR code. Same-repo
+    # branches (maintainer PRs) still trigger the gate; fork PRs are routed to
+    # the fork-safe ubuntu-latest "Agentic PR Gate" instead. Mirrors the guard
+    # already used in baseline_qa.yml / release_builds.yml and protects the
+    # persistent runner's scons cache, credential store, and Actions runner
+    # token from arbitrary code in `tests/ci/*.py`, `SConstruct`, `methods.py`,
+    # or any `SCsub` checked out from a fork.
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && (inputs.run_openworld_proof_dev == true || inputs.run_openworld_proof_weekly == true)) }}
     runs-on: [self-hosted, Windows, X64, godotgs]
     timeout-minutes: 10
     defaults:
@@ -219,7 +226,11 @@ jobs:
 
   module-validation:
     name: Module Build + Runtime Harness (Windows Self-Hosted)
-    if: ${{ github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && (inputs.run_openworld_proof_dev == true || inputs.run_openworld_proof_weekly == true)) }}
+    # Same fork-PR guard as the guards job above: never build/run untrusted
+    # fork PR code (SConstruct, methods.py, tests/ci/*.py, SCsub) on the
+    # persistent self-hosted Windows + GPU runner. `needs: guards` already
+    # cascades the skip, but the explicit guard keeps each job self-describing.
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && (inputs.run_openworld_proof_dev == true || inputs.run_openworld_proof_weekly == true)) }}
     runs-on: [self-hosted, Windows, X64, godotgs, gpu]
     needs:
       - guards

--- a/.github/workflows/gaussian_production_gates.yml
+++ b/.github/workflows/gaussian_production_gates.yml
@@ -131,7 +131,11 @@ jobs:
 
   gpu-evidence-requirement:
     name: GPU Evidence Requirement
-    if: ${{ github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && (inputs.run_openworld_proof_dev == true || inputs.run_openworld_proof_weekly == true)) }}
+    # Skip merge_group explicitly. This job only decides whether the self-hosted GPU
+    # lane is needed; both `guards` and `module-validation` skip merge_group, so the
+    # whole production gate is a consistent no-op on merge-queue runs (rather than
+    # this job being silently skipped because `needs: guards` was skipped).
+    if: ${{ github.event_name != 'merge_group' && github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && (inputs.run_openworld_proof_dev == true || inputs.run_openworld_proof_weekly == true)) }}
     runs-on: ubuntu-latest
     needs: guards
     outputs:

--- a/.github/workflows/gaussian_shader_validation.yml
+++ b/.github/workflows/gaussian_shader_validation.yml
@@ -38,13 +38,12 @@ jobs:
   shader-validation:
     name: Runtime Shader Matrix + Contracts
     # Never run self-hosted Windows on untrusted fork PR code. Same-repo branches
-    # (maintainer PRs), push, and workflow_dispatch still run; fork PRs are skipped
-    # and get their signal from the GitHub-hosted Agentic PR Gate. merge_group is
-    # also skipped: a merge-queue run builds the queued PR's code, which for a queued
-    # fork PR would run on the self-hosted runner. Mirrors the guard used in
-    # gaussian_production_gates.yml and protects the persistent runner from arbitrary
-    # checked-out repo code (compile_shaders.py and anything under modules/.../shaders).
-    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name != 'merge_group' }}
+    # (maintainer PRs), push, and workflow_dispatch still run; fork PRs are skipped.
+    # Mirrors the guard used in gaussian_production_gates.yml and protects the
+    # persistent runner from arbitrary checked-out repo code (compile_shaders.py and
+    # anything under modules/.../shaders). (merge_group is maintainer-gated — see the
+    # runner trust boundary in .github/workflows/README.md.)
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: [self-hosted, Windows, X64, godotgs]
     timeout-minutes: 20
     env:

--- a/.github/workflows/gaussian_shader_validation.yml
+++ b/.github/workflows/gaussian_shader_validation.yml
@@ -38,12 +38,13 @@ jobs:
   shader-validation:
     name: Runtime Shader Matrix + Contracts
     # Never run self-hosted Windows on untrusted fork PR code. Same-repo branches
-    # (maintainer PRs), push, workflow_dispatch, and merge_group still run; fork PRs
-    # are skipped and get their signal from the GitHub-hosted Agentic PR Gate.
-    # Mirrors baseline_qa.yml / release_builds.yml / gaussian_production_gates.yml
-    # and protects the persistent runner from arbitrary checked-out repo code
-    # (compile_shaders.py and anything under modules/.../shaders).
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    # (maintainer PRs), push, and workflow_dispatch still run; fork PRs are skipped
+    # and get their signal from the GitHub-hosted Agentic PR Gate. merge_group is
+    # also skipped: a merge-queue run builds the queued PR's code, which for a queued
+    # fork PR would run on the self-hosted runner. Mirrors the guard used in
+    # gaussian_production_gates.yml and protects the persistent runner from arbitrary
+    # checked-out repo code (compile_shaders.py and anything under modules/.../shaders).
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event_name != 'merge_group' }}
     runs-on: [self-hosted, Windows, X64, godotgs]
     timeout-minutes: 20
     env:

--- a/.github/workflows/gaussian_shader_validation.yml
+++ b/.github/workflows/gaussian_shader_validation.yml
@@ -37,6 +37,13 @@ concurrency:
 jobs:
   shader-validation:
     name: Runtime Shader Matrix + Contracts
+    # Never run self-hosted Windows on untrusted fork PR code. Same-repo branches
+    # (maintainer PRs), push, workflow_dispatch, and merge_group still run; fork PRs
+    # are skipped and get their signal from the GitHub-hosted Agentic PR Gate.
+    # Mirrors baseline_qa.yml / release_builds.yml / gaussian_production_gates.yml
+    # and protects the persistent runner from arbitrary checked-out repo code
+    # (compile_shaders.py and anything under modules/.../shaders).
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: [self-hosted, Windows, X64, godotgs]
     timeout-minutes: 20
     env:


### PR DESCRIPTION
## Summary

Closes a confirmed runner-security gap: `gaussian_production_gates.yml` ran its
self-hosted Windows `guards` job and self-hosted Windows+GPU `module-validation`
job on every `pull_request` event **with no fork-trust guard**, so a fork PR
matching the path filter could execute arbitrary checked-out code (`SConstruct`,
`methods.py`, `tests/ci/*.py`, `SCsub`) on the persistent runner. `baseline_qa.yml`
and `release_builds.yml` already block fork PRs from their self-hosted jobs; this
aligns the third workflow with that established guard.

## Risk class

R3 (release/security workflow surface).

## Base / head

- Base: `master` (`b810f19ac0`)
- This is the first of a 5-PR agentic-engineering foundation series. Independent of the others.

## Changes

- Add `head.repo.full_name == github.repository` fork guard to the `guards` and
  `module-validation` `if:` conditions (ANDed with the existing event gate).
- Document the runner trust boundary across all three self-hosted workflows in
  `.github/workflows/README.md`.

## Validation

- `python tests/ci/validate_automation.py --contracts-only` → PASS (workflow YAML valid).
- Parsed `gaussian_production_gates.yml`; both self-hosted jobs report `fork-guarded: True`.

## User-visible behavior / Godot upstream delta

None. Only workflow config + docs; no C++/GLSL/GDScript touched.

## Rollback

Revert the single commit; restores prior workflow behavior exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
