### PR TITLE
docs(agentic): freeze legacy GAUSSIAN_ISSUE_BOARD

### DIFF
--- a/docs/agent_memory/GAUSSIAN_ISSUE_BOARD.md
+++ b/docs/agent_memory/GAUSSIAN_ISSUE_BOARD.md
@@ -5,8 +5,12 @@
 > This board was a manually maintained snapshot from a past multi-agent
 > orchestration wave (baseline `6dde6a82c3b`). It is **no longer updated** and must
 > **not** be used to determine current project status. Active work is tracked in
-> **GitHub Issues**; durable rules live in `AGENTS.md` and
-> `docs/governance/agentic-engineering.md`.
+> **GitHub Issues** — the always-current source of truth for project status.
+>
+> Durable engineering rules live in `AGENTS.md` and
+> `docs/governance/agentic-engineering.md`, which are added by the
+> agentic-engineering foundation series; once that series is merged, use those for
+> durable rules.
 >
 > Open items below are migrated into GitHub Issues incrementally and then removed
 > from the working tree; the full history remains in git. Do not add a new manual

--- a/docs/agent_memory/GAUSSIAN_ISSUE_BOARD.md
+++ b/docs/agent_memory/GAUSSIAN_ISSUE_BOARD.md
@@ -1,5 +1,17 @@
 # Gaussian Splatting Issue Board
 
+> **FROZEN — LEGACY. Not a source of truth.**
+>
+> This board was a manually maintained snapshot from a past multi-agent
+> orchestration wave (baseline `6dde6a82c3b`). It is **no longer updated** and must
+> **not** be used to determine current project status. Active work is tracked in
+> **GitHub Issues**; durable rules live in `AGENTS.md` and
+> `docs/governance/agentic-engineering.md`.
+>
+> Open items below are migrated into GitHub Issues incrementally and then removed
+> from the working tree; the full history remains in git. Do not add a new manual
+> status file to replace this one.
+
 Baseline commit: `6dde6a82c3b`
 Tracking scope: `ISSUE-001` to `ISSUE-045` (all subsystem Top-5 items)
 


### PR DESCRIPTION
## Summary

Marks the manually maintained `docs/agent_memory/GAUSSIAN_ISSUE_BOARD.md` as
FROZEN/LEGACY and not a source of truth. Active work tracks in GitHub Issues;
durable rules live in `AGENTS.md` and `docs/governance/agentic-engineering.md`.

## Risk class

R0 (docs).

## Base / head

- Base: `master` (`b810f19ac0`). Part of the agentic-engineering foundation series; independent.

## Changes

- Add a FROZEN banner to the issue board. Content is preserved (open items migrate
  to GitHub Issues incrementally and are then removed; history stays in git).
- `COORDINATOR_MEMORY.md` is intentionally left untouched because active worktrees
  may still depend on it.

## Validation

- `python scripts/docs/check_links.py docs/agent_memory/GAUSSIAN_ISSUE_BOARD.md` → all valid (banner uses backtick refs, no new links).

## User-visible behavior / Godot upstream delta

None. Docs only.

## Rollback

Revert the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
