### PR TITLE
gaussian_splatting: refresh RequiresGPU snapshot for #298 recompile test

### DIFF
--- a/docs/reference/renderer_release_gate_manifest.json
+++ b/docs/reference/renderer_release_gate_manifest.json
@@ -92,8 +92,8 @@
   "known_limitations_page": "docs/development/known-public-alpha-limitations.md",
   "requires_gpu_test_snapshot": {
     "source_glob": "modules/gaussian_splatting/tests/**/*.{h,cpp}",
-    "test_count": 107,
-    "sha256": "6cc8d4519396478ef75995ce0be3ddaaab8cd5b2f1f8125591b6e91f4dfa5f4b",
+    "test_count": 108,
+    "sha256": "aac1b9405d8234de2926c0c3d2f5175a73e7c1cd2d4ad58f5448f79a2aa11ae3",
     "deferred_tags_any": ["SceneTree", "Importer"],
     "deferred_count": 29,
     "new_or_missing_test_policy": "fail-contract-check",


### PR DESCRIPTION
## Summary
`master` has a pre-existing RequiresGPU snapshot drift: **108 actual / 107 manifest**. #402 (#298, *free tile shaders on recompile*) added `TEST_CASE("[GaussianSplatting][Renderer][Lifetime][RequiresGPU] tile_shader_recompile frees old shaders")` but did not refresh `docs/reference/renderer_release_gate_manifest.json`.

This fails the deterministic renderer release-gate contract check (`run_module_tests.py --guard-only`) on **every open PR's guard job** (currently #397, #399). It is independent of those PRs.

## Change
- `requires_gpu_test_snapshot.test_count`: 107 → **108**
- `requires_gpu_test_snapshot.sha256`: refreshed to the real test set
- `deferred_count` unchanged (29) — the new test is not SceneTree/Importer-tagged.

Coverage increases by one; **no gate is weakened** (this is the documented refresh procedure, mirroring #401).

## Validation
`python tests/ci/run_module_tests.py --guard-only` → *Renderer release gate contract check passed*; 94 module tests OK.

Risk: **R3** (release manifest). 🤖 Generated with [Claude Code](https://claude.com/claude-code)