### PR TITLE
ci(agentic): CODEOWNERS, PR/issue templates, and fork-safe required gate

### DIFF
--- a/.agentic/README.md
+++ b/.agentic/README.md
@@ -1,0 +1,37 @@
+# `.agentic/` — Agentic Control Plane
+
+Vendor-neutral, machine-readable definitions for how AI coding agents work in this
+repository. Any agent tool can consume these files; nothing here depends on a
+specific product. The human-readable narrative lives in
+`docs/governance/agentic-engineering.md` and `docs/governance/review-policy.md`.
+
+## Contents
+
+| Path | Purpose |
+| --- | --- |
+| `policy.json` | Risk classes (R0–R3), required roles/checks/evidence per class, and path-based classification rules (fail-closed to R3). |
+| `ownership.json` | Agent domains bound to real paths; basis for non-overlapping parallel work. |
+| `schemas/task.schema.json` | Schema for a task contract (one unit of work). |
+| `schemas/review.schema.json` | Schema for a structured review result. |
+| `templates/task.json` | Fillable task-contract template (validates against the schema). |
+| `templates/review.json` | Example review result (validates against the schema). |
+| `roles/*.md` | Per-role mandates and hard constraints. |
+
+## Tooling
+
+Validators live in `scripts/agentic/` (Python 3.11, standard library only):
+
+- `validate_repo_contract.py` — checks this directory is internally consistent.
+- `classify_change.py` — derives the risk class from changed paths.
+- `check_pr_contract.py` — checks a PR's task contract, cross-checking the declared
+  risk class against the diff (the higher class wins).
+- `validate_review.py` — validates a review result against the review schema.
+
+These are exercised by the always-on `Agentic PR Gate` and by tests under
+`tests/agentic/`.
+
+## Rules
+
+- These files are **canonical** and version-controlled. Never gitignore them.
+- Never commit ephemeral state (session IDs, transcripts, scratch) here or
+  anywhere — see `docs/governance/contribution-standards.md`.

--- a/.agentic/README.md
+++ b/.agentic/README.md
@@ -27,8 +27,10 @@ Validators live in `scripts/agentic/` (Python 3.11, standard library only):
   risk class against the diff (the higher class wins).
 - `validate_review.py` — validates a review result against the review schema.
 
-These are exercised by the always-on `Agentic PR Gate` and by tests under
-`tests/agentic/`.
+These are exercised by tests under `tests/agentic/` and, once merged, by the
+always-on `Agentic PR Gate` (`.github/workflows/agentic_pr_gate.yml`) — added by a
+sibling PR in this foundation series. Until that workflow lands, run the validators
+locally; do not assume CI invokes them yet.
 
 ## Rules
 

--- a/.agentic/ownership.json
+++ b/.agentic/ownership.json
@@ -3,7 +3,7 @@
   "description": "Agent ownership domains bound to real paths. Parallel implementer work is only allowed across non-overlapping domains. No domain grants a global change-everything mandate; engine-integration paths are highest risk and require CODEOWNER review.",
   "domains": {
     "core-data-io": {
-      "description": "Core gaussian data types, loaders/importers, and on-disk serialization.",
+      "description": "Core gaussian data types, loaders/importers, and on-disk serialization. The streaming/residency/VRAM files under core/ belong to streaming-lod (more specific) and are R2, not R1 — assign those there.",
       "paths": [
         "modules/gaussian_splatting/core/**",
         "modules/gaussian_splatting/io/**",
@@ -24,10 +24,13 @@
       ]
     },
     "streaming-lod": {
-      "description": "Streaming, residency, and level-of-detail.",
+      "description": "Streaming, residency, VRAM, and level-of-detail (matches the R2 core-streaming paths in policy.json).",
       "paths": [
         "modules/gaussian_splatting/lod/**",
-        "modules/gaussian_splatting/asset_management/**"
+        "modules/gaussian_splatting/asset_management/**",
+        "modules/gaussian_splatting/core/*streaming*",
+        "modules/gaussian_splatting/core/*residency*",
+        "modules/gaussian_splatting/core/*vram*"
       ]
     },
     "editor-import": {

--- a/.agentic/ownership.json
+++ b/.agentic/ownership.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": 1,
+  "description": "Agent ownership domains bound to real paths. Parallel implementer work is only allowed across non-overlapping domains. No domain grants a global change-everything mandate; engine-integration paths are highest risk and require CODEOWNER review.",
+  "domains": {
+    "core-data-io": {
+      "description": "Core gaussian data types, loaders/importers, and on-disk serialization.",
+      "paths": [
+        "modules/gaussian_splatting/core/**",
+        "modules/gaussian_splatting/io/**",
+        "modules/gaussian_splatting/persistence/**"
+      ]
+    },
+    "renderer-resources": {
+      "description": "GPU resources and the render pipeline.",
+      "paths": [
+        "modules/gaussian_splatting/renderer/**",
+        "modules/gaussian_splatting/compute/**"
+      ]
+    },
+    "shaders-contracts": {
+      "description": "GLSL/compute shaders and the host/shader layout contract.",
+      "paths": [
+        "modules/gaussian_splatting/shaders/**"
+      ]
+    },
+    "streaming-lod": {
+      "description": "Streaming, residency, and level-of-detail.",
+      "paths": [
+        "modules/gaussian_splatting/lod/**",
+        "modules/gaussian_splatting/asset_management/**"
+      ]
+    },
+    "editor-import": {
+      "description": "Editor integration and import UX for the module.",
+      "paths": [
+        "modules/gaussian_splatting/editor/**",
+        "modules/gaussian_splatting/nodes/**"
+      ]
+    },
+    "tests-ci": {
+      "description": "Test harness, CI scripts, and agentic tooling.",
+      "paths": [
+        "tests/**",
+        "scripts/**",
+        ".github/**"
+      ]
+    },
+    "engine-integration": {
+      "description": "Godot engine delta outside the module (highest risk, CODEOWNER review required).",
+      "paths": [
+        "servers/**",
+        "scene/**",
+        "core/**",
+        "editor/**",
+        "platform/**"
+      ]
+    }
+  }
+}

--- a/.agentic/ownership.json
+++ b/.agentic/ownership.json
@@ -3,7 +3,7 @@
   "description": "Agent ownership domains bound to real paths. Parallel implementer work is only allowed across non-overlapping domains. No domain grants a global change-everything mandate; engine-integration paths are highest risk and require CODEOWNER review.",
   "domains": {
     "core-data-io": {
-      "description": "Core gaussian data types, loaders/importers, and on-disk serialization. The streaming/residency/VRAM files under core/ belong to streaming-lod (more specific) and are R2, not R1 — assign those there.",
+      "description": "Core gaussian data types, loaders/importers, on-disk serialization, and the streaming/residency code that lives under core/. (Those streaming files are risk class R2 in policy.json; ownership domain and risk class are independent axes.)",
       "paths": [
         "modules/gaussian_splatting/core/**",
         "modules/gaussian_splatting/io/**",
@@ -24,13 +24,10 @@
       ]
     },
     "streaming-lod": {
-      "description": "Streaming, residency, VRAM, and level-of-detail (matches the R2 core-streaming paths in policy.json).",
+      "description": "Level-of-detail and asset streaming OUTSIDE core/ (lod/, asset_management/). Streaming code physically under core/ is owned by core-data-io to keep these domains machine-disjoint; risk class for those files is R2 (policy.json).",
       "paths": [
         "modules/gaussian_splatting/lod/**",
-        "modules/gaussian_splatting/asset_management/**",
-        "modules/gaussian_splatting/core/*streaming*",
-        "modules/gaussian_splatting/core/*residency*",
-        "modules/gaussian_splatting/core/*vram*"
+        "modules/gaussian_splatting/asset_management/**"
       ]
     },
     "editor-import": {

--- a/.agentic/policy.json
+++ b/.agentic/policy.json
@@ -144,9 +144,16 @@
         "reason": "Docs / agentic governance",
         "path_globs": [
           "docs/**",
-          "*.md",
           "**/AGENTS.md",
           "AGENTS.md",
+          "CLAUDE.md",
+          "README.md",
+          "BUILDING.md",
+          "CONTRIBUTING.md",
+          "CHANGELOG.md",
+          "AUTHORS.md",
+          "DONORS.md",
+          "ENGINE_PATCHES.md",
           ".agentic/**",
           "scripts/agentic/**"
         ]

--- a/.agentic/policy.json
+++ b/.agentic/policy.json
@@ -28,7 +28,8 @@
       "description": "Changes within the gaussian_splatting module or tests with no GPU, persistence-format, or engine risk.",
       "required_roles": ["planner", "implementer", "verifier", "correctness-reviewer"],
       "deterministic_checks": [
-        "python tests/ci/run_module_tests.py --guard-only"
+        "python tests/ci/run_module_tests.py --guard-only",
+        "python -m unittest discover -s tests/agentic"
       ],
       "evidence_requirements": [
         "Executed test commands and their results recorded in the PR."
@@ -43,6 +44,7 @@
       "required_roles": ["planner", "implementer", "verifier", "correctness-reviewer", "gpu-performance-reviewer"],
       "deterministic_checks": [
         "python tests/ci/run_module_tests.py --guard-only",
+        "python -m unittest discover -s tests/agentic",
         "python tests/runtime/run_runtime_validation.py --profile streaming-gpu-ci --skip-cpp --fail-on-skip"
       ],
       "evidence_requirements": [
@@ -60,6 +62,7 @@
       "required_roles": ["planner", "implementer", "verifier", "correctness-reviewer", "gpu-performance-reviewer"],
       "deterministic_checks": [
         "python tests/ci/run_module_tests.py --guard-only",
+        "python -m unittest discover -s tests/agentic",
         "python tests/runtime/run_runtime_validation.py --profile streaming-gpu-ci --skip-cpp --fail-on-skip",
         "python tests/ci/validate_automation.py --contracts-only"
       ],

--- a/.agentic/policy.json
+++ b/.agentic/policy.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "description": "Machine-readable risk policy for agentic changes. Human-readable source of truth: docs/governance/agentic-engineering.md. Classification is derived from changed paths by scripts/agentic/classify_change.py and fails closed to the highest class for unrecognized paths.",
+  "description": "Machine-readable risk policy for agentic changes. Human-readable source of truth: docs/governance/agentic-engineering.md. Classification is derived from changed paths by scripts/agentic/classify_change.py and fails closed to the highest class for unrecognized paths. deterministic_checks accumulate along the code-risk axis R1 <= R2 <= R3, so the highest class's checks are a superset of the lower classes' runtime checks.",
   "roles": [
     "planner",
     "implementer",
@@ -60,6 +60,7 @@
       "required_roles": ["planner", "implementer", "verifier", "correctness-reviewer", "gpu-performance-reviewer"],
       "deterministic_checks": [
         "python tests/ci/run_module_tests.py --guard-only",
+        "python tests/runtime/run_runtime_validation.py --profile streaming-gpu-ci --skip-cpp --fail-on-skip",
         "python tests/ci/validate_automation.py --contracts-only"
       ],
       "evidence_requirements": [

--- a/.agentic/policy.json
+++ b/.agentic/policy.json
@@ -131,7 +131,10 @@
           "modules/gaussian_splatting/shaders/**",
           "modules/gaussian_splatting/compute/**",
           "modules/gaussian_splatting/lod/**",
-          "modules/gaussian_splatting/asset_management/**"
+          "modules/gaussian_splatting/asset_management/**",
+          "modules/gaussian_splatting/core/*streaming*",
+          "modules/gaussian_splatting/core/*residency*",
+          "modules/gaussian_splatting/core/*vram*"
         ]
       },
       {

--- a/.agentic/policy.json
+++ b/.agentic/policy.json
@@ -15,7 +15,7 @@
       "required_roles": ["planner", "implementer", "verifier", "correctness-reviewer"],
       "deterministic_checks": [
         "python scripts/agentic/validate_repo_contract.py",
-        "python scripts/docs/check_links.py docs README.md BUILDING.md CONTRIBUTING.md"
+        "python scripts/docs/check_links.py docs/governance README.md CONTRIBUTING.md AGENTS.md"
       ],
       "evidence_requirements": [],
       "human_approval_required": true,

--- a/.agentic/policy.json
+++ b/.agentic/policy.json
@@ -15,6 +15,7 @@
       "required_roles": ["planner", "implementer", "verifier", "correctness-reviewer"],
       "deterministic_checks": [
         "python scripts/agentic/validate_repo_contract.py",
+        "python -m unittest discover -s tests/agentic",
         "python scripts/docs/check_links.py docs/governance README.md CONTRIBUTING.md AGENTS.md"
       ],
       "evidence_requirements": [],
@@ -106,6 +107,16 @@
           ".github/workflows/**",
           ".github/CODEOWNERS",
           "docs/reference/renderer_release_gate_manifest.json"
+        ]
+      },
+      {
+        "class": "R3",
+        "reason": "CI deterministic-check / release-gate machinery",
+        "path_globs": [
+          "tests/ci/run_module_tests.py",
+          "tests/ci/check_renderer_release_gates.py",
+          "tests/ci/validate_automation.py",
+          "tests/runtime/run_runtime_validation.py"
         ]
       },
       {

--- a/.agentic/policy.json
+++ b/.agentic/policy.json
@@ -16,7 +16,7 @@
       "deterministic_checks": [
         "python scripts/agentic/validate_repo_contract.py",
         "python -m unittest discover -s tests/agentic",
-        "python scripts/docs/check_links.py docs/governance README.md CONTRIBUTING.md AGENTS.md"
+        "python scripts/docs/check_links.py docs README.md BUILDING.md CONTRIBUTING.md"
       ],
       "evidence_requirements": [],
       "human_approval_required": true,

--- a/.agentic/policy.json
+++ b/.agentic/policy.json
@@ -120,6 +120,7 @@
           "tests/ci/run_module_tests.py",
           "tests/ci/check_renderer_release_gates.py",
           "tests/ci/validate_automation.py",
+          "tests/ci/run_gpu_harness.py",
           "tests/runtime/run_runtime_validation.py"
         ]
       },

--- a/.agentic/policy.json
+++ b/.agentic/policy.json
@@ -1,0 +1,144 @@
+{
+  "schema_version": 1,
+  "description": "Machine-readable risk policy for agentic changes. Human-readable source of truth: docs/governance/agentic-engineering.md. Classification is derived from changed paths by scripts/agentic/classify_change.py and fails closed to the highest class for unrecognized paths.",
+  "roles": [
+    "planner",
+    "implementer",
+    "verifier",
+    "correctness-reviewer",
+    "gpu-performance-reviewer"
+  ],
+  "risk_classes": {
+    "R0": {
+      "title": "Docs and agentic governance",
+      "description": "Documentation and the agentic control plane only; no runtime, build, or CI behavior change.",
+      "required_roles": ["planner", "implementer", "verifier", "correctness-reviewer"],
+      "deterministic_checks": [
+        "python scripts/agentic/validate_repo_contract.py",
+        "python scripts/docs/check_links.py docs README.md BUILDING.md CONTRIBUTING.md"
+      ],
+      "evidence_requirements": [],
+      "human_approval_required": true,
+      "adr_required": false,
+      "rollback_required": false
+    },
+    "R1": {
+      "title": "Local module / test change",
+      "description": "Changes within the gaussian_splatting module or tests with no GPU, persistence-format, or engine risk.",
+      "required_roles": ["planner", "implementer", "verifier", "correctness-reviewer"],
+      "deterministic_checks": [
+        "python tests/ci/run_module_tests.py --guard-only"
+      ],
+      "evidence_requirements": [
+        "Executed test commands and their results recorded in the PR."
+      ],
+      "human_approval_required": true,
+      "adr_required": false,
+      "rollback_required": true
+    },
+    "R2": {
+      "title": "Renderer / shaders / streaming / performance",
+      "description": "Renderer, shaders, compute, GPU sorting, streaming/LOD, performance, and VRAM changes.",
+      "required_roles": ["planner", "implementer", "verifier", "correctness-reviewer", "gpu-performance-reviewer"],
+      "deterministic_checks": [
+        "python tests/ci/run_module_tests.py --guard-only",
+        "python tests/runtime/run_runtime_validation.py --profile streaming-gpu-ci --skip-cpp --fail-on-skip"
+      ],
+      "evidence_requirements": [
+        "Runtime/GPU harness or benchmark evidence against the immutable base.",
+        "VRAM and frame-time numbers for any change that claims a performance or memory effect.",
+        "Real-scan visual validation for rendering-math changes."
+      ],
+      "human_approval_required": true,
+      "adr_required": false,
+      "rollback_required": true
+    },
+    "R3": {
+      "title": "Engine delta / persistence / release / security",
+      "description": "Godot-engine delta outside the module, persistence/file formats, release or security workflows, and public API/compatibility changes. Also the fail-closed class for unrecognized sensitive paths.",
+      "required_roles": ["planner", "implementer", "verifier", "correctness-reviewer", "gpu-performance-reviewer"],
+      "deterministic_checks": [
+        "python tests/ci/run_module_tests.py --guard-only",
+        "python tests/ci/validate_automation.py --contracts-only"
+      ],
+      "evidence_requirements": [
+        "Design record (ADR or design-change issue) before implementation.",
+        "Backward-compatibility evidence for format/API changes.",
+        "Two independent reviews and CODEOWNER + human approval."
+      ],
+      "human_approval_required": true,
+      "adr_required": true,
+      "rollback_required": true
+    }
+  },
+  "classification": {
+    "ordering": ["R0", "R1", "R2", "R3"],
+    "default_unclassified": "R3",
+    "rules": [
+      {
+        "class": "R3",
+        "reason": "Godot engine delta outside the module",
+        "path_globs": [
+          "servers/**",
+          "scene/**",
+          "core/**",
+          "editor/**",
+          "platform/**",
+          "drivers/**",
+          "main/**",
+          "thirdparty/**",
+          "SConstruct",
+          "methods.py"
+        ]
+      },
+      {
+        "class": "R3",
+        "reason": "Persistence / on-disk format",
+        "path_globs": [
+          "modules/gaussian_splatting/persistence/**",
+          "modules/gaussian_splatting/io/**"
+        ]
+      },
+      {
+        "class": "R3",
+        "reason": "Release / security / CI workflow surface",
+        "path_globs": [
+          ".github/workflows/**",
+          ".github/CODEOWNERS",
+          "docs/reference/renderer_release_gate_manifest.json"
+        ]
+      },
+      {
+        "class": "R2",
+        "reason": "Renderer / shaders / compute / streaming / performance",
+        "path_globs": [
+          "modules/gaussian_splatting/renderer/**",
+          "modules/gaussian_splatting/shaders/**",
+          "modules/gaussian_splatting/compute/**",
+          "modules/gaussian_splatting/lod/**",
+          "modules/gaussian_splatting/asset_management/**"
+        ]
+      },
+      {
+        "class": "R1",
+        "reason": "Local module or test change",
+        "path_globs": [
+          "modules/gaussian_splatting/**",
+          "tests/**"
+        ]
+      },
+      {
+        "class": "R0",
+        "reason": "Docs / agentic governance",
+        "path_globs": [
+          "docs/**",
+          "*.md",
+          "**/AGENTS.md",
+          "AGENTS.md",
+          ".agentic/**",
+          "scripts/agentic/**"
+        ]
+      }
+    ]
+  }
+}

--- a/.agentic/roles/correctness-reviewer.md
+++ b/.agentic/roles/correctness-reviewer.md
@@ -1,0 +1,31 @@
+# Role: Correctness Reviewer
+
+**Mandate:** Independently review the immutable `base..head` diff for correctness.
+Changes **no** code.
+
+## Inputs
+- The task contract, the fixed `base_sha..head_sha` diff, test results, and the
+  relevant architecture rules. Ideally **not** the implementer's working log
+  (review the change, not the narrative).
+
+## Outputs
+- A review result conforming to `../schemas/review.schema.json` with verdict,
+  findings, tests/evidence reviewed, and blind spots.
+
+## What to check
+- Functional correctness against the acceptance criteria and invariants.
+- Threading and locking; data races; lock discipline.
+- Resource lifetime/ownership; freeing on every failure/early-return path.
+- Error and abort paths; partial-failure handling.
+- Backward compatibility (APIs, serialized formats).
+- Test quality: do the tests actually exercise the change and its edge cases?
+- **Scope creep:** changes outside the contract's `owned_paths`, or weakened
+  baselines/thresholds/gates.
+
+## Hard constraints
+- Fresh context; judge only the fixed diff. Do not implement or push fixes.
+- Record what you could **not** verify in `blind_spots`; uncertainty is a finding,
+  not a silent pass.
+- `blocker`/`high` findings must carry a concrete `required_action`.
+- A well-founded blocker stays open until fixed or waived by a human — you do not
+  withdraw it because another reviewer approved.

--- a/.agentic/roles/gpu-performance-reviewer.md
+++ b/.agentic/roles/gpu-performance-reviewer.md
@@ -1,0 +1,38 @@
+# Role: GPU / Performance Reviewer
+
+**Mandate:** For R2+ changes (renderer, shaders, compute, GPU sort, streaming,
+performance, VRAM), add a domain review on top of the correctness review. Changes
+**no** code.
+
+## Inputs
+- The task contract, the fixed `base_sha..head_sha` diff, GPU/runtime evidence,
+  benchmark results, and the renderer/shader architecture rules.
+
+## Outputs
+- A review result conforming to `../schemas/review.schema.json` with
+  `reviewer_role: gpu-performance-reviewer`.
+
+## What to check (in addition to correctness)
+- **Host ↔ shader contract:** struct layouts, binding indices, push-constant
+  sizes, and shared constants match exactly on both sides.
+- **Buffer sizing and bounds:** dispatch/copy sized from real element counts; the
+  zero-element / empty-scene path handled; no out-of-bounds shader indexing.
+- **Device generation and resource ownership:** resources are not reused across a
+  `RenderingDevice` generation; uniform sets do not outlive their resources; every
+  resource freed on failure paths.
+- **Synchronization and async readback:** no main-thread GPU stalls; no race papered
+  over with a synchronous sync.
+- **Timing honesty:** metrics measure what they claim (CPU dispatch ≠ GPU time); no
+  pass-timing monitor silently reading zero.
+- **VRAM and stalls:** peak VRAM, CPU/GPU stalls, and frame-time impact are
+  measured against the immutable base.
+- **Benchmark methodology:** A/B isolates the change (same scene/settings, sort and
+  tile telemetry captured), and real-scan visual validation is present for
+  rendering-math changes.
+
+## Hard constraints
+- Fresh context; judge only the fixed diff and the attached evidence. Do not
+  implement.
+- If evidence is missing or run on only one vendor, that is a `blind_spot` and may
+  be a finding — do not assume it passes.
+- `blocker`/`high` findings must carry a concrete `required_action`.

--- a/.agentic/roles/implementer.md
+++ b/.agentic/roles/implementer.md
@@ -1,0 +1,26 @@
+# Role: Implementer
+
+**Mandate:** Implement exactly one task contract, in its own worktree, within scope.
+
+## Inputs
+- One task contract (`../schemas/task.schema.json`) and its `baseline_sha`.
+
+## Outputs
+- A focused branch implementing the contract, with updated tests and recorded
+  evidence.
+
+## Hard constraints
+- **One task, one branch, one worktree.** Do not expand scope; if new work is
+  needed, request a new contract.
+- Change only `owned_paths`; never touch `forbidden_paths`.
+- **Never weaken** acceptance criteria, baselines, thresholds, gates, or guards to
+  make a check pass. If a baseline genuinely must change, that is a separate,
+  justified task.
+- Never revert or "clean up" another agent's or the user's uncommitted work; stay
+  in your worktree.
+- Honor the invariants in the contract (e.g. free every resource on every failure
+  path; keep the host/shader contract in sync).
+- Run the contract's `validation_commands` and record results honestly; mark
+  unavailable hardware as "not run", never "passed".
+- Do not commit ephemeral artifacts (transcripts, session IDs, scratch files).
+- For stacked work, record the base PR and base SHA in the contract.

--- a/.agentic/roles/planner.md
+++ b/.agentic/roles/planner.md
@@ -1,0 +1,22 @@
+# Role: Planner
+
+**Mandate:** Investigate read-only and produce a task contract. The Planner does
+**not** write production code.
+
+## Inputs
+- A problem or feature request and the current `master` (or a stated base commit).
+
+## Outputs
+- A task contract conforming to `../schemas/task.schema.json` (start from
+  `../templates/task.json`).
+
+## Hard constraints
+- **Read-only.** No edits to source, tests, or config; no commits to a work branch.
+- Record the immutable `baseline_sha` the work will start from.
+- Scope the work to a coherent ownership package (`../ownership.json`); set
+  `owned_paths` and `forbidden_paths` explicitly. One contract → one branch.
+- Set a `risk_class` consistent with `../policy.json`; remember CI re-derives it
+  from the diff and uses the higher value, so do not understate it.
+- Define concrete, checkable `acceptance_criteria`, `invariants`, `non_goals`,
+  `validation_commands`, `evidence_requirements`, and a `rollback_plan`.
+- Do not encode chat history or transcripts into the contract — only the spec.

--- a/.agentic/roles/verifier.md
+++ b/.agentic/roles/verifier.md
@@ -1,0 +1,23 @@
+# Role: Verifier
+
+**Mandate:** Run the deterministic checks for a change and report results. The
+Verifier **fixes nothing**.
+
+## Inputs
+- A branch/PR, its `base_sha`/`head_sha`, and the contract's `validation_commands`
+  plus the deterministic checks for its risk class (`../policy.json`).
+
+## Outputs
+- A factual report (optionally a review result with `reviewer_role: verifier`
+  conforming to `../schemas/review.schema.json`) listing each command and outcome.
+
+## Hard constraints
+- **Mutate no files.** Do not edit code, tests, baselines, or config to make a
+  check pass.
+- Run guards, targeted tests, shader-contract checks, the runtime harness, and
+  (for R2+) benchmarks / GPU evidence as required by the risk class.
+- **Report skips and missing hardware explicitly.** If a GPU/Windows lane could
+  not run, say "not run" and why — never imply it passed.
+- Report flaky or non-reproducible results as such; do not paper over them.
+- Do not approve or block on design opinion — that is the reviewers' job; the
+  Verifier reports facts.

--- a/.agentic/schemas/review.schema.json
+++ b/.agentic/schemas/review.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://godotgs.local/.agentic/schemas/review.schema.json",
+  "title": "Agentic Review Result",
+  "description": "Structured output of one reviewer judging a fixed base..head diff. Reviewers change no code.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "reviewer_role",
+    "base_sha",
+    "head_sha",
+    "verdict",
+    "findings",
+    "tests_reviewed",
+    "evidence_reviewed",
+    "blind_spots"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "reviewer_role": {
+      "type": "string",
+      "enum": ["correctness-reviewer", "gpu-performance-reviewer", "verifier"]
+    },
+    "base_sha": { "type": "string" },
+    "head_sha": { "type": "string" },
+    "verdict": { "type": "string", "enum": ["approve", "changes_requested", "blocked"] },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "severity", "category", "path", "evidence", "required_action"],
+        "properties": {
+          "id": { "type": "string" },
+          "severity": { "type": "string", "enum": ["blocker", "high", "medium", "low", "note"] },
+          "category": { "type": "string" },
+          "path": { "type": "string" },
+          "line": { "type": "integer" },
+          "evidence": { "type": "string" },
+          "required_action": { "type": "string" }
+        }
+      }
+    },
+    "tests_reviewed": { "type": "array", "items": { "type": "string" } },
+    "evidence_reviewed": { "type": "array", "items": { "type": "string" } },
+    "blind_spots": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/.agentic/schemas/task.schema.json
+++ b/.agentic/schemas/task.schema.json
@@ -44,6 +44,10 @@
     "validation_commands": { "type": "array", "items": { "type": "string" } },
     "evidence_requirements": { "type": "array", "items": { "type": "string" } },
     "rollback_plan": { "type": "string" },
+    "design_record": {
+      "type": "string",
+      "description": "Link to the ADR / design-change issue. Required for risk classes whose policy sets adr_required (R3)."
+    },
     "stacked_on": {
       "type": "object",
       "description": "Optional: present only for stacked work.",

--- a/.agentic/schemas/task.schema.json
+++ b/.agentic/schemas/task.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://godotgs.local/.agentic/schemas/task.schema.json",
+  "title": "Agentic Task Contract",
+  "description": "A small, explicit specification for one unit of agent work. One contract -> one branch -> one worktree.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "task_id",
+    "github_issue",
+    "title",
+    "baseline_sha",
+    "risk_class",
+    "owned_paths",
+    "forbidden_paths",
+    "dependencies",
+    "problem_statement",
+    "non_goals",
+    "invariants",
+    "acceptance_criteria",
+    "validation_commands",
+    "evidence_requirements",
+    "rollback_plan"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "task_id": { "type": "string", "description": "Stable identifier, e.g. GS-298." },
+    "github_issue": { "type": "string", "description": "Issue reference or URL, e.g. #298." },
+    "title": { "type": "string" },
+    "baseline_sha": { "type": "string", "description": "Immutable base commit the work starts from." },
+    "risk_class": { "type": "string", "enum": ["R0", "R1", "R2", "R3"] },
+    "owned_paths": { "type": "array", "items": { "type": "string" } },
+    "forbidden_paths": { "type": "array", "items": { "type": "string" } },
+    "dependencies": {
+      "type": "array",
+      "description": "Other task_ids or PRs this work depends on; empty if none.",
+      "items": { "type": "string" }
+    },
+    "problem_statement": { "type": "string" },
+    "non_goals": { "type": "array", "items": { "type": "string" } },
+    "invariants": { "type": "array", "items": { "type": "string" } },
+    "acceptance_criteria": { "type": "array", "items": { "type": "string" } },
+    "validation_commands": { "type": "array", "items": { "type": "string" } },
+    "evidence_requirements": { "type": "array", "items": { "type": "string" } },
+    "rollback_plan": { "type": "string" },
+    "stacked_on": {
+      "type": "object",
+      "description": "Optional: present only for stacked work.",
+      "additionalProperties": false,
+      "properties": {
+        "base_pr": { "type": "string" },
+        "base_sha": { "type": "string" }
+      }
+    }
+  }
+}

--- a/.agentic/templates/review.json
+++ b/.agentic/templates/review.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "reviewer_role": "correctness-reviewer",
+  "base_sha": "0000000000000000000000000000000000000000",
+  "head_sha": "1111111111111111111111111111111111111111",
+  "verdict": "changes_requested",
+  "findings": [
+    {
+      "id": "CORR-001",
+      "severity": "high",
+      "category": "resource-lifetime",
+      "path": "modules/gaussian_splatting/renderer/example.cpp",
+      "line": 412,
+      "evidence": "Uniform set can outlive the RenderingDevice generation that created it on the failed-init path.",
+      "required_action": "Store and compare the device generation before reuse; free the uniform set on the early-return path."
+    }
+  ],
+  "tests_reviewed": [
+    "python tests/ci/run_module_tests.py --guard-only"
+  ],
+  "evidence_reviewed": [
+    "No GPU evidence was attached to the PR."
+  ],
+  "blind_spots": [
+    "No AMD/Intel GPU evidence was available; cross-vendor behavior unverified."
+  ]
+}

--- a/.agentic/templates/task.json
+++ b/.agentic/templates/task.json
@@ -6,7 +6,7 @@
   "baseline_sha": "0000000000000000000000000000000000000000",
   "risk_class": "R1",
   "owned_paths": [
-    "modules/gaussian_splatting/<subsystem>/**"
+    "modules/gaussian_splatting/logger/**"
   ],
   "forbidden_paths": [
     "servers/**",

--- a/.agentic/templates/task.json
+++ b/.agentic/templates/task.json
@@ -29,7 +29,7 @@
     "python -m unittest discover -s tests/agentic"
   ],
   "evidence_requirements": [
-    "Executed commands and results recorded in the PR; for R2+ add runtime/GPU evidence."
+    "Executed test commands and their results recorded in the PR."
   ],
   "rollback_plan": "How to revert safely if this change regresses (e.g. revert the single commit; no migration needed)."
 }

--- a/.agentic/templates/task.json
+++ b/.agentic/templates/task.json
@@ -25,7 +25,8 @@
     "Observable, checkable conditions that define done."
   ],
   "validation_commands": [
-    "python tests/ci/run_module_tests.py --guard-only"
+    "python tests/ci/run_module_tests.py --guard-only",
+    "python -m unittest discover -s tests/agentic"
   ],
   "evidence_requirements": [
     "Executed commands and results recorded in the PR; for R2+ add runtime/GPU evidence."

--- a/.agentic/templates/task.json
+++ b/.agentic/templates/task.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "task_id": "GS-000",
+  "github_issue": "#0",
+  "title": "Short imperative summary of the task",
+  "baseline_sha": "0000000000000000000000000000000000000000",
+  "risk_class": "R1",
+  "owned_paths": [
+    "modules/gaussian_splatting/<subsystem>/**"
+  ],
+  "forbidden_paths": [
+    "servers/**",
+    "scene/**",
+    "modules/gaussian_splatting/persistence/**"
+  ],
+  "dependencies": [],
+  "problem_statement": "What is wrong or missing today, stated concretely and verifiably.",
+  "non_goals": [
+    "Explicitly list what this task will NOT do, to keep scope fixed."
+  ],
+  "invariants": [
+    "Properties that must remain true (e.g. no resource leak on failure paths)."
+  ],
+  "acceptance_criteria": [
+    "Observable, checkable conditions that define done."
+  ],
+  "validation_commands": [
+    "python tests/ci/run_module_tests.py --guard-only"
+  ],
+  "evidence_requirements": [
+    "Executed commands and results recorded in the PR; for R2+ add runtime/GPU evidence."
+  ],
+  "rollback_plan": "How to revert safely if this change regresses (e.g. revert the single commit; no migration needed)."
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,32 @@
+# Code owners for GodotGS.
+#
+# Listed paths require review from @klausi3D before merge. There is intentionally
+# no global owner so that unlisted, low-risk paths are not blocked; the sensitive
+# surfaces below — CI/security, agent governance, the GPU render path, on-disk
+# formats, the Godot engine delta, and tests — always need maintainer review.
+#
+# See docs/governance/github-settings.md for the branch-protection settings that
+# make CODEOWNER review enforceable.
+
+/.github/                                    @klausi3D
+/.agentic/                                   @klausi3D
+/AGENTS.md                                   @klausi3D
+/docs/governance/                            @klausi3D
+
+# GPU render path and host/shader contracts (risk class R2).
+/modules/gaussian_splatting/renderer/        @klausi3D
+/modules/gaussian_splatting/shaders/         @klausi3D
+
+# On-disk / serialization formats (risk class R3).
+/modules/gaussian_splatting/persistence/     @klausi3D
+/modules/gaussian_splatting/io/              @klausi3D
+
+# Godot engine delta (risk class R3).
+/servers/                                    @klausi3D
+/scene/                                      @klausi3D
+/editor/                                     @klausi3D
+/platform/                                   @klausi3D
+/core/                                       @klausi3D
+
+# Test and CI harness.
+/tests/                                      @klausi3D

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,8 +10,10 @@
 
 /.github/                                    @klausi3D
 /.agentic/                                   @klausi3D
-/scripts/agentic/                            @klausi3D
-/scripts/docs/                               @klausi3D
+# All of /scripts/ — these are CI/tooling helpers executed by the workflows
+# (e.g. scripts/agentic/*, scripts/docs/check_links.py, scripts/build_documentation.py,
+# scripts/stage_public_docs.py), so changing them changes CI behavior.
+/scripts/                                    @klausi3D
 /AGENTS.md                                   @klausi3D
 /CLAUDE.md                                   @klausi3D
 /docs/governance/                            @klausi3D

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,12 +23,18 @@
 /modules/gaussian_splatting/persistence/     @klausi3D
 /modules/gaussian_splatting/io/              @klausi3D
 
-# Godot engine delta (risk class R3).
+# Godot engine delta (risk class R3) — must match the R3 engine-delta paths in
+# .agentic/policy.json.
 /servers/                                    @klausi3D
 /scene/                                      @klausi3D
 /editor/                                     @klausi3D
 /platform/                                   @klausi3D
 /core/                                       @klausi3D
+/drivers/                                    @klausi3D
+/main/                                       @klausi3D
+/thirdparty/                                 @klausi3D
+/SConstruct                                  @klausi3D
+/methods.py                                  @klausi3D
 
-# Test and CI harness.
+# Test and CI harness (the deterministic-check / release-gate runners are R3 in policy).
 /tests/                                      @klausi3D

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,9 @@
 
 /.github/                                    @klausi3D
 /.agentic/                                   @klausi3D
+/scripts/agentic/                            @klausi3D
 /AGENTS.md                                   @klausi3D
+/CLAUDE.md                                   @klausi3D
 /docs/governance/                            @klausi3D
 
 # GPU render path and host/shader contracts (risk class R2).

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,13 +15,19 @@
 /CLAUDE.md                                   @klausi3D
 /docs/governance/                            @klausi3D
 
-# GPU render path and host/shader contracts (risk class R2).
+# GPU render path, compute, streaming/LOD, and host/shader contracts (risk class R2).
 /modules/gaussian_splatting/renderer/        @klausi3D
 /modules/gaussian_splatting/shaders/         @klausi3D
+/modules/gaussian_splatting/compute/         @klausi3D
+/modules/gaussian_splatting/lod/             @klausi3D
+/modules/gaussian_splatting/asset_management/ @klausi3D
 
 # On-disk / serialization formats (risk class R3).
 /modules/gaussian_splatting/persistence/     @klausi3D
 /modules/gaussian_splatting/io/              @klausi3D
+
+# Release-gate policy manifest (risk class R3).
+/docs/reference/renderer_release_gate_manifest.json @klausi3D
 
 # Godot engine delta (risk class R3) — must match the R3 engine-delta paths in
 # .agentic/policy.json.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,6 +22,9 @@
 /modules/gaussian_splatting/compute/         @klausi3D
 /modules/gaussian_splatting/lod/             @klausi3D
 /modules/gaussian_splatting/asset_management/ @klausi3D
+/modules/gaussian_splatting/core/*streaming* @klausi3D
+/modules/gaussian_splatting/core/*residency* @klausi3D
+/modules/gaussian_splatting/core/*vram*      @klausi3D
 
 # On-disk / serialization formats (risk class R3).
 /modules/gaussian_splatting/persistence/     @klausi3D

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 /.github/                                    @klausi3D
 /.agentic/                                   @klausi3D
 /scripts/agentic/                            @klausi3D
+/scripts/docs/                               @klausi3D
 /AGENTS.md                                   @klausi3D
 /CLAUDE.md                                   @klausi3D
 /docs/governance/                            @klausi3D

--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -7,8 +7,9 @@ body:
     attributes:
       value: |
         One task → one branch → one worktree. See `docs/governance/agentic-engineering.md`.
-        The risk class is re-derived from the diff in CI and the higher value wins, so do
-        not under-declare it.
+        The Agentic PR Gate re-derives the risk class from the diff and reports it;
+        reviewers/CODEOWNERS use that to catch under-declaration (and `check_pr_contract`
+        takes the higher of declared vs computed when a task contract is checked).
   - type: input
     id: task_id
     attributes:

--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -1,0 +1,98 @@
+name: Agent Task
+description: Define a scoped task contract for an AI coding agent (or human) to implement.
+title: "[task]: "
+labels: ["agent-task"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        One task → one branch → one worktree. See `docs/governance/agentic-engineering.md`.
+        The risk class is re-derived from the diff in CI and the higher value wins, so do
+        not under-declare it.
+  - type: input
+    id: task_id
+    attributes:
+      label: Task ID
+      description: Stable identifier, e.g. GS-298.
+    validations:
+      required: true
+  - type: input
+    id: baseline_sha
+    attributes:
+      label: Baseline SHA
+      description: Immutable base commit the work starts from.
+    validations:
+      required: true
+  - type: dropdown
+    id: risk_class
+    attributes:
+      label: Risk class
+      options:
+        - R0 (docs / agentic governance)
+        - R1 (local module / test change)
+        - R2 (renderer / shaders / streaming / performance)
+        - R3 (engine delta / persistence / release / security)
+    validations:
+      required: true
+  - type: textarea
+    id: problem_statement
+    attributes:
+      label: Problem statement
+      description: What is wrong or missing today, stated concretely and verifiably.
+    validations:
+      required: true
+  - type: textarea
+    id: owned_paths
+    attributes:
+      label: Owned paths
+      description: Paths this task may modify (one per line).
+    validations:
+      required: true
+  - type: textarea
+    id: forbidden_paths
+    attributes:
+      label: Forbidden paths
+      description: Paths this task must not touch (one per line).
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: What this task will explicitly NOT do.
+  - type: textarea
+    id: invariants
+    attributes:
+      label: Invariants
+      description: Properties that must remain true (e.g. no resource leak on failure paths).
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: Observable, checkable conditions that define done.
+    validations:
+      required: true
+  - type: textarea
+    id: validation_commands
+    attributes:
+      label: Validation commands
+      description: Exact commands a verifier will run.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence_requirements
+    attributes:
+      label: Evidence requirements
+      description: For R2+, the runtime/GPU/benchmark evidence required.
+  - type: input
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Other task IDs / PRs this depends on (or "none").
+  - type: textarea
+    id: rollback_plan
+    attributes:
+      label: Rollback plan
+      description: How to revert safely if this regresses.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/design-change.yml
+++ b/.github/ISSUE_TEMPLATE/design-change.yml
@@ -1,0 +1,53 @@
+name: Design Change (R3 / architecture)
+description: Propose a high-risk or architectural change (engine delta, on-disk format, public API, release/security) before implementation.
+title: "[design]: "
+labels: ["design-change", "needs-adr"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for **R3** or architecture-affecting changes. A design record must be
+        agreed before implementation. See `docs/governance/agentic-engineering.md` and
+        `docs/governance/review-policy.md`.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve, and why now?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: The design, including affected subsystems and paths.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches and why they were rejected.
+    validations:
+      required: true
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility and migration
+      description: Impact on on-disk formats, public APIs, and existing scenes/projects; migration path.
+    validations:
+      required: true
+  - type: textarea
+    id: rollback
+    attributes:
+      label: Rollback
+      description: How the change can be reverted if it regresses.
+    validations:
+      required: true
+  - type: textarea
+    id: risk
+    attributes:
+      label: Risk and evidence plan
+      description: Key risks and the evidence (tests, GPU/runtime, benchmarks) that will validate the change.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,10 @@
 ## Risk class
 
 <!-- R0 / R1 / R2 / R3 (see docs/governance/agentic-engineering.md).
-     CI re-derives this from the diff and uses the higher of the two. -->
+     The Agentic PR Gate re-derives the risk class from this PR's diff
+     (classify_change) and reports it. When a task contract is supplied,
+     check_pr_contract takes the higher of declared vs computed and enforces
+     path scope; a higher computed class is review pushback regardless. -->
 
 - Declared risk class:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,79 @@
+<!--
+  See AGENTS.md and docs/governance/review-policy.md. Keep the change small and
+  reviewable. Fill in every section; delete a section only if it is genuinely N/A
+  and say why.
+-->
+
+## Summary
+
+<!-- What changed and why, in a few sentences. -->
+
+## Linked task / issue
+
+<!-- Task contract id and/or GitHub issue, e.g. GS-298 / #298. -->
+
+## Risk class
+
+<!-- R0 / R1 / R2 / R3 (see docs/governance/agentic-engineering.md).
+     CI re-derives this from the diff and uses the higher of the two. -->
+
+- Declared risk class:
+
+## Base / head
+
+- Base SHA:
+- Head SHA:
+- Stacked on (if applicable): base PR #___ at base SHA ___
+
+## Scope
+
+- Owned paths touched:
+- Explicit non-goals (what this PR does NOT do):
+
+## Invariants
+
+<!-- Properties that must remain true (e.g. no resource leak on failure paths,
+     host/shader layout in sync). -->
+
+## User-visible behavior
+
+<!-- Any change a user/developer would observe, or "none". -->
+
+## Godot upstream delta
+
+<!-- Does this touch servers/scene/core/editor/platform? If yes, justify. -->
+
+## Validation
+
+<!-- Exact commands and their results. Mark unavailable hardware as "not run". -->
+
+```text
+
+```
+
+## GPU / performance evidence (R2+)
+
+<!-- Runtime/GPU harness or benchmark evidence vs the immutable base; VRAM and
+     frame-time numbers for perf/memory claims; real-scan visual validation for
+     rendering-math changes. "N/A" for non-R2 changes. -->
+
+## Review artifacts
+
+<!-- Links to review results (correctness / GPU-performance), if produced. -->
+
+## Known blind spots
+
+<!-- What you could not verify (e.g. no AMD/Intel GPU evidence). -->
+
+## Rollback plan
+
+<!-- How to revert safely if this regresses. -->
+
+## Checklist
+
+- [ ] Scope is focused and justified; no unrelated changes.
+- [ ] No secrets or tokens added.
+- [ ] No generated artifacts, transcripts, or session IDs committed.
+- [ ] No baseline/threshold/gate weakened to make a check pass.
+- [ ] Validation commands and results included above.
+- [ ] Canonical docs updated if behavior changed.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,7 +19,8 @@ GitHub's Actions tab can also show historical workflow names from past runs, dis
 
 `agentic-pr-gate` (the job name in `agentic_pr_gate.yml`, shown in the PR checks UI
 as `Agentic PR Gate / agentic-pr-gate`) is the fork-safe, always-on blocking check
-intended for `master` branch protection (see `docs/governance/github-settings.md`).
+intended for `master` branch protection (see `docs/governance/github-settings.md`,
+added by a sibling PR in this foundation series).
 It runs only on GitHub-hosted runners, so external fork PRs always receive a status
 without touching the self-hosted lanes. It runs:
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -13,14 +13,15 @@ GitHub's Actions tab can also show historical workflow names from past runs, dis
 | Gaussian Production Gates | `gaussian_production_gates.yml` | Enforces guard checks, pipeline smoke, runtime validation, the blocking streaming gate, and optional non-blocking benchmark evidence surfaces. | Owns the single Windows build for validation workflows. `streaming-gpu-ci` is the canonical blocking GPU-backed streaming runtime gate; `openworld-proof-dev` and `openworld-proof-weekly` are evidence-only benchmark surfaces. |
 | Gaussian Shader Validation | `gaussian_shader_validation.yml` | Validates shader compile matrix and host/shader contract checks. | Focused shader CI gate. |
 | Release Builds | `release_builds.yml` | Builds Linux and Windows editors for CI artifacts, nightly prereleases, and optional stable-tag publishes. | Publishes Linux tarballs and Windows zips on the nightly schedule and on `v*` tag pushes. |
-| Agentic PR Gate | `agentic_pr_gate.yml` | Fork-safe, always-on gate: validates the agentic control plane, runs the agentic tests, the agentic/governance link check, and the GPU-free `--guard-only` lane. | GitHub-hosted (`ubuntu-latest`); runs on every PR and the merge queue. Required check name: `Agentic PR Gate / required`. |
+| Agentic PR Gate | `agentic_pr_gate.yml` | Fork-safe, always-on gate: validates the agentic control plane, runs the agentic tests, the agentic/governance link check, and the GPU-free `--guard-only` lane. | GitHub-hosted (`ubuntu-latest`); runs on every PR and the merge queue. Required status check (job name): `agentic-pr-gate`. |
 
 ## Required Checks
 
-`Agentic PR Gate / required` is the fork-safe, always-on blocking check intended for
-`master` branch protection (see `docs/governance/github-settings.md`). It runs only
-on GitHub-hosted runners, so external fork PRs always receive a status without
-touching the self-hosted lanes. It runs:
+`agentic-pr-gate` (the job name in `agentic_pr_gate.yml`, shown in the PR checks UI
+as `Agentic PR Gate / agentic-pr-gate`) is the fork-safe, always-on blocking check
+intended for `master` branch protection (see `docs/governance/github-settings.md`).
+It runs only on GitHub-hosted runners, so external fork PRs always receive a status
+without touching the self-hosted lanes. It runs:
 
 - `python scripts/agentic/validate_repo_contract.py`
 - the `scripts/agentic` contract validators against the shipped templates

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,6 +1,6 @@
 # GitHub Actions Workflows
 
-This directory contains 5 active workflow files.
+This directory contains 6 active workflow files.
 
 GitHub's Actions tab can also show historical workflow names from past runs, disabled files, or workflow files that are no longer present in this directory. This README tracks the workflow files currently checked into `.github/workflows/`.
 
@@ -13,6 +13,24 @@ GitHub's Actions tab can also show historical workflow names from past runs, dis
 | Gaussian Production Gates | `gaussian_production_gates.yml` | Enforces guard checks, pipeline smoke, runtime validation, the blocking streaming gate, and optional non-blocking benchmark evidence surfaces. | Owns the single Windows build for validation workflows. `streaming-gpu-ci` is the canonical blocking GPU-backed streaming runtime gate; `openworld-proof-dev` and `openworld-proof-weekly` are evidence-only benchmark surfaces. |
 | Gaussian Shader Validation | `gaussian_shader_validation.yml` | Validates shader compile matrix and host/shader contract checks. | Focused shader CI gate. |
 | Release Builds | `release_builds.yml` | Builds Linux and Windows editors for CI artifacts, nightly prereleases, and optional stable-tag publishes. | Publishes Linux tarballs and Windows zips on the nightly schedule and on `v*` tag pushes. |
+| Agentic PR Gate | `agentic_pr_gate.yml` | Fork-safe, always-on gate: validates the agentic control plane, runs the agentic tests, the agentic/governance link check, and the GPU-free `--guard-only` lane. | GitHub-hosted (`ubuntu-latest`); runs on every PR and the merge queue. Required check name: `Agentic PR Gate / required`. |
+
+## Required Checks
+
+`Agentic PR Gate / required` is the fork-safe, always-on blocking check intended for
+`master` branch protection (see `docs/governance/github-settings.md`). It runs only
+on GitHub-hosted runners, so external fork PRs always receive a status without
+touching the self-hosted lanes. It runs:
+
+- `python scripts/agentic/validate_repo_contract.py`
+- the `scripts/agentic` contract validators against the shipped templates
+- `python -m unittest discover -s tests/agentic`
+- `python scripts/docs/check_links.py docs/governance README.md CONTRIBUTING.md AGENTS.md`
+- `python tests/ci/run_module_tests.py --guard-only` (GPU-free; the StringName guard
+  self-skips when no Godot binary is present)
+
+The link check here is scoped to the agentic/governance surface; the full-tree link
+check remains a contributor step (`docs/governance/contribution-standards.md`).
 
 ## Manual Dispatch Inputs
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -26,12 +26,13 @@ without touching the self-hosted lanes. It runs:
 - `python scripts/agentic/validate_repo_contract.py`
 - the `scripts/agentic` contract validators against the shipped templates
 - `python -m unittest discover -s tests/agentic`
-- `python scripts/docs/check_links.py docs/governance README.md CONTRIBUTING.md AGENTS.md`
+- `python scripts/docs/check_links.py docs README.md BUILDING.md CONTRIBUTING.md AGENTS.md CLAUDE.md`
 - `python tests/ci/run_module_tests.py --guard-only` (GPU-free; the StringName guard
   self-skips when no Godot binary is present)
 
-The link check here is scoped to the agentic/governance surface; the full-tree link
-check remains a contributor step (`docs/governance/contribution-standards.md`).
+The link check covers the full docs tree plus the root governance docs (only paths
+present in the tree are passed, so it is robust on partial trees and is the full-docs
+check on `master`).
 
 ## Manual Dispatch Inputs
 

--- a/.github/workflows/agentic_pr_gate.yml
+++ b/.github/workflows/agentic_pr_gate.yml
@@ -54,19 +54,18 @@ jobs:
       - name: Run agentic unit tests
         run: python -m unittest discover -s tests/agentic -v
 
-      - name: Check documentation links (agentic/governance surface, when present)
-        # Scoped to the agentic/governance surface so the required gate stays green;
-        # the full-tree link check is a contributor step (see contribution-standards.md).
-        # Only check paths that exist so the gate is robust on trees that don't carry
-        # the whole foundation yet (e.g. before the governance docs land); on master,
-        # where all are present, this checks the full agentic/governance surface.
+      - name: Check documentation links (full docs surface, present paths)
+        # Checks the full docs tree plus the root governance docs. Only existing paths
+        # are passed so the gate is robust on trees that don't carry the whole
+        # foundation yet (e.g. before the AGENTS.md hierarchy lands); on master, where
+        # all are present, this is the full-docs link check.
         run: |
           targets=()
-          for p in docs/governance README.md CONTRIBUTING.md AGENTS.md; do
+          for p in docs README.md BUILDING.md CONTRIBUTING.md AGENTS.md CLAUDE.md; do
             [ -e "$p" ] && targets+=("$p")
           done
           if [ ${#targets[@]} -eq 0 ]; then
-            echo "No agentic/governance docs present in this tree; skipping link check."
+            echo "No documentation present in this tree; skipping link check."
           else
             echo "Link-checking: ${targets[*]}"
             python scripts/docs/check_links.py "${targets[@]}"

--- a/.github/workflows/agentic_pr_gate.yml
+++ b/.github/workflows/agentic_pr_gate.yml
@@ -1,0 +1,60 @@
+name: Agentic PR Gate
+
+# Fork-safe, always-on required gate. Runs on every pull request (no path filter)
+# and on the merge queue, entirely on a GitHub-hosted runner, so external fork PRs
+# always get a blocking signal without touching the persistent self-hosted runners.
+# Required check name: "Agentic PR Gate / required".
+
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agentic-pr-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHONUTF8: "1"
+
+jobs:
+  required:
+    name: required
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate agentic control plane
+        run: python scripts/agentic/validate_repo_contract.py
+
+      - name: Exercise contract validators on shipped templates
+        run: |
+          python scripts/agentic/validate_review.py --review .agentic/templates/review.json
+          python scripts/agentic/check_pr_contract.py \
+            --contract .agentic/templates/task.json \
+            --paths modules/gaussian_splatting/logger/example.cpp
+          python scripts/agentic/classify_change.py \
+            --paths modules/gaussian_splatting/renderer/example.cpp
+
+      - name: Run agentic unit tests
+        run: python -m unittest discover -s tests/agentic -v
+
+      - name: Check documentation links (agentic/governance surface)
+        # Scoped to the agentic-governance surface so the required gate stays green;
+        # the full-tree link check is a contributor step (see contribution-standards.md).
+        run: python scripts/docs/check_links.py docs/governance README.md CONTRIBUTING.md AGENTS.md
+
+      - name: Run guard-only checks (GPU-free, portable)
+        run: python tests/ci/run_module_tests.py --guard-only

--- a/.github/workflows/agentic_pr_gate.yml
+++ b/.github/workflows/agentic_pr_gate.yml
@@ -51,10 +51,23 @@ jobs:
       - name: Run agentic unit tests
         run: python -m unittest discover -s tests/agentic -v
 
-      - name: Check documentation links (agentic/governance surface)
-        # Scoped to the agentic-governance surface so the required gate stays green;
+      - name: Check documentation links (agentic/governance surface, when present)
+        # Scoped to the agentic/governance surface so the required gate stays green;
         # the full-tree link check is a contributor step (see contribution-standards.md).
-        run: python scripts/docs/check_links.py docs/governance README.md CONTRIBUTING.md AGENTS.md
+        # Only check paths that exist so the gate is robust on trees that don't carry
+        # the whole foundation yet (e.g. before the governance docs land); on master,
+        # where all are present, this checks the full agentic/governance surface.
+        run: |
+          targets=()
+          for p in docs/governance README.md CONTRIBUTING.md AGENTS.md; do
+            [ -e "$p" ] && targets+=("$p")
+          done
+          if [ ${#targets[@]} -eq 0 ]; then
+            echo "No agentic/governance docs present in this tree; skipping link check."
+          else
+            echo "Link-checking: ${targets[*]}"
+            python scripts/docs/check_links.py "${targets[@]}"
+          fi
 
       - name: Run guard-only checks (GPU-free, portable)
         run: python tests/ci/run_module_tests.py --guard-only

--- a/.github/workflows/agentic_pr_gate.yml
+++ b/.github/workflows/agentic_pr_gate.yml
@@ -3,7 +3,10 @@ name: Agentic PR Gate
 # Fork-safe, always-on required gate. Runs on every pull request (no path filter)
 # and on the merge queue, entirely on a GitHub-hosted runner, so external fork PRs
 # always get a blocking signal without touching the persistent self-hosted runners.
-# Required check name: "Agentic PR Gate / required".
+#
+# The branch-protection required status check is the JOB name, "agentic-pr-gate"
+# (unique across workflows, per GitHub's required-checks rules). The PR checks UI
+# displays it as "Agentic PR Gate / agentic-pr-gate".
 
 on:
   pull_request:
@@ -21,8 +24,8 @@ env:
   PYTHONUTF8: "1"
 
 jobs:
-  required:
-    name: required
+  agentic-pr-gate:
+    name: agentic-pr-gate
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/agentic_pr_gate.yml
+++ b/.github/workflows/agentic_pr_gate.yml
@@ -48,8 +48,12 @@ jobs:
           python scripts/agentic/check_pr_contract.py \
             --contract .agentic/templates/task.json \
             --paths modules/gaussian_splatting/logger/example.cpp
-          python scripts/agentic/classify_change.py \
-            --paths modules/gaussian_splatting/renderer/example.cpp
+
+      - name: Re-derive risk class from this PR's diff
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          echo "Risk class derived from the changed files in this PR:"
+          python scripts/agentic/classify_change.py --base-ref "${{ github.event.pull_request.base.sha }}"
 
       - name: Run agentic unit tests
         run: python -m unittest discover -s tests/agentic -v

--- a/.github/workflows/agentic_pr_gate.yml
+++ b/.github/workflows/agentic_pr_gate.yml
@@ -33,6 +33,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # This gate checks out fork-PR-controlled code and runs scripts/tests from it.
+          # Do not leave the GITHUB_TOKEN in local git config where an invoked script
+          # could read it; the gate runs no authenticated git commands after checkout.
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -508,6 +508,15 @@ node_modules/
 /measure_*.gd
 /measure_*.gd.uid
 
+# Agentic local / ephemeral runtime state.
+# NOTE: the canonical .agentic/ control-plane files (policy, schemas, roles,
+# templates) ARE tracked; only local instances and scratch are ignored here.
+.agentic-local/
+.worktrees/
+/agentic_task_*.local.json
+/agentic_review_*.local.json
+*.agent-session.json
+
 # Misc local outputs
 /addons/*/bin/
 *.wasm

--- a/docs/testing/setup-guide.md
+++ b/docs/testing/setup-guide.md
@@ -44,7 +44,7 @@ Run Gaussian Splatting test lanes through maintained runners in `tests/ci/` and 
 | `run_tests.bat` | Windows batch full module run | `run_tests.bat:24`, `run_tests.bat:31` |
 | `ci/scripts/run_module_tests.bat` | Windows quick guard + module run | `ci/scripts/run_module_tests.bat:23`, `ci/scripts/run_module_tests.bat:47` |
 
-## GPU Test Harness (`--gs-gpu-test`)
+## GPU Test Harness (gs-gpu-test)
 
 The `--gs-gpu-test` entrypoint is a second doctest runner specifically for tests tagged `[RequiresGPU]`. It bootstraps `RenderingDevice` offscreen via `Main::test_setup()` + `RenderingContextDriverVulkan` / `RenderingContextDriverD3D12` (no `SceneTree`, no window) and is therefore distinct from the `--test` lane driven by `tests/ci/run_module_tests.py`.
 

--- a/scripts/agentic/check_pr_contract.py
+++ b/scripts/agentic/check_pr_contract.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Check a pull request's task contract against the agentic policy.
+
+Validates the contract against ``.agentic/schemas/task.schema.json`` and enforces
+the rules a schema cannot express:
+
+* required fields are present **and non-empty**;
+* the author's declared ``risk_class`` is cross-checked against the risk class
+  derived from the changed paths (``classify_change``) - the **higher** class
+  wins, so a PR cannot under-declare its risk;
+* the effective risk class's policy requirements (rollback plan, evidence) are met;
+* a stacked PR declares both its base PR and base SHA.
+
+Exit code is non-zero if the contract is non-compliant.
+
+Examples
+--------
+    python scripts/agentic/check_pr_contract.py --contract task.json --base-ref master
+    python scripts/agentic/check_pr_contract.py --contract task.json --paths modules/gaussian_splatting/renderer/x.cpp
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_POLICY = ROOT / ".agentic" / "policy.json"
+DEFAULT_TASK_SCHEMA = ROOT / ".agentic" / "schemas" / "task.schema.json"
+
+# Fields that must be present AND non-empty (beyond schema presence checks).
+NON_EMPTY_STRING_FIELDS = ("task_id", "github_issue", "title", "baseline_sha", "rollback_plan", "problem_statement")
+NON_EMPTY_ARRAY_FIELDS = ("owned_paths", "invariants", "acceptance_criteria", "validation_commands")
+
+
+def _load_sibling(name: str):
+    path = Path(__file__).with_name(f"{name}.py")
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+classify_change = _load_sibling("classify_change")
+validate_review = _load_sibling("validate_review")
+
+
+def check_contract(
+    contract: dict[str, Any],
+    policy: dict[str, Any],
+    task_schema: dict[str, Any],
+    changed_paths: list[str] | None,
+) -> list[str]:
+    errors: list[str] = []
+
+    # 1. Schema validation.
+    errors.extend(validate_review.validate_instance(contract, task_schema, "$"))
+
+    # 2. Non-empty required fields.
+    for field in NON_EMPTY_STRING_FIELDS:
+        value = contract.get(field)
+        if isinstance(value, str) and not value.strip():
+            errors.append(f"$.{field}: must not be empty")
+    for field in NON_EMPTY_ARRAY_FIELDS:
+        value = contract.get(field)
+        if isinstance(value, list) and len(value) == 0:
+            errors.append(f"$.{field}: must not be empty")
+
+    ordering = policy["classification"]["ordering"]
+    rank = {cls: index for index, cls in enumerate(ordering)}
+    declared = contract.get("risk_class")
+
+    # 3. Cross-check declared risk class against the diff.
+    effective = declared
+    if changed_paths is not None:
+        computed, _ = classify_change.classify_paths(changed_paths, policy)
+        if declared in rank and computed in rank:
+            if rank[computed] > rank[declared]:
+                errors.append(
+                    f"$.risk_class: declared {declared} understates computed {computed} "
+                    f"from the changed paths; use the higher class"
+                )
+                effective = computed
+
+    # 4. Effective-class policy requirements.
+    class_policy = policy.get("risk_classes", {}).get(effective)
+    if class_policy:
+        if class_policy.get("rollback_required") and not str(contract.get("rollback_plan", "")).strip():
+            errors.append(f"$.rollback_plan: required for risk class {effective}")
+        if class_policy.get("evidence_requirements") and not contract.get("evidence_requirements"):
+            errors.append(f"$.evidence_requirements: required for risk class {effective}")
+        if class_policy.get("adr_required"):
+            # ADR existence is a human-checked process step; surface it explicitly.
+            errors.append(
+                f"note: risk class {effective} requires a design record (ADR / design-change "
+                f"issue) before implementation - confirm it is linked in the PR"
+            )
+
+    # 5. Stacked PR completeness.
+    stacked = contract.get("stacked_on")
+    if isinstance(stacked, dict):
+        for field in ("base_pr", "base_sha"):
+            if not str(stacked.get(field, "")).strip():
+                errors.append(f"$.stacked_on.{field}: required for a stacked PR")
+
+    return errors
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--contract", type=Path, required=True, help="Path to the task contract JSON.")
+    parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY, help="Path to policy.json.")
+    parser.add_argument("--task-schema", type=Path, default=DEFAULT_TASK_SCHEMA, help="Path to task.schema.json.")
+    parser.add_argument("--paths", nargs="*", help="Explicit changed paths for the risk cross-check.")
+    parser.add_argument("--base-ref", help="Git ref to diff HEAD against for the risk cross-check.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    policy = classify_change.load_policy(args.policy)
+    with open(args.task_schema, encoding="utf-8") as handle:
+        task_schema = json.load(handle)
+    contract = json.loads(args.contract.read_text(encoding="utf-8"))
+
+    changed_paths: list[str] | None
+    if args.paths is not None:
+        changed_paths = args.paths
+    elif args.base_ref:
+        changed_paths = classify_change.git_changed_paths(args.base_ref)
+    else:
+        changed_paths = None
+        print("warning: no --paths/--base-ref; skipping risk-class cross-check", file=sys.stderr)
+
+    errors = check_contract(contract, policy, task_schema, changed_paths)
+
+    # "note:" lines are advisory; treat only hard errors as failures.
+    hard_errors = [error for error in errors if not error.startswith("note:")]
+    notes = [error for error in errors if error.startswith("note:")]
+
+    for note in notes:
+        print(note)
+    if hard_errors:
+        print("PR contract is NON-COMPLIANT:")
+        for error in hard_errors:
+            print(f"  - {error}")
+        return 1
+
+    print("PR contract is compliant.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/agentic/check_pr_contract.py
+++ b/scripts/agentic/check_pr_contract.py
@@ -87,6 +87,18 @@ def check_contract(
                 )
                 effective = computed
 
+    # 3b. Enforce scope: changed paths must stay inside owned_paths and never match
+    # forbidden_paths (the implementer constraint the contract is meant to enforce).
+    if changed_paths is not None:
+        owned = contract.get("owned_paths") or []
+        forbidden = contract.get("forbidden_paths") or []
+        for raw in changed_paths:
+            norm = classify_change._norm(raw)
+            if any(classify_change._matches(norm, classify_change._norm(g)) for g in forbidden):
+                errors.append(f"$.forbidden_paths: changed path '{norm}' matches a forbidden path")
+            elif owned and not any(classify_change._matches(norm, classify_change._norm(g)) for g in owned):
+                errors.append(f"$.owned_paths: changed path '{norm}' is outside the declared owned_paths")
+
     # 4. Effective-class policy requirements.
     class_policy = policy.get("risk_classes", {}).get(effective)
     if class_policy:

--- a/scripts/agentic/check_pr_contract.py
+++ b/scripts/agentic/check_pr_contract.py
@@ -89,10 +89,14 @@ def check_contract(
 
     # 3b. Enforce scope: changed paths must stay inside owned_paths and never match
     # forbidden_paths (the implementer constraint the contract is meant to enforce).
+    # Only string globs/paths are considered; malformed non-string entries are caught
+    # by the schema check above and must not crash this gate.
     if changed_paths is not None:
-        owned = contract.get("owned_paths") or []
-        forbidden = contract.get("forbidden_paths") or []
+        owned = [g for g in (contract.get("owned_paths") or []) if isinstance(g, str)]
+        forbidden = [g for g in (contract.get("forbidden_paths") or []) if isinstance(g, str)]
         for raw in changed_paths:
+            if not isinstance(raw, str):
+                continue
             norm = classify_change._norm(raw)
             if any(classify_change._matches(norm, classify_change._norm(g)) for g in forbidden):
                 errors.append(f"$.forbidden_paths: changed path '{norm}' matches a forbidden path")

--- a/scripts/agentic/check_pr_contract.py
+++ b/scripts/agentic/check_pr_contract.py
@@ -115,6 +115,15 @@ def check_contract(
                 f"$.design_record: risk class {effective} requires a linked design record "
                 f"(ADR / design-change issue) before implementation"
             )
+        # The contract must commit to actually running the class's deterministic
+        # checks; otherwise a high-risk task could declare validation_commands: ["true"].
+        declared_cmds = {c for c in (contract.get("validation_commands") or []) if isinstance(c, str)}
+        for command in class_policy.get("deterministic_checks", []):
+            if command not in declared_cmds:
+                errors.append(
+                    f"$.validation_commands: risk class {effective} requires the deterministic "
+                    f"check '{command}'"
+                )
 
     # 5. Stacked PR completeness.
     stacked = contract.get("stacked_on")

--- a/scripts/agentic/check_pr_contract.py
+++ b/scripts/agentic/check_pr_contract.py
@@ -110,11 +110,10 @@ def check_contract(
             errors.append(f"$.rollback_plan: required for risk class {effective}")
         if class_policy.get("evidence_requirements") and not contract.get("evidence_requirements"):
             errors.append(f"$.evidence_requirements: required for risk class {effective}")
-        if class_policy.get("adr_required"):
-            # ADR existence is a human-checked process step; surface it explicitly.
+        if class_policy.get("adr_required") and not str(contract.get("design_record", "")).strip():
             errors.append(
-                f"note: risk class {effective} requires a design record (ADR / design-change "
-                f"issue) before implementation - confirm it is linked in the PR"
+                f"$.design_record: risk class {effective} requires a linked design record "
+                f"(ADR / design-change issue) before implementation"
             )
 
     # 5. Stacked PR completeness.

--- a/scripts/agentic/check_pr_contract.py
+++ b/scripts/agentic/check_pr_contract.py
@@ -146,6 +146,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--task-schema", type=Path, default=DEFAULT_TASK_SCHEMA, help="Path to task.schema.json.")
     parser.add_argument("--paths", nargs="*", help="Explicit changed paths for the risk cross-check.")
     parser.add_argument("--base-ref", help="Git ref to diff HEAD against for the risk cross-check.")
+    parser.add_argument(
+        "--schema-only",
+        action="store_true",
+        help="Validate the contract document alone, WITHOUT the risk/scope cross-check. "
+        "Not a full PR-gate check; must be requested explicitly.",
+    )
     return parser
 
 
@@ -162,9 +168,17 @@ def main(argv: list[str] | None = None) -> int:
         changed_paths = args.paths
     elif args.base_ref:
         changed_paths = classify_change.git_changed_paths(args.base_ref)
-    else:
+    elif args.schema_only:
+        # Explicit opt-out: validate the document only (no risk/scope enforcement).
         changed_paths = None
-        print("warning: no --paths/--base-ref; skipping risk-class cross-check", file=sys.stderr)
+    else:
+        print(
+            "error: a full PR-gate check needs the diff — pass --paths or --base-ref "
+            "(or --schema-only to validate the contract document without the risk/scope "
+            "cross-check)",
+            file=sys.stderr,
+        )
+        return 2
 
     errors = check_contract(contract, policy, task_schema, changed_paths)
 

--- a/scripts/agentic/check_pr_contract.py
+++ b/scripts/agentic/check_pr_contract.py
@@ -108,8 +108,12 @@ def check_contract(
     if class_policy:
         if class_policy.get("rollback_required") and not str(contract.get("rollback_plan", "")).strip():
             errors.append(f"$.rollback_plan: required for risk class {effective}")
-        if class_policy.get("evidence_requirements") and not contract.get("evidence_requirements"):
-            errors.append(f"$.evidence_requirements: required for risk class {effective}")
+        # The contract must carry the class's policy evidence items, not just any
+        # non-empty list (otherwise an R2/R3 task could pass with ['n/a']).
+        declared_evidence = {e for e in (contract.get("evidence_requirements") or []) if isinstance(e, str)}
+        for item in class_policy.get("evidence_requirements", []):
+            if item not in declared_evidence:
+                errors.append(f"$.evidence_requirements: risk class {effective} requires evidence item: '{item}'")
         if class_policy.get("adr_required") and not str(contract.get("design_record", "")).strip():
             errors.append(
                 f"$.design_record: risk class {effective} requires a linked design record "

--- a/scripts/agentic/classify_change.py
+++ b/scripts/agentic/classify_change.py
@@ -15,9 +15,9 @@ Examples
 from __future__ import annotations
 
 import argparse
-import fnmatch
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -25,6 +25,8 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_POLICY = ROOT / ".agentic" / "policy.json"
+
+_GLOB_REGEX_CACHE: dict[str, "re.Pattern[str]"] = {}
 
 
 def load_policy(policy_path: Path) -> dict[str, Any]:
@@ -39,10 +41,33 @@ def _norm(path: str) -> str:
     return text
 
 
+def _glob_to_regex(glob: str) -> "re.Pattern[str]":
+    """Path-aware glob: ``**`` matches across ``/``, ``*`` matches within one path
+    segment, ``?`` matches one non-``/`` char. Case-sensitive."""
+    pattern = _GLOB_REGEX_CACHE.get(glob)
+    if pattern is None:
+        out: list[str] = []
+        i, n = 0, len(glob)
+        while i < n:
+            if glob[i : i + 2] == "**":
+                out.append(".*")
+                i += 2
+            elif glob[i] == "*":
+                out.append("[^/]*")
+                i += 1
+            elif glob[i] == "?":
+                out.append("[^/]")
+                i += 1
+            else:
+                out.append(re.escape(glob[i]))
+                i += 1
+        pattern = re.compile("^" + "".join(out) + r"\Z")
+        _GLOB_REGEX_CACHE[glob] = pattern
+    return pattern
+
+
 def _matches(path: str, glob: str) -> bool:
-    # Case-sensitive matching; fnmatch's ``*`` spans ``/`` which is the behavior
-    # we want for ``**``-style prefixes used in the policy globs.
-    return fnmatch.fnmatchcase(path, glob)
+    return _glob_to_regex(glob).match(path) is not None
 
 
 def classify_paths(paths: list[str], policy: dict[str, Any]) -> tuple[str, list[dict[str, str]]]:

--- a/scripts/agentic/classify_change.py
+++ b/scripts/agentic/classify_change.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Derive the agentic risk class (R0-R3) for a set of changed paths.
+
+Classification rules live in ``.agentic/policy.json``. For each changed path the
+highest matching class is taken; the overall result is the maximum class across
+all paths. Paths that match no rule fall back to ``default_unclassified`` (R3) so
+that unrecognized, potentially sensitive paths fail closed.
+
+Examples
+--------
+    python scripts/agentic/classify_change.py --paths modules/gaussian_splatting/renderer/foo.cpp
+    python scripts/agentic/classify_change.py --base-ref master --format json
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_POLICY = ROOT / ".agentic" / "policy.json"
+
+
+def load_policy(policy_path: Path) -> dict[str, Any]:
+    with open(policy_path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _norm(path: str) -> str:
+    text = path.replace("\\", "/")
+    if text.startswith("./"):
+        text = text[2:]
+    return text
+
+
+def _matches(path: str, glob: str) -> bool:
+    # Case-sensitive matching; fnmatch's ``*`` spans ``/`` which is the behavior
+    # we want for ``**``-style prefixes used in the policy globs.
+    return fnmatch.fnmatchcase(path, glob)
+
+
+def classify_paths(paths: list[str], policy: dict[str, Any]) -> tuple[str, list[dict[str, str]]]:
+    """Return (overall_class, per_path_detail)."""
+    classification = policy["classification"]
+    ordering = classification["ordering"]
+    rank = {cls: index for index, cls in enumerate(ordering)}
+    default = classification["default_unclassified"]
+    rules = classification["rules"]
+
+    per_path: list[dict[str, str]] = []
+    overall: str | None = None
+
+    for raw in paths:
+        path = _norm(raw)
+        best: str | None = None
+        best_reason = ""
+        for rule in rules:
+            cls = rule["class"]
+            for glob in rule["path_globs"]:
+                if _matches(path, _norm(glob)):
+                    if best is None or rank[cls] > rank[best]:
+                        best = cls
+                        best_reason = rule["reason"]
+                    break
+        if best is None:
+            best = default
+            best_reason = "unclassified path (fail-closed)"
+        per_path.append({"path": path, "class": best, "reason": best_reason})
+        if overall is None or rank[best] > rank[overall]:
+            overall = best
+
+    if overall is None:
+        # No changed paths: nothing risky to classify.
+        overall = ordering[0]
+    return overall, per_path
+
+
+def git_changed_paths(base_ref: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(ROOT), "diff", "--name-only", f"{base_ref}...HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        # Fall back to a two-dot diff if the merge-base form is unavailable.
+        result = subprocess.run(
+            ["git", "-C", str(ROOT), "diff", "--name-only", base_ref],
+            capture_output=True,
+            text=True,
+        )
+    if result.returncode != 0:
+        raise SystemExit(f"git diff failed for base-ref {base_ref!r}: {result.stderr.strip()}")
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--paths", nargs="*", help="Explicit changed paths to classify.")
+    parser.add_argument("--base-ref", help="Git ref to diff HEAD against to discover changed paths.")
+    parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY, help="Path to policy.json.")
+    parser.add_argument("--format", choices=["text", "json"], default="text", help="Output format.")
+    parser.add_argument(
+        "--github-output",
+        action="store_true",
+        help="Also write risk_class to the file named by $GITHUB_OUTPUT.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    policy = load_policy(args.policy)
+
+    if args.paths is not None:
+        paths = args.paths
+    elif args.base_ref:
+        paths = git_changed_paths(args.base_ref)
+    else:
+        print("error: provide --paths or --base-ref", file=sys.stderr)
+        return 2
+
+    risk_class, per_path = classify_paths(paths, policy)
+
+    if args.format == "json":
+        print(json.dumps({"risk_class": risk_class, "paths": per_path}, indent=2))
+    else:
+        print(f"risk_class: {risk_class}")
+        for detail in per_path:
+            print(f"  {detail['class']}  {detail['path']}  ({detail['reason']})")
+
+    if args.github_output:
+        output_file = os.environ.get("GITHUB_OUTPUT")
+        if output_file:
+            with open(output_file, "a", encoding="utf-8") as handle:
+                handle.write(f"risk_class={risk_class}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/agentic/classify_change.py
+++ b/scripts/agentic/classify_change.py
@@ -82,15 +82,18 @@ def classify_paths(paths: list[str], policy: dict[str, Any]) -> tuple[str, list[
 
 
 def git_changed_paths(base_ref: str) -> list[str]:
+    # --no-renames so a rename reports BOTH the deleted source and the added
+    # destination; otherwise moving a sensitive R3 path onto an R0 docs path would
+    # hide the high-risk source and defeat the fail-closed classification.
     result = subprocess.run(
-        ["git", "-C", str(ROOT), "diff", "--name-only", f"{base_ref}...HEAD"],
+        ["git", "-C", str(ROOT), "diff", "--name-only", "--no-renames", f"{base_ref}...HEAD"],
         capture_output=True,
         text=True,
     )
     if result.returncode != 0:
         # Fall back to a two-dot diff if the merge-base form is unavailable.
         result = subprocess.run(
-            ["git", "-C", str(ROOT), "diff", "--name-only", base_ref],
+            ["git", "-C", str(ROOT), "diff", "--name-only", "--no-renames", base_ref],
             capture_output=True,
             text=True,
         )

--- a/scripts/agentic/validate_repo_contract.py
+++ b/scripts/agentic/validate_repo_contract.py
@@ -3,14 +3,18 @@
 
 Checks (against ``--root``, default: repository root):
 
-* all required ``.agentic/``, ``scripts/agentic/``, ``AGENTS.md`` and
-  ``docs/governance/`` files exist;
+* all required ``.agentic/`` and ``scripts/agentic/`` control-plane files exist;
 * the JSON files parse;
 * the templates validate against their schemas;
 * every role referenced by ``policy.json`` exists as a role file and is listed in
   ``policy.json``'s ``roles``;
 * the classification rules reference only known classes;
 * no session-id / transcript artifacts have leaked into ``.agentic/``.
+
+By default this validates only the self-contained control plane, so it passes on a
+branch that adds ``.agentic/`` + ``scripts/agentic/`` without the wider AGENTS.md /
+governance-doc hierarchy. Pass ``--strict-hierarchy`` to additionally require the
+``AGENTS.md`` files and ``docs/governance/`` docs (use on a fully merged tree).
 
 Exit code is non-zero if anything is inconsistent.
 """
@@ -27,7 +31,8 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
 
-REQUIRED_FILES = [
+# Self-contained control plane: always required.
+CONTROL_PLANE_FILES = [
     ".agentic/README.md",
     ".agentic/policy.json",
     ".agentic/ownership.json",
@@ -44,6 +49,10 @@ REQUIRED_FILES = [
     "scripts/agentic/check_pr_contract.py",
     "scripts/agentic/validate_review.py",
     "scripts/agentic/validate_repo_contract.py",
+]
+
+# Wider hierarchy: only required under --strict-hierarchy (a fully merged tree).
+HIERARCHY_FILES = [
     "AGENTS.md",
     "modules/gaussian_splatting/AGENTS.md",
     "modules/gaussian_splatting/renderer/AGENTS.md",
@@ -82,11 +91,14 @@ def _load_validate_instance():
 validate_instance = _load_validate_instance()
 
 
-def validate_repo_contract(root: Path) -> list[str]:
+def validate_repo_contract(root: Path, strict_hierarchy: bool = False) -> list[str]:
     errors: list[str] = []
 
-    # 1. Required files exist.
-    for rel in REQUIRED_FILES:
+    # 1. Required files exist (control plane always; hierarchy only when strict).
+    required = list(CONTROL_PLANE_FILES)
+    if strict_hierarchy:
+        required += HIERARCHY_FILES
+    for rel in required:
         if not (root / rel).is_file():
             errors.append(f"missing required file: {rel}")
 
@@ -147,12 +159,17 @@ def validate_repo_contract(root: Path) -> list[str]:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--root", type=Path, default=ROOT, help="Repository root to validate.")
+    parser.add_argument(
+        "--strict-hierarchy",
+        action="store_true",
+        help="Also require the AGENTS.md hierarchy and docs/governance docs (fully merged tree).",
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    errors = validate_repo_contract(args.root)
+    errors = validate_repo_contract(args.root, strict_hierarchy=args.strict_hierarchy)
     if errors:
         print("Agentic control plane is INCONSISTENT:")
         for error in errors:

--- a/scripts/agentic/validate_repo_contract.py
+++ b/scripts/agentic/validate_repo_contract.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Validate that the agentic control plane is internally consistent.
+
+Checks (against ``--root``, default: repository root):
+
+* all required ``.agentic/``, ``scripts/agentic/``, ``AGENTS.md`` and
+  ``docs/governance/`` files exist;
+* the JSON files parse;
+* the templates validate against their schemas;
+* every role referenced by ``policy.json`` exists as a role file and is listed in
+  ``policy.json``'s ``roles``;
+* the classification rules reference only known classes;
+* no session-id / transcript artifacts have leaked into ``.agentic/``.
+
+Exit code is non-zero if anything is inconsistent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+
+REQUIRED_FILES = [
+    ".agentic/README.md",
+    ".agentic/policy.json",
+    ".agentic/ownership.json",
+    ".agentic/schemas/task.schema.json",
+    ".agentic/schemas/review.schema.json",
+    ".agentic/templates/task.json",
+    ".agentic/templates/review.json",
+    ".agentic/roles/planner.md",
+    ".agentic/roles/implementer.md",
+    ".agentic/roles/verifier.md",
+    ".agentic/roles/correctness-reviewer.md",
+    ".agentic/roles/gpu-performance-reviewer.md",
+    "scripts/agentic/classify_change.py",
+    "scripts/agentic/check_pr_contract.py",
+    "scripts/agentic/validate_review.py",
+    "scripts/agentic/validate_repo_contract.py",
+    "AGENTS.md",
+    "modules/gaussian_splatting/AGENTS.md",
+    "modules/gaussian_splatting/renderer/AGENTS.md",
+    "modules/gaussian_splatting/shaders/AGENTS.md",
+    "tests/AGENTS.md",
+    ".github/workflows/AGENTS.md",
+    "docs/governance/agentic-engineering.md",
+    "docs/governance/review-policy.md",
+    "docs/governance/github-settings.md",
+]
+
+JSON_FILES = [
+    ".agentic/policy.json",
+    ".agentic/ownership.json",
+    ".agentic/schemas/task.schema.json",
+    ".agentic/schemas/review.schema.json",
+    ".agentic/templates/task.json",
+    ".agentic/templates/review.json",
+]
+
+# Concrete session-id / agent-session UUID format (as used by the legacy
+# coordinator memory, e.g. "019d0571-b295-..."). Prose like "session IDs" is fine;
+# this matches an actual leaked identifier value.
+SESSION_ID_RE = re.compile(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b")
+
+
+def _load_validate_instance():
+    path = Path(__file__).with_name("validate_review.py")
+    spec = importlib.util.spec_from_file_location("validate_review", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.validate_instance
+
+
+validate_instance = _load_validate_instance()
+
+
+def validate_repo_contract(root: Path) -> list[str]:
+    errors: list[str] = []
+
+    # 1. Required files exist.
+    for rel in REQUIRED_FILES:
+        if not (root / rel).is_file():
+            errors.append(f"missing required file: {rel}")
+
+    # 2. JSON files parse.
+    parsed: dict[str, Any] = {}
+    for rel in JSON_FILES:
+        path = root / rel
+        if not path.is_file():
+            continue
+        try:
+            parsed[rel] = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            errors.append(f"invalid JSON in {rel}: {exc}")
+
+    # 3. Templates validate against their schemas.
+    pairs = [
+        (".agentic/templates/task.json", ".agentic/schemas/task.schema.json"),
+        (".agentic/templates/review.json", ".agentic/schemas/review.schema.json"),
+    ]
+    for template_rel, schema_rel in pairs:
+        if template_rel in parsed and schema_rel in parsed:
+            for error in validate_instance(parsed[template_rel], parsed[schema_rel], "$"):
+                errors.append(f"{template_rel} does not match {schema_rel}: {error}")
+
+    policy = parsed.get(".agentic/policy.json")
+    if isinstance(policy, dict):
+        roles = policy.get("roles", [])
+        # 4. Each declared role has a role file.
+        for role in roles:
+            if not (root / ".agentic" / "roles" / f"{role}.md").is_file():
+                errors.append(f"policy role '{role}' has no .agentic/roles/{role}.md")
+        # 5. required_roles reference known roles.
+        for cls, config in policy.get("risk_classes", {}).items():
+            for role in config.get("required_roles", []):
+                if role not in roles:
+                    errors.append(f"risk class {cls} requires unknown role '{role}'")
+        # 6. Classification references known classes.
+        classification = policy.get("classification", {})
+        ordering = classification.get("ordering", [])
+        if classification.get("default_unclassified") not in ordering:
+            errors.append("classification.default_unclassified is not in ordering")
+        for rule in classification.get("rules", []):
+            if rule.get("class") not in ordering:
+                errors.append(f"classification rule has unknown class '{rule.get('class')}'")
+
+    # 7. No leaked session-id / transcript artifacts under .agentic/.
+    agentic_dir = root / ".agentic"
+    if agentic_dir.is_dir():
+        for path in sorted(agentic_dir.rglob("*")):
+            if path.is_file() and path.suffix in (".md", ".json"):
+                text = path.read_text(encoding="utf-8", errors="ignore")
+                if SESSION_ID_RE.search(text):
+                    errors.append(f"possible session-id/transcript artifact in {path.relative_to(root)}")
+
+    return errors
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--root", type=Path, default=ROOT, help="Repository root to validate.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    errors = validate_repo_contract(args.root)
+    if errors:
+        print("Agentic control plane is INCONSISTENT:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+    print("Agentic control plane is consistent.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/agentic/validate_review.py
+++ b/scripts/agentic/validate_review.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Validate an agentic review result against ``.agentic/schemas/review.schema.json``.
+
+Beyond the schema (required fields, enums), this enforces the review-policy rules
+that a schema cannot express: non-empty SHAs and that every ``blocker``/``high``
+finding carries a concrete ``required_action``.
+
+Exit code is non-zero if the review is invalid.
+
+Examples
+--------
+    python scripts/agentic/validate_review.py --review .agentic/templates/review.json
+    cat review.json | python scripts/agentic/validate_review.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCHEMA = ROOT / ".agentic" / "schemas" / "review.schema.json"
+
+
+# --------------------------------------------------------------------------- #
+# Minimal JSON-Schema-lite validator (shared by the agentic tooling).
+# Supports: type, const, enum, required, properties, additionalProperties:false,
+# and array items. This is intentionally small; it is not a full JSON Schema
+# engine, only enough for the agentic task/review contracts.
+# --------------------------------------------------------------------------- #
+def _type_ok(value: Any, type_name: Any) -> bool:
+    if isinstance(type_name, list):
+        return any(_type_ok(value, item) for item in type_name)
+    if type_name == "string":
+        return isinstance(value, str)
+    if type_name == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if type_name == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if type_name == "boolean":
+        return isinstance(value, bool)
+    if type_name == "array":
+        return isinstance(value, list)
+    if type_name == "object":
+        return isinstance(value, dict)
+    if type_name == "null":
+        return value is None
+    return True
+
+
+def validate_instance(instance: Any, schema: dict[str, Any], path: str = "$") -> list[str]:
+    errors: list[str] = []
+    type_name = schema.get("type")
+    if type_name is not None and not _type_ok(instance, type_name):
+        errors.append(f"{path}: expected type {type_name}, got {type(instance).__name__}")
+        return errors
+
+    if "const" in schema and instance != schema["const"]:
+        errors.append(f"{path}: expected {schema['const']!r}, got {instance!r}")
+    if "enum" in schema and instance not in schema["enum"]:
+        errors.append(f"{path}: {instance!r} is not one of {schema['enum']}")
+
+    if isinstance(instance, dict):
+        properties = schema.get("properties", {})
+        for required in schema.get("required", []):
+            if required not in instance:
+                errors.append(f"{path}: missing required property '{required}'")
+        if schema.get("additionalProperties", True) is False:
+            for key in instance:
+                if key not in properties:
+                    errors.append(f"{path}: unexpected property '{key}'")
+        for key, value in instance.items():
+            if key in properties:
+                errors.extend(validate_instance(value, properties[key], f"{path}.{key}"))
+
+    if isinstance(instance, list) and "items" in schema:
+        for index, item in enumerate(instance):
+            errors.extend(validate_instance(item, schema["items"], f"{path}[{index}]"))
+
+    return errors
+
+
+def validate_review(review: dict[str, Any], schema: dict[str, Any]) -> list[str]:
+    errors = validate_instance(review, schema, "$")
+
+    # Policy rules a schema cannot express.
+    for field in ("base_sha", "head_sha"):
+        value = review.get(field)
+        if isinstance(value, str) and not value.strip():
+            errors.append(f"$.{field}: must not be empty")
+
+    findings = review.get("findings")
+    if isinstance(findings, list):
+        for index, finding in enumerate(findings):
+            if not isinstance(finding, dict):
+                continue
+            severity = finding.get("severity")
+            action = finding.get("required_action")
+            if severity in ("blocker", "high") and not (isinstance(action, str) and action.strip()):
+                errors.append(
+                    f"$.findings[{index}]: severity '{severity}' requires a non-empty required_action"
+                )
+    return errors
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--review", type=Path, help="Path to the review JSON (default: read stdin).")
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA, help="Path to review.schema.json.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    with open(args.schema, encoding="utf-8") as handle:
+        schema = json.load(handle)
+
+    if args.review:
+        raw = args.review.read_text(encoding="utf-8")
+    else:
+        raw = sys.stdin.read()
+
+    try:
+        review = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"invalid JSON: {exc}", file=sys.stderr)
+        return 1
+
+    errors = validate_review(review, schema)
+    if errors:
+        print("Review is INVALID:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print("Review is valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/agentic/test_check_pr_contract.py
+++ b/tests/agentic/test_check_pr_contract.py
@@ -45,6 +45,28 @@ class CheckPrContractTest(unittest.TestCase):
         )
         self.assertTrue(any("understates" in e for e in _hard(errors)))
 
+    def test_forbidden_path_change_fails(self):
+        # Template forbids modules/gaussian_splatting/persistence/**.
+        errors = cpc.check_contract(
+            copy.deepcopy(TEMPLATE),
+            POLICY,
+            TASK_SCHEMA,
+            ["modules/gaussian_splatting/persistence/incremental_saver.cpp"],
+        )
+        self.assertTrue(any("forbidden path" in e for e in _hard(errors)))
+
+    def test_out_of_scope_path_fails(self):
+        # Same risk class (R1) but outside the declared owned_paths (logger/**).
+        errors = cpc.check_contract(
+            copy.deepcopy(TEMPLATE),
+            POLICY,
+            TASK_SCHEMA,
+            ["modules/gaussian_splatting/animation/animation_state_machine.cpp"],
+        )
+        hard = _hard(errors)
+        self.assertTrue(any("outside the declared owned_paths" in e for e in hard))
+        self.assertFalse(any("understates" in e for e in hard))
+
     def test_missing_required_field_fails(self):
         contract = copy.deepcopy(TEMPLATE)
         del contract["rollback_plan"]

--- a/tests/agentic/test_check_pr_contract.py
+++ b/tests/agentic/test_check_pr_contract.py
@@ -147,6 +147,20 @@ class CheckPrContractTest(unittest.TestCase):
         errors = cpc.check_contract(contract, POLICY, TASK_SCHEMA, ["tests/agentic/test_classify_change.py"])
         self.assertTrue(any("unittest discover -s tests/agentic" in e for e in _hard(errors)))
 
+    def test_single_segment_glob_does_not_span_directories(self):
+        # owned_paths with a single-segment '*' must not match a deeper path.
+        contract = copy.deepcopy(TEMPLATE)
+        contract["owned_paths"] = ["modules/gaussian_splatting/logger/*"]
+        errors = cpc.check_contract(
+            contract, POLICY, TASK_SCHEMA,
+            ["modules/gaussian_splatting/logger/private/x.cpp"],
+        )
+        self.assertTrue(any("outside the declared owned_paths" in e for e in _hard(errors)))
+        # ...while a single-segment file directly under it is in scope.
+        ok = cpc.check_contract(
+            contract, POLICY, TASK_SCHEMA, ["modules/gaussian_splatting/logger/x.cpp"],
+        )
+        self.assertFalse(any("outside the declared owned_paths" in e for e in _hard(ok)))
 
     def test_main_requires_diff_source(self):
         # A full PR-gate check must not silently skip the cross-check when no diff is given.

--- a/tests/agentic/test_check_pr_contract.py
+++ b/tests/agentic/test_check_pr_contract.py
@@ -115,8 +115,9 @@ class CheckPrContractTest(unittest.TestCase):
         contract["owned_paths"] = ["servers/rendering/foo.cpp"]
         contract["forbidden_paths"] = []
         contract["design_record"] = "https://github.com/klausi3D/godotGS/issues/123"
-        # An R3 contract must commit to the full R3 deterministic check set.
+        # An R3 contract must commit to the full R3 deterministic checks and evidence.
         contract["validation_commands"] = list(POLICY["risk_classes"]["R3"]["deterministic_checks"])
+        contract["evidence_requirements"] = list(POLICY["risk_classes"]["R3"]["evidence_requirements"])
         errors = cpc.check_contract(contract, POLICY, TASK_SCHEMA, ["servers/rendering/foo.cpp"])
         self.assertEqual(_hard(errors), [])
 
@@ -126,6 +127,16 @@ class CheckPrContractTest(unittest.TestCase):
         contract["validation_commands"] = ["true"]
         errors = cpc.check_contract(contract, POLICY, TASK_SCHEMA, ["modules/gaussian_splatting/logger/x.cpp"])
         self.assertTrue(any("deterministic check" in e for e in _hard(errors)))
+
+    def test_missing_evidence_item_fails(self):
+        # An R2 contract must carry the R2 policy evidence items, not a placeholder.
+        contract = copy.deepcopy(TEMPLATE)
+        contract["risk_class"] = "R2"
+        contract["owned_paths"] = ["modules/gaussian_splatting/renderer/**"]
+        contract["validation_commands"] = list(POLICY["risk_classes"]["R2"]["deterministic_checks"])
+        contract["evidence_requirements"] = ["n/a"]
+        errors = cpc.check_contract(contract, POLICY, TASK_SCHEMA, ["modules/gaussian_splatting/renderer/x.cpp"])
+        self.assertTrue(any("evidence item" in e for e in _hard(errors)))
 
     def test_agentic_tests_change_requires_agentic_suite(self):
         # A change to the agentic test suite (R1 via tests/**) must require running it.

--- a/tests/agentic/test_check_pr_contract.py
+++ b/tests/agentic/test_check_pr_contract.py
@@ -67,6 +67,15 @@ class CheckPrContractTest(unittest.TestCase):
         self.assertTrue(any("outside the declared owned_paths" in e for e in hard))
         self.assertFalse(any("understates" in e for e in hard))
 
+    def test_malformed_path_entries_do_not_crash(self):
+        # Non-string owned/forbidden entries are caught by the schema; the scope
+        # check must skip them rather than raise AttributeError.
+        contract = copy.deepcopy(TEMPLATE)
+        contract["owned_paths"] = [None, "modules/gaussian_splatting/logger/**"]
+        contract["forbidden_paths"] = [123]
+        errors = cpc.check_contract(contract, POLICY, TASK_SCHEMA, ["modules/gaussian_splatting/logger/x.cpp"])
+        self.assertTrue(any("owned_paths" in e or "forbidden_paths" in e for e in errors))
+
     def test_missing_required_field_fails(self):
         contract = copy.deepcopy(TEMPLATE)
         del contract["rollback_plan"]

--- a/tests/agentic/test_check_pr_contract.py
+++ b/tests/agentic/test_check_pr_contract.py
@@ -16,9 +16,10 @@ assert spec and spec.loader
 cpc = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(cpc)
 
+TEMPLATE_PATH = ROOT / ".agentic" / "templates" / "task.json"
 POLICY = json.loads((ROOT / ".agentic" / "policy.json").read_text(encoding="utf-8"))
 TASK_SCHEMA = json.loads((ROOT / ".agentic" / "schemas" / "task.schema.json").read_text(encoding="utf-8"))
-TEMPLATE = json.loads((ROOT / ".agentic" / "templates" / "task.json").read_text(encoding="utf-8"))
+TEMPLATE = json.loads(TEMPLATE_PATH.read_text(encoding="utf-8"))
 
 
 def _hard(errors):
@@ -145,6 +146,17 @@ class CheckPrContractTest(unittest.TestCase):
         contract["validation_commands"] = ["python tests/ci/run_module_tests.py --guard-only"]
         errors = cpc.check_contract(contract, POLICY, TASK_SCHEMA, ["tests/agentic/test_classify_change.py"])
         self.assertTrue(any("unittest discover -s tests/agentic" in e for e in _hard(errors)))
+
+
+    def test_main_requires_diff_source(self):
+        # A full PR-gate check must not silently skip the cross-check when no diff is given.
+        rc = cpc.main(["--contract", str(TEMPLATE_PATH)])
+        self.assertEqual(rc, 2)
+
+    def test_main_schema_only_opt_out(self):
+        # The schema-only escape hatch must be explicit and pass on the valid template.
+        rc = cpc.main(["--contract", str(TEMPLATE_PATH), "--schema-only"])
+        self.assertEqual(rc, 0)
 
 
 if __name__ == "__main__":

--- a/tests/agentic/test_check_pr_contract.py
+++ b/tests/agentic/test_check_pr_contract.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/agentic/check_pr_contract.py."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "agentic" / "check_pr_contract.py"
+spec = importlib.util.spec_from_file_location("check_pr_contract", SCRIPT)
+assert spec and spec.loader
+cpc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cpc)
+
+POLICY = json.loads((ROOT / ".agentic" / "policy.json").read_text(encoding="utf-8"))
+TASK_SCHEMA = json.loads((ROOT / ".agentic" / "schemas" / "task.schema.json").read_text(encoding="utf-8"))
+TEMPLATE = json.loads((ROOT / ".agentic" / "templates" / "task.json").read_text(encoding="utf-8"))
+
+
+def _hard(errors):
+    return [e for e in errors if not e.startswith("note:")]
+
+
+class CheckPrContractTest(unittest.TestCase):
+    def test_valid_contract_matching_risk(self):
+        errors = cpc.check_contract(
+            copy.deepcopy(TEMPLATE),
+            POLICY,
+            TASK_SCHEMA,
+            ["modules/gaussian_splatting/logger/logger.cpp"],  # R1, matches declared R1
+        )
+        self.assertEqual(_hard(errors), [])
+
+    def test_understated_risk_fails(self):
+        # Declared R1 but the diff touches the renderer (R2).
+        errors = cpc.check_contract(
+            copy.deepcopy(TEMPLATE),
+            POLICY,
+            TASK_SCHEMA,
+            ["modules/gaussian_splatting/renderer/gpu_sorter.cpp"],
+        )
+        self.assertTrue(any("understates" in e for e in _hard(errors)))
+
+    def test_missing_required_field_fails(self):
+        contract = copy.deepcopy(TEMPLATE)
+        del contract["rollback_plan"]
+        errors = cpc.check_contract(contract, POLICY, TASK_SCHEMA, ["modules/gaussian_splatting/logger/x.cpp"])
+        self.assertTrue(any("rollback_plan" in e for e in _hard(errors)))
+
+    def test_empty_validation_commands_fails(self):
+        contract = copy.deepcopy(TEMPLATE)
+        contract["validation_commands"] = []
+        errors = cpc.check_contract(contract, POLICY, TASK_SCHEMA, ["modules/gaussian_splatting/logger/x.cpp"])
+        self.assertTrue(any("validation_commands" in e for e in _hard(errors)))
+
+    def test_unknown_risk_class_value_fails_schema(self):
+        contract = copy.deepcopy(TEMPLATE)
+        contract["risk_class"] = "R9"
+        errors = cpc.check_contract(contract, POLICY, TASK_SCHEMA, None)
+        self.assertTrue(any("risk_class" in e for e in _hard(errors)))
+
+    def test_stacked_pr_requires_base_fields(self):
+        contract = copy.deepcopy(TEMPLATE)
+        contract["stacked_on"] = {"base_pr": "", "base_sha": ""}
+        errors = cpc.check_contract(contract, POLICY, TASK_SCHEMA, ["modules/gaussian_splatting/logger/x.cpp"])
+        self.assertTrue(any("stacked_on.base_pr" in e for e in _hard(errors)))
+        self.assertTrue(any("stacked_on.base_sha" in e for e in _hard(errors)))
+
+    def test_r3_emits_adr_note_but_no_hard_error(self):
+        contract = copy.deepcopy(TEMPLATE)
+        contract["risk_class"] = "R3"
+        contract["owned_paths"] = ["servers/rendering/foo.cpp"]
+        contract["forbidden_paths"] = []
+        errors = cpc.check_contract(contract, POLICY, TASK_SCHEMA, ["servers/rendering/foo.cpp"])
+        self.assertTrue(any(e.startswith("note:") and "design record" in e for e in errors))
+        self.assertEqual(_hard(errors), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agentic/test_check_pr_contract.py
+++ b/tests/agentic/test_check_pr_contract.py
@@ -115,8 +115,25 @@ class CheckPrContractTest(unittest.TestCase):
         contract["owned_paths"] = ["servers/rendering/foo.cpp"]
         contract["forbidden_paths"] = []
         contract["design_record"] = "https://github.com/klausi3D/godotGS/issues/123"
+        # An R3 contract must commit to the full R3 deterministic check set.
+        contract["validation_commands"] = list(POLICY["risk_classes"]["R3"]["deterministic_checks"])
         errors = cpc.check_contract(contract, POLICY, TASK_SCHEMA, ["servers/rendering/foo.cpp"])
         self.assertEqual(_hard(errors), [])
+
+    def test_missing_deterministic_check_fails(self):
+        # A contract that omits its class's deterministic checks must not pass.
+        contract = copy.deepcopy(TEMPLATE)
+        contract["validation_commands"] = ["true"]
+        errors = cpc.check_contract(contract, POLICY, TASK_SCHEMA, ["modules/gaussian_splatting/logger/x.cpp"])
+        self.assertTrue(any("deterministic check" in e for e in _hard(errors)))
+
+    def test_agentic_tests_change_requires_agentic_suite(self):
+        # A change to the agentic test suite (R1 via tests/**) must require running it.
+        contract = copy.deepcopy(TEMPLATE)
+        contract["owned_paths"] = ["tests/agentic/**"]
+        contract["validation_commands"] = ["python tests/ci/run_module_tests.py --guard-only"]
+        errors = cpc.check_contract(contract, POLICY, TASK_SCHEMA, ["tests/agentic/test_classify_change.py"])
+        self.assertTrue(any("unittest discover -s tests/agentic" in e for e in _hard(errors)))
 
 
 if __name__ == "__main__":

--- a/tests/agentic/test_check_pr_contract.py
+++ b/tests/agentic/test_check_pr_contract.py
@@ -101,13 +101,21 @@ class CheckPrContractTest(unittest.TestCase):
         self.assertTrue(any("stacked_on.base_pr" in e for e in _hard(errors)))
         self.assertTrue(any("stacked_on.base_sha" in e for e in _hard(errors)))
 
-    def test_r3_emits_adr_note_but_no_hard_error(self):
+    def test_r3_without_design_record_fails(self):
         contract = copy.deepcopy(TEMPLATE)
         contract["risk_class"] = "R3"
         contract["owned_paths"] = ["servers/rendering/foo.cpp"]
         contract["forbidden_paths"] = []
         errors = cpc.check_contract(contract, POLICY, TASK_SCHEMA, ["servers/rendering/foo.cpp"])
-        self.assertTrue(any(e.startswith("note:") and "design record" in e for e in errors))
+        self.assertTrue(any("design_record" in e for e in _hard(errors)))
+
+    def test_r3_with_design_record_passes(self):
+        contract = copy.deepcopy(TEMPLATE)
+        contract["risk_class"] = "R3"
+        contract["owned_paths"] = ["servers/rendering/foo.cpp"]
+        contract["forbidden_paths"] = []
+        contract["design_record"] = "https://github.com/klausi3D/godotGS/issues/123"
+        errors = cpc.check_contract(contract, POLICY, TASK_SCHEMA, ["servers/rendering/foo.cpp"])
         self.assertEqual(_hard(errors), [])
 
 

--- a/tests/agentic/test_classify_change.py
+++ b/tests/agentic/test_classify_change.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/agentic/classify_change.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "agentic" / "classify_change.py"
+spec = importlib.util.spec_from_file_location("classify_change", SCRIPT)
+assert spec and spec.loader
+classify = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(classify)
+
+POLICY = json.loads((ROOT / ".agentic" / "policy.json").read_text(encoding="utf-8"))
+
+
+class ClassifyChangeTest(unittest.TestCase):
+    def _cls(self, paths):
+        return classify.classify_paths(paths, POLICY)[0]
+
+    def test_engine_path_is_r3(self):
+        self.assertEqual(self._cls(["servers/rendering/foo.cpp"]), "R3")
+
+    def test_persistence_path_is_r3(self):
+        self.assertEqual(self._cls(["modules/gaussian_splatting/io/ply_loader.cpp"]), "R3")
+
+    def test_renderer_path_is_r2(self):
+        self.assertEqual(self._cls(["modules/gaussian_splatting/renderer/gpu_sorter.cpp"]), "R2")
+
+    def test_shaders_path_is_r2(self):
+        self.assertEqual(self._cls(["modules/gaussian_splatting/shaders/raster.glsl"]), "R2")
+
+    def test_local_module_is_r1(self):
+        self.assertEqual(self._cls(["modules/gaussian_splatting/logger/logger.cpp"]), "R1")
+
+    def test_tests_path_is_r1(self):
+        self.assertEqual(self._cls(["tests/ci/run_module_tests.py"]), "R1")
+
+    def test_docs_is_r0(self):
+        self.assertEqual(self._cls(["docs/governance/review-policy.md"]), "R0")
+
+    def test_unknown_sensitive_path_fails_closed_to_r3(self):
+        self.assertEqual(self._cls(["some/unmapped/path.bin"]), "R3")
+
+    def test_overall_is_max_across_paths(self):
+        self.assertEqual(
+            self._cls(["docs/x.md", "modules/gaussian_splatting/renderer/a.cpp"]),
+            "R2",
+        )
+        self.assertEqual(
+            self._cls(["docs/x.md", "servers/y.cpp"]),
+            "R3",
+        )
+
+    def test_empty_changeset_is_lowest_class(self):
+        self.assertEqual(self._cls([]), "R0")
+
+    def test_windows_separators_are_normalized(self):
+        self.assertEqual(self._cls([r"modules\gaussian_splatting\renderer\a.cpp"]), "R2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agentic/test_classify_change.py
+++ b/tests/agentic/test_classify_change.py
@@ -34,6 +34,16 @@ class ClassifyChangeTest(unittest.TestCase):
     def test_shaders_path_is_r2(self):
         self.assertEqual(self._cls(["modules/gaussian_splatting/shaders/raster.glsl"]), "R2")
 
+    def test_core_streaming_is_r2(self):
+        # Streaming/VRAM files under core/ are R2, not R1.
+        self.assertEqual(self._cls(["modules/gaussian_splatting/core/gaussian_streaming.cpp"]), "R2")
+        self.assertEqual(self._cls(["modules/gaussian_splatting/core/streaming_vram_regulator.h"]), "R2")
+        self.assertEqual(self._cls(["modules/gaussian_splatting/core/residency_budget_controller.cpp"]), "R2")
+
+    def test_core_nonstreaming_is_r1(self):
+        # Ordinary core data files stay R1.
+        self.assertEqual(self._cls(["modules/gaussian_splatting/core/gaussian_data.cpp"]), "R1")
+
     def test_local_module_is_r1(self):
         self.assertEqual(self._cls(["modules/gaussian_splatting/logger/logger.cpp"]), "R1")
 

--- a/tests/agentic/test_classify_change.py
+++ b/tests/agentic/test_classify_change.py
@@ -55,6 +55,7 @@ class ClassifyChangeTest(unittest.TestCase):
         self.assertEqual(self._cls(["tests/ci/run_module_tests.py"]), "R3")
         self.assertEqual(self._cls(["tests/runtime/run_runtime_validation.py"]), "R3")
         self.assertEqual(self._cls(["tests/ci/check_renderer_release_gates.py"]), "R3")
+        self.assertEqual(self._cls(["tests/ci/run_gpu_harness.py"]), "R3")
 
     def test_docs_is_r0(self):
         self.assertEqual(self._cls(["docs/governance/review-policy.md"]), "R0")

--- a/tests/agentic/test_classify_change.py
+++ b/tests/agentic/test_classify_change.py
@@ -49,8 +49,17 @@ class ClassifyChangeTest(unittest.TestCase):
     def test_docs_is_r0(self):
         self.assertEqual(self._cls(["docs/governance/review-policy.md"]), "R0")
 
+    def test_root_doc_is_r0(self):
+        self.assertEqual(self._cls(["README.md"]), "R0")
+        self.assertEqual(self._cls(["CONTRIBUTING.md"]), "R0")
+
     def test_unknown_sensitive_path_fails_closed_to_r3(self):
         self.assertEqual(self._cls(["some/unmapped/path.bin"]), "R3")
+
+    def test_unmapped_markdown_fails_closed_to_r3(self):
+        # A markdown file outside the known doc/root scopes must not slip to R0 via a
+        # blanket *.md rule; unrecognized paths fail closed to R3.
+        self.assertEqual(self._cls(["weird/unmapped/notes.md"]), "R3")
 
     def test_overall_is_max_across_paths(self):
         self.assertEqual(

--- a/tests/agentic/test_classify_change.py
+++ b/tests/agentic/test_classify_change.py
@@ -37,8 +37,14 @@ class ClassifyChangeTest(unittest.TestCase):
     def test_local_module_is_r1(self):
         self.assertEqual(self._cls(["modules/gaussian_splatting/logger/logger.cpp"]), "R1")
 
-    def test_tests_path_is_r1(self):
-        self.assertEqual(self._cls(["tests/ci/run_module_tests.py"]), "R1")
+    def test_ordinary_test_path_is_r1(self):
+        self.assertEqual(self._cls(["tests/ci/test_ply_loader_ci.gd"]), "R1")
+
+    def test_ci_gate_machinery_is_r3(self):
+        # The deterministic-check / release-gate runners must not be downgradable at R1.
+        self.assertEqual(self._cls(["tests/ci/run_module_tests.py"]), "R3")
+        self.assertEqual(self._cls(["tests/runtime/run_runtime_validation.py"]), "R3")
+        self.assertEqual(self._cls(["tests/ci/check_renderer_release_gates.py"]), "R3")
 
     def test_docs_is_r0(self):
         self.assertEqual(self._cls(["docs/governance/review-policy.md"]), "R0")

--- a/tests/agentic/test_validate_repo_contract.py
+++ b/tests/agentic/test_validate_repo_contract.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/agentic/validate_repo_contract.py.
+
+Uses synthetic roots (a copy of the real .agentic/ tree plus stub files) so the
+tests do not depend on any single branch having the full AGENTS.md hierarchy.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "agentic" / "validate_repo_contract.py"
+spec = importlib.util.spec_from_file_location("validate_repo_contract", SCRIPT)
+assert spec and spec.loader
+vrc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(vrc)
+
+
+def _make_valid_root(base: Path) -> Path:
+    root = base / "repo"
+    root.mkdir()
+    shutil.copytree(ROOT / ".agentic", root / ".agentic")
+    for rel in vrc.REQUIRED_FILES:
+        path = root / rel
+        if not path.exists():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("stub\n", encoding="utf-8")
+    return root
+
+
+class ValidateRepoContractTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = _make_valid_root(Path(self._tmp.name))
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_valid_root_passes(self):
+        self.assertEqual(vrc.validate_repo_contract(self.root), [])
+
+    def test_missing_role_file_fails(self):
+        (self.root / ".agentic" / "roles" / "planner.md").unlink()
+        errors = vrc.validate_repo_contract(self.root)
+        self.assertTrue(any("planner" in e for e in errors))
+
+    def test_missing_required_file_fails(self):
+        (self.root / "AGENTS.md").unlink()
+        errors = vrc.validate_repo_contract(self.root)
+        self.assertTrue(any("AGENTS.md" in e for e in errors))
+
+    def test_invalid_json_fails(self):
+        (self.root / ".agentic" / "policy.json").write_text("{ not valid json", encoding="utf-8")
+        errors = vrc.validate_repo_contract(self.root)
+        self.assertTrue(any("invalid JSON" in e for e in errors))
+
+    def test_session_id_artifact_fails(self):
+        readme = self.root / ".agentic" / "README.md"
+        readme.write_text(
+            readme.read_text(encoding="utf-8") + "\nagent-build-ci: 019d0571-b295-7a1c-9f3e-0123456789ab\n",
+            encoding="utf-8",
+        )
+        errors = vrc.validate_repo_contract(self.root)
+        self.assertTrue(any("session-id" in e for e in errors))
+
+    def test_template_schema_mismatch_fails(self):
+        # Break the task template so it no longer matches its schema.
+        (self.root / ".agentic" / "templates" / "task.json").write_text(
+            '{"schema_version": 1}', encoding="utf-8"
+        )
+        errors = vrc.validate_repo_contract(self.root)
+        self.assertTrue(any("task.json does not match" in e for e in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agentic/test_validate_repo_contract.py
+++ b/tests/agentic/test_validate_repo_contract.py
@@ -25,7 +25,7 @@ def _make_valid_root(base: Path) -> Path:
     root = base / "repo"
     root.mkdir()
     shutil.copytree(ROOT / ".agentic", root / ".agentic")
-    for rel in vrc.REQUIRED_FILES:
+    for rel in vrc.CONTROL_PLANE_FILES + vrc.HIERARCHY_FILES:
         path = root / rel
         if not path.exists():
             path.parent.mkdir(parents=True, exist_ok=True)
@@ -43,16 +43,25 @@ class ValidateRepoContractTest(unittest.TestCase):
 
     def test_valid_root_passes(self):
         self.assertEqual(vrc.validate_repo_contract(self.root), [])
+        self.assertEqual(vrc.validate_repo_contract(self.root, strict_hierarchy=True), [])
 
     def test_missing_role_file_fails(self):
         (self.root / ".agentic" / "roles" / "planner.md").unlink()
         errors = vrc.validate_repo_contract(self.root)
         self.assertTrue(any("planner" in e for e in errors))
 
-    def test_missing_required_file_fails(self):
-        (self.root / "AGENTS.md").unlink()
+    def test_missing_control_plane_file_fails_by_default(self):
+        (self.root / "scripts" / "agentic" / "classify_change.py").unlink()
         errors = vrc.validate_repo_contract(self.root)
-        self.assertTrue(any("AGENTS.md" in e for e in errors))
+        self.assertTrue(any("classify_change.py" in e for e in errors))
+
+    def test_missing_hierarchy_passes_default_fails_strict(self):
+        (self.root / "AGENTS.md").unlink()
+        # Default scope ignores the wider hierarchy, so the control plane is still valid.
+        self.assertEqual(vrc.validate_repo_contract(self.root), [])
+        # Strict scope requires it.
+        strict_errors = vrc.validate_repo_contract(self.root, strict_hierarchy=True)
+        self.assertTrue(any("AGENTS.md" in e for e in strict_errors))
 
     def test_invalid_json_fails(self):
         (self.root / ".agentic" / "policy.json").write_text("{ not valid json", encoding="utf-8")

--- a/tests/agentic/test_validate_review.py
+++ b/tests/agentic/test_validate_review.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/agentic/validate_review.py."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "agentic" / "validate_review.py"
+spec = importlib.util.spec_from_file_location("validate_review", SCRIPT)
+assert spec and spec.loader
+vr = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(vr)
+
+SCHEMA = json.loads((ROOT / ".agentic" / "schemas" / "review.schema.json").read_text(encoding="utf-8"))
+TEMPLATE = json.loads((ROOT / ".agentic" / "templates" / "review.json").read_text(encoding="utf-8"))
+
+
+class ValidateReviewTest(unittest.TestCase):
+    def test_template_is_valid(self):
+        self.assertEqual(vr.validate_review(copy.deepcopy(TEMPLATE), SCHEMA), [])
+
+    def test_missing_base_sha_fails(self):
+        review = copy.deepcopy(TEMPLATE)
+        del review["base_sha"]
+        errors = vr.validate_review(review, SCHEMA)
+        self.assertTrue(any("base_sha" in e for e in errors))
+
+    def test_empty_head_sha_fails(self):
+        review = copy.deepcopy(TEMPLATE)
+        review["head_sha"] = "   "
+        errors = vr.validate_review(review, SCHEMA)
+        self.assertTrue(any("head_sha" in e for e in errors))
+
+    def test_unknown_verdict_fails(self):
+        review = copy.deepcopy(TEMPLATE)
+        review["verdict"] = "looks_good"
+        errors = vr.validate_review(review, SCHEMA)
+        self.assertTrue(any("verdict" in e for e in errors))
+
+    def test_unknown_reviewer_role_fails(self):
+        review = copy.deepcopy(TEMPLATE)
+        review["reviewer_role"] = "vibes-reviewer"
+        errors = vr.validate_review(review, SCHEMA)
+        self.assertTrue(any("reviewer_role" in e for e in errors))
+
+    def test_missing_blind_spots_fails(self):
+        review = copy.deepcopy(TEMPLATE)
+        del review["blind_spots"]
+        errors = vr.validate_review(review, SCHEMA)
+        self.assertTrue(any("blind_spots" in e for e in errors))
+
+    def test_blocker_without_required_action_fails(self):
+        review = copy.deepcopy(TEMPLATE)
+        review["findings"][0]["severity"] = "blocker"
+        review["findings"][0]["required_action"] = ""
+        errors = vr.validate_review(review, SCHEMA)
+        self.assertTrue(any("required_action" in e for e in errors))
+
+    def test_unknown_severity_fails(self):
+        review = copy.deepcopy(TEMPLATE)
+        review["findings"][0]["severity"] = "catastrophic"
+        errors = vr.validate_review(review, SCHEMA)
+        self.assertTrue(any("severity" in e for e in errors))
+
+    def test_unexpected_property_fails(self):
+        review = copy.deepcopy(TEMPLATE)
+        review["extra"] = True
+        errors = vr.validate_review(review, SCHEMA)
+        self.assertTrue(any("unexpected property" in e for e in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci/validate_automation.py
+++ b/tests/ci/validate_automation.py
@@ -301,6 +301,7 @@ def check_ci_workflow() -> bool:
         ".github/workflows/baseline_qa.yml",
         ".github/workflows/gaussian_production_gates.yml",
         ".github/workflows/gaussian_shader_validation.yml",
+        ".github/workflows/agentic_pr_gate.yml",
     ]
 
     try:


### PR DESCRIPTION
## Summary

Adds the GitHub work surface and a fork-safe, always-on required gate that builds
on the agentic control plane.

## Risk class

R3 (CI/security workflow surface).

## Base / head — STACKED

- **Stacked on #405** (`build/agentic-contracts-validators`, base SHA `7693f6ebb7`).
- This PR's base is the PR3 branch so the diff shows only the GitHub-surface delta.
  GitHub will auto-retarget to `master` once #405 merges. **Merge #405 first.**

## Changes

- `.github/workflows/agentic_pr_gate.yml`: runs on every `pull_request` (no path
  filter) and the merge queue on `ubuntu-latest` with `contents: read` only. Check
  name **`Agentic PR Gate / required`**. Runs `validate_repo_contract`, the contract
  validators on the shipped templates, the agentic unit tests, a scoped
  agentic/governance link check, and the GPU-free `--guard-only` lane. Fork PRs get
  a blocking signal without touching the self-hosted runners.
- `.github/CODEOWNERS`: `@klausi3D` owns CI/security, `.agentic`, governance docs,
  the GPU render path, on-disk formats, the Godot engine delta, and tests.
- `.github/PULL_REQUEST_TEMPLATE.md` + `agent-task.yml` / `design-change.yml` issue
  forms aligned with the task contract and risk classes.
- README workflow count 5 → 6 + a Required Checks section; register the gate in
  `validate_automation.py`; ignore agentic-local/worktree/session scratch in
  `.gitignore` (canonical `.agentic/` files stay tracked).

## Validation

- Gate YAML parses; `runs-on: ubuntu-latest`, `permissions: {contents: read}`,
  triggers `pull_request` + `merge_group`, check name `Agentic PR Gate / required`.
- `python tests/ci/validate_automation.py --contracts-only` → PASS (includes the new gate).
- On the combined tree the full gate steps run green; `--guard-only` is GPU-free
  (the StringName guard self-skips with no binary). A real ubuntu-latest CI run of
  the gate is the remaining confirmation.

## Notes

- README is also edited by #403; the two edits auto-merged with no conflict in local integration testing. Merge #403 before this PR to keep that clean.

## Rollback

Revert the single commit; removes the gate, CODEOWNERS, and templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
