### PR TITLE
docs(agentic): hierarchical AGENTS.md and governance docs

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md — `.github/workflows`
+
+Refines the root [`AGENTS.md`](../../AGENTS.md) for CI workflows. Workflow changes
+that affect gates, runners, or the trust boundary are **risk class R3** and need
+maintainer (CODEOWNER) review. Read `README.md` in this directory for the current
+workflow inventory and the runner trust policy.
+
+## Security rules (non-negotiable)
+
+- **Least privilege.** Every workflow sets explicit `permissions:`; default to
+  `contents: read` and add scopes only as needed.
+- **No untrusted code on persistent self-hosted runners.** Self-hosted Windows/GPU
+  jobs must carry the fork guard
+  `github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository`
+  so fork PRs are skipped. Fork PRs get their signal from GitHub-hosted lanes.
+- **Never use `pull_request_target` to check out fork code with a privileged
+  token or secrets.** If you think you need it, you don't — stop and ask a
+  maintainer.
+- **Fail closed.** When the trust level of an event is unclear, do not run the
+  privileged/self-hosted path.
+
+## Gate rules
+
+- A required gate must **always report a terminal status** (no path filter that
+  silently skips it into a missing-required-check state). The fork-safe required
+  gate is `agentic_pr_gate.yml` (`ubuntu-latest`, check name
+  `Agentic PR Gate / required`).
+- Do not weaken or remove an existing guard, runtime gate, or release gate to make
+  a PR pass.
+
+## Process rules
+
+- Keep `README.md` in sync: workflow count, triggers, schedules, and the runner
+  trust policy. Validate YAML parses (`python tests/ci/validate_automation.py
+  --contracts-only`).
+- **Any change that relaxes the trust boundary or downgrades a gate must be
+  documented** here, in `README.md`, and in `docs/governance/review-policy.md`,
+  and explicitly approved by a human maintainer.

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -24,7 +24,9 @@ workflow inventory and the runner trust policy.
 - A required gate must **always report a terminal status** (no path filter that
   silently skips it into a missing-required-check state). The fork-safe required
   gate is `agentic_pr_gate.yml` (`ubuntu-latest`, check name
-  `Agentic PR Gate / required`).
+  `Agentic PR Gate / required`), added by a sibling PR in this foundation series.
+  Do not mark its check required in branch protection until that workflow is
+  merged (see `docs/governance/github-settings.md`).
 - Do not weaken or remove an existing guard, runtime gate, or release gate to make
   a PR pass.
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -12,7 +12,10 @@ workflow inventory and the runner trust policy.
 - **No untrusted code on persistent self-hosted runners.** Self-hosted Windows/GPU
   jobs must carry the fork guard
   `github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository`
-  so fork PRs are skipped. Fork PRs get their signal from GitHub-hosted lanes.
+  so fork PRs are skipped. This is the required standard; the agentic-foundation
+  series brings all self-hosted workflows under it, so verify a given job actually
+  carries the guard rather than assuming universal coverage. Fork PRs get their
+  blocking signal from the GitHub-hosted `agentic-pr-gate` check.
 - **Never use `pull_request_target` to check out fork code with a privileged
   token or secrets.** If you think you need it, you don't — stop and ask a
   maintainer.
@@ -23,10 +26,10 @@ workflow inventory and the runner trust policy.
 
 - A required gate must **always report a terminal status** (no path filter that
   silently skips it into a missing-required-check state). The fork-safe required
-  gate is `agentic_pr_gate.yml` (`ubuntu-latest`, check name
-  `Agentic PR Gate / required`), added by a sibling PR in this foundation series.
-  Do not mark its check required in branch protection until that workflow is
-  merged (see `docs/governance/github-settings.md`).
+  gate is `agentic_pr_gate.yml` (`ubuntu-latest`); its required status check is the
+  job name `agentic-pr-gate`. It is added by a sibling PR in this foundation series;
+  do not mark its check required in branch protection until that workflow is merged
+  (see `docs/governance/github-settings.md`).
 - Do not weaken or remove an existing guard, runtime gate, or release gate to make
   a PR pass.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md — GodotGS
+
+Instructions for any AI coding agent (and any human) working in this repository.
+Keep it short; deeper rules live in the linked canonical docs and in the nested
+`AGENTS.md` files closer to the code.
+
+GodotGS is a **fork of the Godot engine**. Almost all project-specific work lives
+under `modules/gaussian_splatting/`. Treat everything else as upstream Godot.
+
+## Repository map
+
+| Path | What it is |
+| --- | --- |
+| `modules/gaussian_splatting/` | The Gaussian Splatting module — where work happens. Has its own `AGENTS.md`. |
+| `modules/gaussian_splatting/renderer/`, `shaders/` | GPU resources, render pipeline, GLSL. Each has its own `AGENTS.md`. |
+| `tests/` | CI guards, runtime harness, benchmarks, GDScript/C++ tests. Has its own `AGENTS.md`. |
+| `.github/workflows/` | CI workflows incl. self-hosted runners. Has its own `AGENTS.md`. |
+| `.agentic/` | Machine-readable agent control plane (risk policy, ownership, task/review contracts, roles). |
+| `docs/governance/` | Canonical process docs. |
+| `docs/agent_memory/` | **Legacy. Not source of truth** (see below). |
+| `servers/`, `scene/`, `core/`, `editor/`, `platform/`, `drivers/`, `main/` | Upstream Godot. Touch only with strong justification. |
+
+## Canonical docs — read before working
+
+- [Contribution standards](docs/governance/contribution-standards.md) — mandatory rules for every merged change.
+- [Build / test / CI reference](docs/reference/build-test-ci.md) — how to build and which checks to run.
+- [Agentic engineering](docs/governance/agentic-engineering.md) — roles, task contracts, risk classes, worktree isolation.
+- [Review policy](docs/governance/review-policy.md) — deterministic + independent + GPU/domain review, human disposition.
+- Module entry points: [`modules/gaussian_splatting/READING_ORDER.md`](modules/gaussian_splatting/READING_ORDER.md), [`ARCHITECTURE.md`](modules/gaussian_splatting/ARCHITECTURE.md).
+
+When docs conflict, the two canonical pages named in `CONTRIBUTING.md`
+(contribution-standards + build-test-ci) win.
+
+## Working rules
+
+- **Small, reviewable changes.** One task → one branch → one worktree. Do not
+  bundle unrelated work. Do not expand scope without a new task.
+- **Never revert or "clean up" another agent's or the user's uncommitted work.**
+  Work in your own worktree; leave other working trees alone.
+- **Always anchor to a base.** Record the base commit SHA you started from; review
+  and evidence are evaluated against the immutable `base..head` diff.
+- **Stacked PRs** must state their base PR and base SHA so reviewers never grade a
+  moving base or only the top diff.
+- **Reviewers do not implement.** A reviewing agent reports findings on a fixed
+  diff and changes no code. A verifying agent runs checks and changes no code.
+- **Humans own the merge.** Agents never auto-merge and never dismiss a review
+  blocker; a blocker stays open until fixed or a human waives it with a reason.
+- **Do not commit ephemeral agent artifacts** — transcripts, session IDs, scratch
+  notes, dirty-worktree dumps, local task instances. See
+  [contribution standards](docs/governance/contribution-standards.md).
+- **Do not weaken a guard, baseline, threshold, or gate to make a check pass.**
+- **Evidence by risk.** Higher-risk changes (renderer/shaders/persistence/engine)
+  require runtime/GPU evidence and extra review — see the risk classes (R0–R3) in
+  [agentic engineering](docs/governance/agentic-engineering.md), mirrored
+  machine-readably in `.agentic/policy.json`.
+
+## Upstream Godot boundary
+
+Do **not** scatter `AGENTS.md` into generic upstream directories (`servers/`,
+`scene/`, `core/`, `editor/`, `platform/`). Keep the delta to upstream Godot
+small; changes there are highest risk and need maintainer (CODEOWNER) review.
+
+## Legacy memory
+
+`docs/agent_memory/COORDINATOR_MEMORY.md` and `GAUSSIAN_ISSUE_BOARD.md` are a
+legacy multi-agent coordination system. **Do not treat them as current project
+status.** Active issues live in GitHub Issues; durable rules live in the docs
+linked above. The issue board is frozen and migrates to GitHub incrementally.
+
+## Nested instructions
+
+More specific `AGENTS.md` files refine these rules for their subtree. They add
+detail; they never copy or weaken what is written here. Always read the most
+specific `AGENTS.md` for the code you are touching.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,9 @@ When docs conflict, the two canonical pages named in `CONTRIBUTING.md`
 - **Evidence by risk.** Higher-risk changes (renderer/shaders/persistence/engine)
   require runtime/GPU evidence and extra review — see the risk classes (R0–R3) in
   [agentic engineering](docs/governance/agentic-engineering.md), mirrored
-  machine-readably in `.agentic/policy.json`.
+  machine-readably in `.agentic/policy.json` (added by a sibling PR in this
+  foundation series; until it lands, use the human-readable risk classes in the
+  agentic-engineering doc).
 
 ## Upstream Godot boundary
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# CLAUDE.md
+
+Agent instructions for this repository are maintained **vendor-neutrally** in
+[`AGENTS.md`](AGENTS.md) and the nested `AGENTS.md` files. Those are the canonical
+source of truth; this file only bridges them into Claude Code.
+
+Claude Code: follow [`AGENTS.md`](AGENTS.md), and always read the most specific
+`AGENTS.md` for the files you are touching (for example
+`modules/gaussian_splatting/renderer/AGENTS.md` when working on the renderer).
+Process, roles, and risk classes are described in
+[`docs/governance/agentic-engineering.md`](docs/governance/agentic-engineering.md).
+
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,7 @@ Canonical build/test commands:
 - `docs/reference/build-test-ci.md`
 
 When docs conflict, treat those two pages as source of truth.
+
+AI coding agents (and contributors using them): start with `AGENTS.md` at the
+repository root and the nested `AGENTS.md` files closer to the code. Process and
+roles are described in `docs/governance/agentic-engineering.md`.

--- a/docs/governance/agentic-engineering.md
+++ b/docs/governance/agentic-engineering.md
@@ -10,6 +10,13 @@ schemas, templates, roles) and is enforced by `scripts/agentic/`. See also
 [`AGENTS.md`](../../AGENTS.md), [contribution standards](contribution-standards.md),
 and the [review policy](review-policy.md).
 
+> **Rollout note.** This foundation is introduced as a coordinated series of pull
+> requests. The machine-readable control plane (`.agentic/`, `scripts/agentic/`)
+> and the always-on required gate (`.github/workflows/agentic_pr_gate.yml`) are
+> added by sibling PRs in the same series. References to those paths below describe
+> the target design and resolve once the series has been merged; until then, follow
+> the parts already present on your branch.
+
 ## Principles
 
 - **Specs over chat.** Work starts from a task contract (a small, explicit

--- a/docs/governance/agentic-engineering.md
+++ b/docs/governance/agentic-engineering.md
@@ -1,0 +1,88 @@
+# Agentic Engineering
+
+How AI coding agents work in this repository. The goal is **specification-driven**,
+not chat-driven, development: one agent plans, one implements, deterministic
+systems plus independent reviewers verify, and a human decides the merge.
+
+This page is the human-readable source of truth for roles and risk classes. A
+machine-readable mirror lives under `.agentic/` (`policy.json`, `ownership.json`,
+schemas, templates, roles) and is enforced by `scripts/agentic/`. See also
+[`AGENTS.md`](../../AGENTS.md), [contribution standards](contribution-standards.md),
+and the [review policy](review-policy.md).
+
+## Principles
+
+- **Specs over chat.** Work starts from a task contract (a small, explicit
+  specification), not from a conversation transcript. The contract — not the chat
+  history — is what gets reviewed and reproduced.
+- **Immutable base.** Every task records the base commit SHA. Implementation,
+  evidence, and review are all evaluated against the fixed `base..head` diff.
+- **Reproducible evidence.** Claims (tests pass, perf improved, leak fixed) are
+  backed by commands anyone can re-run. Missing hardware is reported as "not run",
+  never silently as "passed".
+- **No ephemeral state in git.** Session IDs, transcripts, scratch notes, and
+  dirty-worktree dumps are never committed (see [contribution standards](contribution-standards.md)).
+
+## Roles
+
+Each role is a separate context with a narrow mandate; full prompts live in
+`.agentic/roles/`.
+
+| Role | Mandate | May change code? |
+| --- | --- | --- |
+| **Planner** | Read-only investigation; writes the task contract. | No |
+| **Implementer** | Implements exactly one task in its own worktree, within scope. | Yes, in scope only |
+| **Verifier** | Runs guards/tests/harness/benchmarks and reports results, incl. skips. | No |
+| **Correctness reviewer** | Independent review of the immutable diff for correctness. | No |
+| **GPU/performance reviewer** | Adds host↔shader/sync/lifetime/bounds/timing/VRAM/benchmark-method review. | No |
+
+- The **implementer may not weaken** acceptance criteria, baselines, thresholds,
+  or gates to pass.
+- A **reviewer never implements**, gets a fresh context, sees the fixed
+  `base..head` diff (and ideally not the implementer's log), and reports
+  uncertainty and missing evidence as findings.
+- A **human owns the merge** and is the only one who can waive a blocker, with a
+  written reason.
+
+## Task contracts
+
+A task contract (`.agentic/templates/task.json`, schema
+`.agentic/schemas/task.schema.json`) captures: the problem, base SHA, risk class,
+owned and forbidden paths, dependencies, non-goals, invariants, acceptance
+criteria, validation commands, evidence requirements, and a rollback plan. One
+contract → one branch → one worktree.
+
+## Worktree isolation and parallel work
+
+- Each implementer works in its **own git worktree** so concurrent work never
+  collides and no agent disturbs another's (or the user's) uncommitted changes.
+- Parallel work is allowed **only across non-overlapping ownership packages**
+  (see `.agentic/ownership.json`, which binds domains to real paths). Two agents
+  must not edit the same paths on the same branch.
+
+## Stacked PRs
+
+Stacking is allowed but must be explicit: a stacked PR states its **base PR and
+base SHA** so a reviewer never grades a moving base or only the top-of-stack diff.
+
+## Risk classes
+
+Risk drives required roles, checks, and evidence. The machine-readable definition
+is `.agentic/policy.json`; `scripts/agentic/classify_change.py` derives the class
+from the changed paths and **fails closed to R3** for unrecognized sensitive paths.
+
+| Class | Scope | Required process |
+| --- | --- | --- |
+| **R0** | Docs and agentic governance only. | Deterministic checks + one review. |
+| **R1** | Local module/test changes with no GPU/persistence/engine risk. | Guards + targeted tests + correctness review. |
+| **R2** | Renderer, shaders, compute, GPU sort, streaming, performance, VRAM. | R1 + GPU/performance review + runtime/GPU evidence. |
+| **R3** | Godot-engine delta outside the module; persistence/file formats; release/security workflows; public API/compat. | ADR before implementation + two reviews + CODEOWNER and human approval. |
+
+The PR author's self-declared risk class is **not** trusted on its own: CI
+re-derives it from the diff and uses the higher of the two.
+
+## Legacy coordination data
+
+`docs/agent_memory/` is a frozen legacy system and is **not** current status.
+Active issues live in GitHub Issues; the board migrates there incrementally and
+its history remains in git.

--- a/docs/governance/github-settings.md
+++ b/docs/governance/github-settings.md
@@ -1,0 +1,50 @@
+# GitHub Repository Settings
+
+These are the repository rules that back the [review policy](review-policy.md).
+They must be configured **manually** by a maintainer in the GitHub UI / rulesets —
+nothing in this repo changes them automatically. This page is the checklist of
+intended state.
+
+Today `master` has **no required status checks** (documented in
+`.github/workflows/README.md`). The settings below close that gap.
+
+## Branch protection / ruleset for `master`
+
+- **Require a pull request before merging** — no direct pushes to `master`.
+- **Require at least one approving review from a human maintainer.**
+- **Require review from Code Owners** (`.github/CODEOWNERS`).
+- **Dismiss stale approvals** when new commits are pushed.
+- **Require conversation resolution** — all review threads resolved before merge.
+- **Require status checks to pass**, including:
+  - `Agentic PR Gate / required` (the fork-safe, always-on gate).
+- **Require branches to be up to date** before merging (or use the merge queue).
+- **Block force pushes** and **block branch deletion** for `master`.
+
+## Risk-class escalation
+
+- **R3 changes** (Godot-engine delta outside the module, persistence/file formats,
+  release/security workflows, public API/compat) require **two approvals** and a
+  design record (ADR / design-change issue) before implementation. Enforce via a
+  CODEOWNERS ownership of the sensitive paths plus a documented reviewer
+  expectation; GitHub rulesets cannot encode "risk class" directly, so the
+  required second approval for R3 is a maintainer-enforced convention checked at
+  review time.
+
+## Runner trust boundary
+
+- Keep the fork guard on every self-hosted job (see
+  `.github/workflows/README.md`). Do not add a ruleset or automation that runs
+  fork PR code on a persistent self-hosted runner, and never enable a
+  `pull_request_target` privileged checkout.
+
+## Emergency bypass
+
+- Repository admins may bypass protection only for a genuine emergency. Any bypass
+  must be recorded (PR comment or incident note) with the reason and a follow-up
+  to restore normal flow. Bypass is never the routine path.
+
+## Notes
+
+- Required-check names must match the job's reported check name exactly; if the
+  gate's workflow/job name changes, update the required-checks list here and in the
+  ruleset.

--- a/docs/governance/github-settings.md
+++ b/docs/governance/github-settings.md
@@ -12,14 +12,17 @@ Today `master` has **no required status checks** (documented in
 
 - **Require a pull request before merging** — no direct pushes to `master`.
 - **Require at least one approving review from a human maintainer.**
-- **Require review from Code Owners** (`.github/CODEOWNERS`).
+- **Require review from Code Owners** (`.github/CODEOWNERS`). Enable this only
+  **after** `.github/CODEOWNERS` (added by a sibling PR in this foundation series)
+  has merged; with no owners defined the setting cannot request anyone and the R3
+  escalation below stays unenforced.
 - **Dismiss stale approvals** when new commits are pushed.
 - **Require conversation resolution** — all review threads resolved before merge.
 - **Require status checks to pass**, including:
-  - `Agentic PR Gate / required` (the fork-safe, always-on gate). Mark this check
-    required only **after** the `agentic_pr_gate.yml` workflow has merged to
-    `master` and reported at least once, so PRs are not blocked on a status that
-    cannot report.
+  - `agentic-pr-gate` — the fork-safe, always-on gate's job name (shown in the PR
+    UI as `Agentic PR Gate / agentic-pr-gate`). Mark this check required only
+    **after** the `agentic_pr_gate.yml` workflow has merged to `master` and reported
+    at least once, so PRs are not blocked on a status that cannot report.
 - **Require branches to be up to date** before merging (or use the merge queue).
 - **Block force pushes** and **block branch deletion** for `master`.
 

--- a/docs/governance/github-settings.md
+++ b/docs/governance/github-settings.md
@@ -16,7 +16,10 @@ Today `master` has **no required status checks** (documented in
 - **Dismiss stale approvals** when new commits are pushed.
 - **Require conversation resolution** — all review threads resolved before merge.
 - **Require status checks to pass**, including:
-  - `Agentic PR Gate / required` (the fork-safe, always-on gate).
+  - `Agentic PR Gate / required` (the fork-safe, always-on gate). Mark this check
+    required only **after** the `agentic_pr_gate.yml` workflow has merged to
+    `master` and reported at least once, so PRs are not blocked on a status that
+    cannot report.
 - **Require branches to be up to date** before merging (or use the merge queue).
 - **Block force pushes** and **block branch deletion** for `master`.
 

--- a/docs/governance/index.md
+++ b/docs/governance/index.md
@@ -1,3 +1,6 @@
 # Governance
 
 - [Contribution Standards](contribution-standards.md)
+- [Agentic Engineering](agentic-engineering.md)
+- [Review Policy](review-policy.md)
+- [GitHub Settings](github-settings.md)

--- a/docs/governance/review-policy.md
+++ b/docs/governance/review-policy.md
@@ -47,9 +47,12 @@ validated by `scripts/agentic/validate_review.py`). Every review records the
 - The author's self-declared risk class is cross-checked against
   `scripts/agentic/classify_change.py`; the higher class wins and sets the required
   review layers.
-- **Untrusted fork code** is never validated on persistent self-hosted runners;
+- **Untrusted fork code** must never be validated on persistent self-hosted runners;
   GPU/Windows validation happens only after a maintainer moves the change onto a
-  same-repo branch (see `.github/workflows/README.md`). Any change that relaxes a
+  same-repo branch. This is the required standard the agentic-foundation series brings
+  every self-hosted workflow under (via the per-job fork guard); verify a given
+  workflow actually carries the guard rather than assuming the boundary is already
+  closed everywhere (see `.github/workflows/README.md`). Any change that relaxes a
   gate or the runner trust boundary must be documented and human-approved.
 
 ## Repository enforcement

--- a/docs/governance/review-policy.md
+++ b/docs/governance/review-policy.md
@@ -1,0 +1,59 @@
+# Review Policy
+
+How changes are reviewed before a human merges them. Reviews layer four signals;
+a change advances only when each required layer is satisfied. See
+[agentic engineering](agentic-engineering.md) for roles and risk classes.
+
+## The four layers
+
+1. **Deterministic review.** Compiler/build, guards, targeted tests, contract
+   checks, runtime harness, and (for R2+) GPU evidence / benchmarks. These are the
+   non-negotiable, reproducible gates — see `docs/reference/build-test-ci.md`.
+2. **Independent correctness review.** A reviewer with a fresh context evaluates
+   the immutable `base..head` diff for correctness, threading/locking, resource
+   lifetime, error/abort paths, back-compat, test quality, and scope creep. The
+   reviewer changes no code.
+3. **Domain review (R2+).** For renderer/shader/streaming/performance changes, a
+   GPU/performance reviewer additionally checks host↔shader contracts, buffer
+   bounds and zero paths, device-generation/resource ownership, synchronization
+   and async readback, timing honesty, VRAM, and benchmark methodology.
+4. **Human disposition.** A human maintainer decides the merge, resolves
+   conflicting findings, and is the only party that can waive a blocker — with a
+   written reason recorded on the PR.
+
+## Findings
+
+Reviews are emitted as structured findings (`.agentic/schemas/review.schema.json`,
+validated by `scripts/agentic/validate_review.py`). Every review records the
+`base_sha`/`head_sha` it judged, the tests/evidence it reviewed, and its
+**blind spots**. Each finding has a severity:
+
+| Severity | Meaning |
+| --- | --- |
+| `blocker` | Must be fixed (or waived by a human) before merge. |
+| `high` | Strongly expected to be fixed; needs an explicit decision. |
+| `medium` / `low` | Should be addressed or consciously deferred. |
+| `note` | Informational. |
+
+`blocker` and `high` findings must carry a concrete `required_action`.
+
+## Rules
+
+- **No voting.** Reviewers do not outvote each other. A well-founded blocker stays
+  open until it is fixed or a human waives it; a second approval does not clear it.
+- **Reviewers do not implement**, and verifiers do not fix — they report.
+- A **reconciler** (human or agent) may deduplicate or merge overlapping findings
+  but may **not** silently drop or downgrade a blocker.
+- The author's self-declared risk class is cross-checked against
+  `scripts/agentic/classify_change.py`; the higher class wins and sets the required
+  review layers.
+- **Untrusted fork code** is never validated on persistent self-hosted runners;
+  GPU/Windows validation happens only after a maintainer moves the change onto a
+  same-repo branch (see `.github/workflows/README.md`). Any change that relaxes a
+  gate or the runner trust boundary must be documented and human-approved.
+
+## Repository enforcement
+
+The branch-protection and required-check settings that back this policy are listed
+in [GitHub settings](github-settings.md); they are applied manually by a
+maintainer.

--- a/docs/governance/review-policy.md
+++ b/docs/governance/review-policy.md
@@ -24,9 +24,11 @@ a change advances only when each required layer is satisfied. See
 ## Findings
 
 Reviews are emitted as structured findings (`.agentic/schemas/review.schema.json`,
-validated by `scripts/agentic/validate_review.py`). Every review records the
-`base_sha`/`head_sha` it judged, the tests/evidence it reviewed, and its
-**blind spots**. Each finding has a severity:
+validated by `scripts/agentic/validate_review.py`). Those files are added by a
+sibling PR in this foundation series; until the series is merged, follow the parts
+already present on your branch. Every review records the `base_sha`/`head_sha` it
+judged, the tests/evidence it reviewed, and its **blind spots**. Each finding has a
+severity:
 
 | Severity | Meaning |
 | --- | --- |

--- a/modules/gaussian_splatting/AGENTS.md
+++ b/modules/gaussian_splatting/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md — `modules/gaussian_splatting`
+
+Refines the root [`AGENTS.md`](../../AGENTS.md) for the Gaussian Splatting module.
+Read `READING_ORDER.md` and `ARCHITECTURE.md` in this directory first; the
+lifetime/ownership rules below are mandatory and recur in CI guards.
+
+## Ownership and lifetime
+
+- **`GaussianData` and GPU resources have a single owner.** A resource's owner
+  creates it and is the only code that frees it. Do not free a resource you did
+  not create; do not hand a raw RID/buffer to code that will outlive the owner.
+- Every RID/buffer/uniform-set freed on teardown must also be freed on **every
+  early-return and failure path**. The repo's lifetime-accounting guards exist
+  because partial init used to leak — see `docs/architecture/renderer-lifetime-ownership.md`.
+- Prefer the existing managers (e.g. the GPU buffer manager) over ad-hoc resource
+  handles. New long-lived GPU state must have a documented free path.
+
+## Threading and locking
+
+- State touched from both the main thread and worker/streaming threads must be
+  guarded by the established lock for that subsystem; do not invent a second lock
+  over the same data. Document the lock that protects any new shared field.
+- Never block the main thread on a GPU readback. Use the existing async-readback
+  path; report timing honestly (see renderer `AGENTS.md`).
+
+## Errors and partial failure
+
+- Initialization is all-or-nothing: on failure, release everything acquired so
+  far and surface the error — never leave a half-initialized node "running".
+- No silent fallbacks that change visual/semantic output without telling the
+  caller. A degraded path must be explicit and observable.
+
+## Serialization and back-compat
+
+- On-disk formats live in `persistence/` (scene serialization, incremental
+  saver) and loaders/importers in `io/` (`.ply`, `.spz`, `.gsplatworld`).
+- **Bumping a layout/format version is a breaking change** (risk class R3): keep
+  read paths able to load the previous version, add the version to the serialized
+  contract, and validate it on load. Do not change a format silently.
+
+## Tests
+
+- Guard + structural checks: `python tests/ci/run_module_tests.py --guard-only`.
+- Full module tests need a built Godot binary: `python tests/ci/run_module_tests.py --godot-binary <bin>`.
+- Renderer/streaming behavior is exercised by `tests/runtime/` — see `tests/AGENTS.md`.
+- See the full command set in `docs/reference/build-test-ci.md`.
+
+Sub-areas with their own rules: [`renderer/`](renderer/AGENTS.md),
+[`shaders/`](shaders/AGENTS.md).

--- a/modules/gaussian_splatting/renderer/AGENTS.md
+++ b/modules/gaussian_splatting/renderer/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md — `modules/gaussian_splatting/renderer`
+
+Refines [`../AGENTS.md`](../AGENTS.md) for GPU resources and the render pipeline.
+Renderer changes are **risk class R2** (or R3 if they cross into engine/persistence)
+and require runtime/GPU evidence plus an independent GPU/performance review — see
+`docs/governance/review-policy.md`.
+
+## RenderingDevice and resource ownership
+
+- A GPU resource (buffer, texture, uniform set, pipeline) is valid only for the
+  `RenderingDevice` generation that created it. Store and compare the device
+  generation before reusing a cached resource; a uniform set must never outlive
+  the device/resources it binds.
+- Free on teardown **and** on every failure/early-return path. New persistent GPU
+  state needs an explicit, tested free path (the lifetime-accounting guards will
+  flag leaks).
+
+## Buffers, bounds, and the zero path
+
+- Size every dispatch/copy from the actual element count; never assume a fixed
+  capacity. Respect buffer bounds on both host and shader sides (see
+  `shaders/AGENTS.md` for the host↔shader contract).
+- Handle the **zero-element / empty-scene path** explicitly — no dispatch with a
+  zero or negative count, no read past the end of a partially filled buffer.
+
+## Synchronization and readback
+
+- Never stall the main thread on the GPU. Use the existing async readback /
+  timestamp paths; do not add a synchronous `sync()` to "fix" a race.
+- **Timing honesty:** a metric must measure what its name claims. CPU dispatch
+  time is not GPU time; do not report dispatch latency as GPU cost or leave a
+  pass-timing monitor reading zero while implying it is measured. If a number is
+  not actually measured on the render path in use, say so.
+
+## No silent unsafe fallbacks
+
+- Do not silently render unsorted, skip the sort, or drop records to hit a budget
+  — these produce wrong images that look plausible. Any fallback must be explicit
+  and observable, and must not regress correctness on real-scan content.
+
+## Evidence
+
+- Provide runtime/GPU evidence for render changes (the production-gates runtime
+  harness, GPU harness, and/or benchmark surface). Include VRAM and frame-time
+  numbers for changes that claim a performance or memory effect, measured against
+  the immutable base.
+- Background and references: `docs/architecture/render-pipeline.md`,
+  `docs/architecture/renderer-lifetime-ownership.md`.

--- a/modules/gaussian_splatting/shaders/AGENTS.md
+++ b/modules/gaussian_splatting/shaders/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md — `modules/gaussian_splatting/shaders`
+
+Refines [`../AGENTS.md`](../AGENTS.md) for GLSL/compute shaders and the
+host↔shader contract. Shader changes are **risk class R2** and must pass the
+shader-contract checks (run by `gaussian_shader_validation.yml` and the
+guard suite). See `README.md` in this directory for the compile pipeline.
+
+## Build and includes
+
+- Shaders are compiled to generated headers (`*.gen.h`) via `compile_shaders.py`;
+  shared GLSL lives in `includes/`. If you add/rename an include or a shader,
+  update the build inputs so the generated header is regenerated — a stale
+  `*.gen.h` is a silent correctness bug. Do **not** hand-edit generated headers.
+- Keep the shader-dependency guard happy: declared includes must match actual
+  `#include`s.
+
+## Host ↔ shader layout contract
+
+- Struct layouts, binding indices, push-constant sizes, and shared constants must
+  match **exactly** between the C++ host and the shader. A mismatch reads garbage
+  or overflows. When you change one side, change the other in the same commit and
+  re-run the layout-sync / contract check.
+- Derive related magic numbers (binning extent, alpha cutoff, projection radius,
+  low-pass dilation, etc.) from one shared constant rather than copying literals
+  into both host and shader.
+
+## Bounds and numerics
+
+- Every buffer index in a shader must be bounds-checked or provably in range;
+  guard the zero-element path. Out-of-bounds access is undefined and vendor-specific.
+- Watch numeric stability: avoid catastrophic cancellation and divide-by-near-zero
+  in covariance/projection math; keep precision consistent with the host.
+
+## Cross-vendor behavior
+
+- Code must behave on NVIDIA, AMD, and Intel — do not rely on a single vendor's
+  tolerance for UB, subgroup size, or unsorted access. If a change is validated on
+  only one vendor, record that as a blind spot in the PR.
+
+## Sort keys
+
+- Sort-key width/precision is a correctness contract (32-bit quantized keys band
+  and flicker on real-scan data). Do not narrow sort keys to save bandwidth
+  without re-validating visually on real-scan content.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md — `tests`
+
+Refines the root [`AGENTS.md`](../AGENTS.md) for the test and CI harness.
+Full command reference: `docs/reference/build-test-ci.md`.
+
+## Layout
+
+- `tests/ci/` — guard checks, contract validators, baseline QA, GPU harness,
+  and Python `unittest` tests (`test_*.py`). Entry point:
+  `python tests/ci/run_module_tests.py` (`--guard-only` for the GPU-free lane).
+- `tests/runtime/` — runtime validation harness, streaming/residency/GPU-stress
+  GDScript scenarios, benchmark runner. Entry point:
+  `python tests/runtime/run_runtime_validation.py --profile <profile>`.
+- `tests/agentic/` — `unittest` tests for the `scripts/agentic` validators.
+
+## Rules
+
+- **Separate the tiers.** Structural/guard tests must stay deterministic and run
+  without a GPU or a built binary where possible; runtime and performance tests
+  are separate and may require hardware. Do not fold a hardware-dependent check
+  into the guard lane.
+- **Deterministic fixtures.** Use fixed seeds and the synthetic-asset helpers
+  (`tests/runtime/prepare_synthetic_assets.py`); do not depend on wall-clock,
+  network, or machine-specific paths. Real-scan visual validation is required for
+  rendering-math changes but lives in its own lane, not the unit tests.
+- **No unjustified baseline/threshold updates.** Never edit a golden baseline,
+  performance threshold, or release-gate manifest just to make a test pass.
+  Changing a baseline requires its own justification and review; treat it as a
+  contract change, not a fix.
+- **No generated artifacts in commits.** Reports, logs, `output/`, captured
+  images, and `__pycache__` are build outputs, not source — keep them untracked.
+- **Document what you ran.** PRs must list the exact test commands and their
+  results. Where GPU/Windows hardware was unavailable, write "not run", never
+  "passed".
+- Python tests use the standard-library `unittest` style already in the repo
+  (e.g. `tests/ci/test_renderer_release_gates.py`): load the module under test
+  with `importlib.util.spec_from_file_location` and use `tempfile` fixtures. Do
+  not add a new test-framework dependency.


### PR DESCRIPTION
## Summary

Introduces hierarchical, human-readable agent governance with no behavior change:
a concise root `AGENTS.md`, nested `AGENTS.md` for the module / renderer / shaders /
tests / workflows, and three governance docs. Children refine the root rules
(ownership & lifetime, host/shader contracts, runner trust boundary, test tiers)
without copying or weakening them.

## Risk class

R0 (docs / agentic governance).

## Base / head

- Base: `master` (`b810f19ac0`). Part of the agentic-engineering foundation series; independent.

## Changes

- `AGENTS.md` (root) + `modules/gaussian_splatting/AGENTS.md`, `.../renderer/AGENTS.md`,
  `.../shaders/AGENTS.md`, `tests/AGENTS.md`, `.github/workflows/AGENTS.md`.
- `docs/governance/agentic-engineering.md` (roles, task contracts, worktree
  isolation, R0–R3 risk classes), `review-policy.md` (deterministic + independent +
  GPU/domain review, human disposition, no-voting), `github-settings.md` (manual
  branch-protection checklist).
- Wire pages into `docs/governance/index.md`; point `CONTRIBUTING.md` at `AGENTS.md`.

## Validation

- `python scripts/docs/check_links.py docs/governance CONTRIBUTING.md AGENTS.md <nested AGENTS.md>` → all valid.
- The 4 pre-existing broken anchors in `docs/testing/setup-guide.md` are untouched by this PR (tracked as a separate follow-up).

## User-visible behavior / Godot upstream delta

None. Docs only.

## Rollback

Revert the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
