### PR TITLE
gaussian_splatting: key asset_records on the full 64-bit ObjectID

### DIFF
--- a/docs/reference/renderer_release_gate_manifest.json
+++ b/docs/reference/renderer_release_gate_manifest.json
@@ -92,8 +92,8 @@
   "known_limitations_page": "docs/development/known-public-alpha-limitations.md",
   "requires_gpu_test_snapshot": {
     "source_glob": "modules/gaussian_splatting/tests/**/*.{h,cpp}",
-    "test_count": 109,
-    "sha256": "a9e1fb34bcdba339e6cfdc8c07273cb10fa8e6294b1d732294f3d4d6cdbc5d26",
+    "test_count": 110,
+    "sha256": "9a404e5b2e9156f3105315e933623705c2cfb617ef705bdf0485737545d01711",
     "deferred_tags_any": ["SceneTree", "Importer"],
     "deferred_count": 29,
     "new_or_missing_test_policy": "fail-contract-check",

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -707,7 +707,7 @@ bool GaussianSplatSceneDirector::_populate_gaussian_data_from_asset(const Ref<Ga
 	return true;
 }
 
-bool GaussianSplatSceneDirector::_retain_asset_record(SharedWorld &p_world, const Ref<GaussianSplatAsset> &p_asset, uint32_t p_asset_id) {
+bool GaussianSplatSceneDirector::_retain_asset_record(SharedWorld &p_world, const Ref<GaussianSplatAsset> &p_asset, uint64_t p_asset_id) {
 	if (p_asset.is_null()) {
 		return false;
 	}
@@ -747,7 +747,7 @@ bool GaussianSplatSceneDirector::_retain_asset_record(SharedWorld &p_world, cons
 	return true;
 }
 
-bool GaussianSplatSceneDirector::_refresh_asset_record(SharedWorld &p_world, const Ref<GaussianSplatAsset> &p_asset, uint32_t p_asset_id) {
+bool GaussianSplatSceneDirector::_refresh_asset_record(SharedWorld &p_world, const Ref<GaussianSplatAsset> &p_asset, uint64_t p_asset_id) {
 	if (p_asset.is_null()) {
 		return false;
 	}
@@ -775,7 +775,7 @@ bool GaussianSplatSceneDirector::_refresh_asset_record(SharedWorld &p_world, con
 	return true;
 }
 
-void GaussianSplatSceneDirector::_release_asset_record(SharedWorld &p_world, uint32_t p_asset_id) {
+void GaussianSplatSceneDirector::_release_asset_record(SharedWorld &p_world, uint64_t p_asset_id) {
 	SharedWorld::AssetRecord *record = p_world.asset_records.getptr(p_asset_id);
 	if (!record) {
 		return;
@@ -935,7 +935,7 @@ void GaussianSplatSceneDirector::register_instance(ObjectID p_node_id, const Ref
 			continue;
 		}
 		const uint32_t idx = *stale_index;
-		const uint32_t stale_asset_id = other.instances[idx].asset_id;
+		const uint64_t stale_asset_id = other.instances[idx].asset_id;
 		const uint32_t last_index = other.instances.size() - 1;
 		if (idx != last_index) {
 			other.instances[idx] = other.instances[last_index];
@@ -960,8 +960,10 @@ void GaussianSplatSceneDirector::register_instance(ObjectID p_node_id, const Ref
 		GaussianSplatting::debug_trace_record_event("instance_reg", "FAIL: asset=null", true);
 		return;
 	}
-	const uint64_t asset_id_u64 = p_asset->get_instance_id();
-	const uint32_t asset_id = static_cast<uint32_t>(asset_id_u64);
+	// Use the full 64-bit ObjectID as the asset_records key. Truncating to
+	// uint32_t (the old behaviour) made two assets whose ObjectIDs share the
+	// low 32 bits alias the same asset record.
+	const uint64_t asset_id = _asset_records_key(p_asset->get_instance_id());
 	const float wind_intensity = MAX(0.0f, p_wind_intensity);
 	const uint32_t wind_mode = MIN(p_wind_mode, (uint32_t)INSTANCE_WIND_FORCE_ENABLED);
 	const float wind_frequency = MAX(0.0f, p_wind_frequency);
@@ -972,7 +974,7 @@ void GaussianSplatSceneDirector::register_instance(ObjectID p_node_id, const Ref
 		return;
 	}
 	GaussianSplatting::debug_trace_record_event("instance_reg",
-			vformat("OK: asset_id=%d instances_before=%d", asset_id, world->instances.size()),
+			vformat("OK: asset_id=%s instances_before=%d", String::num_uint64(asset_id), world->instances.size()),
 			false);
 
 	uint32_t *index_ptr = world->instance_lookup.getptr(p_node_id);
@@ -1276,7 +1278,7 @@ void GaussianSplatSceneDirector::unregister_instance(ObjectID p_node_id) {
 	}
 
 	uint32_t index = *index_ptr;
-	const uint32_t asset_id = world->instances[index].asset_id;
+	const uint64_t asset_id = world->instances[index].asset_id;
 	uint32_t last_index = world->instances.size() - 1;
 	if (index != last_index) {
 		world->instances[index] = world->instances[last_index];
@@ -1390,8 +1392,8 @@ void GaussianSplatSceneDirector::update_instance_lods(const Vector3 &p_camera_po
 			}
 			if (desired_lod == static_cast<int>(current_lod)) {
 				if (log_enabled) {
-					GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (no change)",
-							String::num_uint64((uint64_t)record.node_id), record.asset_id, distance, bias, effective_distance, current_lod, desired_lod));
+					GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%s dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (no change)",
+							String::num_uint64((uint64_t)record.node_id), String::num_uint64(record.asset_id), distance, bias, effective_distance, current_lod, desired_lod));
 				}
 				continue;
 			}
@@ -1401,8 +1403,8 @@ void GaussianSplatSceneDirector::update_instance_lods(const Vector3 &p_camera_po
 				const float zone = use_fallback ? MAX(0.5f, 0.05f * threshold) : p_hysteresis_zone;
 				if (effective_distance < threshold + zone) {
 					if (log_enabled) {
-						GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (hold-up)",
-								String::num_uint64((uint64_t)record.node_id), record.asset_id, distance, bias, effective_distance, current_lod, desired_lod));
+						GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%s dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (hold-up)",
+								String::num_uint64((uint64_t)record.node_id), String::num_uint64(record.asset_id), distance, bias, effective_distance, current_lod, desired_lod));
 					}
 					continue;
 				}
@@ -1411,8 +1413,8 @@ void GaussianSplatSceneDirector::update_instance_lods(const Vector3 &p_camera_po
 				const float zone = use_fallback ? MAX(0.5f, 0.05f * threshold) : p_hysteresis_zone;
 				if (effective_distance > threshold - zone) {
 					if (log_enabled) {
-						GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (hold-down)",
-								String::num_uint64((uint64_t)record.node_id), record.asset_id, distance, bias, effective_distance, current_lod, desired_lod));
+						GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%s dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (hold-down)",
+								String::num_uint64((uint64_t)record.node_id), String::num_uint64(record.asset_id), distance, bias, effective_distance, current_lod, desired_lod));
 					}
 					continue;
 				}
@@ -1422,8 +1424,8 @@ void GaussianSplatSceneDirector::update_instance_lods(const Vector3 &p_camera_po
 			record.dirty = true;
 			any_changed = true;
 			if (log_enabled) {
-				GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u -> %u",
-						String::num_uint64((uint64_t)record.node_id), record.asset_id, distance, bias, effective_distance,
+				GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%s dist=%.3f bias=%.3f eff=%.3f lod=%u -> %u",
+						String::num_uint64((uint64_t)record.node_id), String::num_uint64(record.asset_id), distance, bias, effective_distance,
 						current_lod, record.last_lod));
 			}
 		}
@@ -1463,8 +1465,8 @@ void GaussianSplatSceneDirector::update_instance_lods_for_renderer(const Gaussia
 		}
 		if (desired_lod == static_cast<int>(current_lod)) {
 			if (log_enabled) {
-				GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (no change)",
-						String::num_uint64((uint64_t)record.node_id), record.asset_id, distance, bias, effective_distance, current_lod, desired_lod));
+				GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%s dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (no change)",
+						String::num_uint64((uint64_t)record.node_id), String::num_uint64(record.asset_id), distance, bias, effective_distance, current_lod, desired_lod));
 			}
 			continue;
 		}
@@ -1474,8 +1476,8 @@ void GaussianSplatSceneDirector::update_instance_lods_for_renderer(const Gaussia
 			const float zone = use_fallback ? MAX(0.5f, 0.05f * threshold) : p_hysteresis_zone;
 			if (effective_distance < threshold + zone) {
 				if (log_enabled) {
-					GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (hold-up)",
-							String::num_uint64((uint64_t)record.node_id), record.asset_id, distance, bias, effective_distance, current_lod, desired_lod));
+					GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%s dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (hold-up)",
+							String::num_uint64((uint64_t)record.node_id), String::num_uint64(record.asset_id), distance, bias, effective_distance, current_lod, desired_lod));
 				}
 				continue;
 			}
@@ -1484,8 +1486,8 @@ void GaussianSplatSceneDirector::update_instance_lods_for_renderer(const Gaussia
 			const float zone = use_fallback ? MAX(0.5f, 0.05f * threshold) : p_hysteresis_zone;
 			if (effective_distance > threshold - zone) {
 				if (log_enabled) {
-					GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (hold-down)",
-							String::num_uint64((uint64_t)record.node_id), record.asset_id, distance, bias, effective_distance, current_lod, desired_lod));
+					GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%s dist=%.3f bias=%.3f eff=%.3f lod=%u desired=%d (hold-down)",
+							String::num_uint64((uint64_t)record.node_id), String::num_uint64(record.asset_id), distance, bias, effective_distance, current_lod, desired_lod));
 				}
 				continue;
 			}
@@ -1495,8 +1497,8 @@ void GaussianSplatSceneDirector::update_instance_lods_for_renderer(const Gaussia
 		record.dirty = true;
 		any_changed = true;
 		if (log_enabled) {
-			GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%u dist=%.3f bias=%.3f eff=%.3f lod=%u -> %u",
-					String::num_uint64((uint64_t)record.node_id), record.asset_id, distance, bias, effective_distance,
+			GS_LOG_RENDERER_DEBUG(vformat("[InstanceLOD] node=%s asset=%s dist=%.3f bias=%.3f eff=%.3f lod=%u -> %u",
+					String::num_uint64((uint64_t)record.node_id), String::num_uint64(record.asset_id), distance, bias, effective_distance,
 					current_lod, record.last_lod));
 		}
 	}
@@ -1562,7 +1564,10 @@ void GaussianSplatSceneDirector::build_instance_buffer(LocalVector<InstanceDataG
 			entry.params[2] = record.wind_intensity;
 			entry.params[3] = float(record.wind_mode);
 
-			entry.ids[0] = record.asset_id;
+			// GPU instance slot is a 32-bit opaque tag used only for dense-id
+			// remapping; the collision-free identity lives in the 64-bit
+			// asset_records key, so truncation here is intentional.
+			entry.ids[0] = static_cast<uint32_t>(record.asset_id);
 			uint32_t flags = record.flags;
 			if (rotation.is_equal_approx(Quaternion())) {
 				flags |= GS_INSTANCE_FLAG_ROTATION_IDENTITY;
@@ -1672,8 +1677,8 @@ void GaussianSplatSceneDirector::build_instance_buffer_for_renderer(const Gaussi
 		const SharedWorld::AssetRecord *asset_record = world->asset_records.getptr(record.asset_id);
 		if (!asset_record || asset_record->data.is_null()) {
 			if (log_enabled) {
-				GS_LOG_RENDERER_DEBUG(vformat("[InstanceBuffer] SKIP asset_id=%d record=%s data=%s",
-						record.asset_id,
+				GS_LOG_RENDERER_DEBUG(vformat("[InstanceBuffer] SKIP asset_id=%s record=%s data=%s",
+						String::num_uint64(record.asset_id),
 						asset_record ? "found" : "NULL",
 						(asset_record && asset_record->data.is_valid()) ? "valid" : "null"));
 			}
@@ -1712,7 +1717,8 @@ void GaussianSplatSceneDirector::build_instance_buffer_for_renderer(const Gaussi
 		entry.params[2] = record.wind_intensity;
 		entry.params[3] = float(record.wind_mode);
 
-		entry.ids[0] = record.asset_id;
+		// 32-bit GPU tag; collision-free identity lives in asset_records (see above).
+		entry.ids[0] = static_cast<uint32_t>(record.asset_id);
 		uint32_t flags = record.flags;
 		if (rotation.is_equal_approx(Quaternion())) {
 			flags |= GS_INSTANCE_FLAG_ROTATION_IDENTITY;
@@ -1748,9 +1754,9 @@ void GaussianSplatSceneDirector::build_instance_buffer_for_renderer(const Gaussi
 			traced_fully_identity += (rotation_identity && scale_identity && translation_zero) ? 1u : 0u;
 		}
 		if (log_enabled) {
-			GS_LOG_RENDERER_DEBUG(vformat("[InstanceBuffer] idx=%d node=%s asset=%u lod=%u flags=0x%08X pos=(%.3f,%.3f,%.3f) scale=%.3f",
+			GS_LOG_RENDERER_DEBUG(vformat("[InstanceBuffer] idx=%d node=%s asset=%s lod=%u flags=0x%08X pos=(%.3f,%.3f,%.3f) scale=%.3f",
 					out.size() - 1,
-					String::num_uint64((uint64_t)record.node_id), record.asset_id, record.last_lod, record.flags,
+					String::num_uint64((uint64_t)record.node_id), String::num_uint64(record.asset_id), record.last_lod, record.flags,
 					entry.translation_scale[0], entry.translation_scale[1], entry.translation_scale[2], entry.translation_scale[3]));
 		}
 	}
@@ -2681,6 +2687,26 @@ bool GaussianSplatSceneDirector::has_shared_world_for_scenario(const RID &p_scen
 	return worlds.getptr(p_scenario) != nullptr;
 }
 
+#if defined(TESTS_ENABLED) || defined(TOOLS_ENABLED)
+uint32_t GaussianSplatSceneDirector::test_asset_record_count_for_scenario(const RID &p_scenario) const {
+	MutexLock lock(world_mutex);
+	const SharedWorld *world = worlds.getptr(p_scenario);
+	if (!world) {
+		return 0;
+	}
+	return world->asset_records.size();
+}
+
+bool GaussianSplatSceneDirector::test_has_asset_record_for_scenario(const RID &p_scenario, ObjectID p_asset_object_id) const {
+	MutexLock lock(world_mutex);
+	const SharedWorld *world = worlds.getptr(p_scenario);
+	if (!world) {
+		return false;
+	}
+	return world->asset_records.has(_asset_records_key(p_asset_object_id));
+}
+#endif
+
 void GaussianSplatSceneDirector::teardown_world_for_scenario(const RID &p_scenario) {
 	// Explicit, idempotent F6-reload teardown. See header comment for rationale.
 	// Drops every Ref the SharedWorld holds (renderer, asset records, world-submission
@@ -2866,7 +2892,7 @@ void GaussianSplatSceneDirector::collect_instance_assets_for_renderer(const Gaus
 		return;
 	}
 
-	HashSet<uint32_t> selected_asset_ids;
+	HashSet<uint64_t> selected_asset_ids;
 	selected_asset_ids.reserve(world->asset_records.size());
 	for (const InstanceRecord &record : world->instances) {
 		if (!record.visible) {
@@ -2881,13 +2907,15 @@ void GaussianSplatSceneDirector::collect_instance_assets_for_renderer(const Gaus
 	}
 
 	out.reserve(selected_asset_ids.size());
-	for (const uint32_t &asset_id : selected_asset_ids) {
+	for (const uint64_t &asset_id : selected_asset_ids) {
 		const SharedWorld::AssetRecord *record = world->asset_records.getptr(asset_id);
 		if (!record || record->data.is_null()) {
 			continue;
 		}
 		InstanceAssetRegistration entry;
-		entry.asset_id = asset_id;
+		// InstanceAssetRegistration::asset_id is the 32-bit GPU/dense-id tag;
+		// the dedupe above runs on the collision-free 64-bit key.
+		entry.asset_id = static_cast<uint32_t>(asset_id);
 		entry.data = record->data;
 		entry.edited_version = record->edited_version;
 		entry.requests_full_fidelity_runtime = _asset_requests_full_fidelity_runtime(record->asset);
@@ -2906,12 +2934,13 @@ void GaussianSplatSceneDirector::collect_registered_assets_for_renderer(const Ga
 	}
 
 	out.reserve(world->asset_records.size());
-	for (const KeyValue<uint32_t, SharedWorld::AssetRecord> &E : world->asset_records) {
+	for (const KeyValue<uint64_t, SharedWorld::AssetRecord> &E : world->asset_records) {
 		if (E.key == 0 || E.value.data.is_null()) {
 			continue;
 		}
 		InstanceAssetRegistration entry;
-		entry.asset_id = E.key;
+		// 32-bit GPU/dense-id tag projected from the 64-bit asset_records key.
+		entry.asset_id = static_cast<uint32_t>(E.key);
 		entry.data = E.value.data;
 		entry.edited_version = E.value.edited_version;
 		entry.requests_full_fidelity_runtime = _asset_requests_full_fidelity_runtime(E.value.asset);

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -1597,9 +1597,13 @@ void GaussianSplatSceneDirector::build_instance_buffer(LocalVector<InstanceDataG
 }
 
 void GaussianSplatSceneDirector::build_instance_buffer_for_renderer(const GaussianSplatRenderer *p_renderer,
-		LocalVector<InstanceDataGPU> &out, bool p_shadow_casters_only) const {
+		LocalVector<InstanceDataGPU> &out, bool p_shadow_casters_only,
+		LocalVector<uint64_t> *r_submission_asset_ids) const {
 	MutexLock lock(world_mutex);
 	out.clear();
+	if (r_submission_asset_ids) {
+		r_submission_asset_ids->clear();
+	}
 
 	const SharedWorld *world = _find_world_for_renderer(p_renderer);
 	if (!world) {
@@ -1654,6 +1658,10 @@ void GaussianSplatSceneDirector::build_instance_buffer_for_renderer(const Gaussi
 			entry.effect_params[2] = _encode_u32_as_float_bits(world_scope_mask);
 			entry.effect_params[3] = float(scene_payload.size());
 			out.push_back(entry);
+			if (r_submission_asset_ids) {
+				// Primary/world-submission asset id is 0 (kPrimary*AssetId).
+				r_submission_asset_ids->push_back(0ULL);
+			}
 		}
 		return;
 	}
@@ -1717,7 +1725,10 @@ void GaussianSplatSceneDirector::build_instance_buffer_for_renderer(const Gaussi
 		entry.params[2] = record.wind_intensity;
 		entry.params[3] = float(record.wind_mode);
 
-		// 32-bit GPU tag; collision-free identity lives in asset_records (see above).
+		// GPU tag is only 32 bits; it carries a TRANSIENT truncated asset id that
+		// update_instance_buffer() overwrites with the resolved dense slot. The
+		// collision-free 64-bit submission identity is published in parallel via
+		// r_submission_asset_ids below (and lives authoritatively in asset_records).
 		entry.ids[0] = static_cast<uint32_t>(record.asset_id);
 		uint32_t flags = record.flags;
 		if (rotation.is_equal_approx(Quaternion())) {
@@ -1743,6 +1754,9 @@ void GaussianSplatSceneDirector::build_instance_buffer_for_renderer(const Gaussi
 		entry.effect_params[3] = float(scene_payload.size());
 
 		out.push_back(entry);
+		if (r_submission_asset_ids) {
+			r_submission_asset_ids->push_back(record.asset_id);
+		}
 		if (trace_enabled) {
 			const bool rotation_identity = (flags & GS_INSTANCE_FLAG_ROTATION_IDENTITY) != 0u;
 			const bool scale_identity = (flags & GS_INSTANCE_FLAG_SCALE_IDENTITY) != 0u;
@@ -2913,9 +2927,10 @@ void GaussianSplatSceneDirector::collect_instance_assets_for_renderer(const Gaus
 			continue;
 		}
 		InstanceAssetRegistration entry;
-		// InstanceAssetRegistration::asset_id is the 32-bit GPU/dense-id tag;
-		// the dedupe above runs on the collision-free 64-bit key.
-		entry.asset_id = static_cast<uint32_t>(asset_id);
+		// Carry the FULL 64-bit submission identity through to the renderer remap.
+		// This is the collision-free key into PublishedInstanceAssetRemap; truncating
+		// it here would alias two assets whose ObjectIDs share the low 32 bits.
+		entry.asset_id = asset_id;
 		entry.data = record->data;
 		entry.edited_version = record->edited_version;
 		entry.requests_full_fidelity_runtime = _asset_requests_full_fidelity_runtime(record->asset);
@@ -2939,8 +2954,9 @@ void GaussianSplatSceneDirector::collect_registered_assets_for_renderer(const Ga
 			continue;
 		}
 		InstanceAssetRegistration entry;
-		// 32-bit GPU/dense-id tag projected from the 64-bit asset_records key.
-		entry.asset_id = static_cast<uint32_t>(E.key);
+		// Carry the FULL 64-bit asset_records key (host submission identity) through
+		// to the renderer remap so distinct ObjectIDs never alias a dense slot.
+		entry.asset_id = E.key;
 		entry.data = E.value.data;
 		entry.edited_version = E.value.edited_version;
 		entry.requests_full_fidelity_runtime = _asset_requests_full_fidelity_runtime(E.value.asset);

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
@@ -274,6 +274,20 @@ public:
     // given scenario in the director's map. Distinct from get_shared_renderer(),
     // which lazily creates the entry on a miss.
     bool has_shared_world_for_scenario(const RID &p_scenario) const;
+#if defined(TESTS_ENABLED) || defined(TOOLS_ENABLED)
+    // Test/diagnostics-only: returns the SharedWorld::asset_records key the
+    // director derives from an asset's ObjectID. Exposed so a regression test
+    // can prove two ObjectIDs colliding in the low 32 bits do NOT alias.
+    static uint64_t test_asset_records_key(ObjectID p_asset_object_id) {
+        return _asset_records_key(p_asset_object_id);
+    }
+    // Test/diagnostics-only: number of distinct asset records retained in the
+    // SharedWorld bound to the given scenario (0 if no world exists).
+    uint32_t test_asset_record_count_for_scenario(const RID &p_scenario) const;
+    // Test/diagnostics-only: true iff the SharedWorld for the scenario holds an
+    // asset record under the full 64-bit ObjectID key.
+    bool test_has_asset_record_for_scenario(const RID &p_scenario, ObjectID p_asset_object_id) const;
+#endif
     bool get_world_submission(ObjectID p_owner_id, WorldSubmission *r_submission) const;
     bool get_world_submission_for_scenario(const RID &p_scenario, WorldSubmission *r_submission) const;
     bool has_world_submission_for_renderer(const GaussianSplatRenderer *p_renderer) const;
@@ -300,7 +314,10 @@ private:
 		float wind_frequency = 1.0f;
 		float effect_position_scale = 1.0f;
 		float effect_opacity_scale = 1.0f;
-		uint32_t asset_id = 0;
+		// Full 64-bit ObjectID of the asset Node3D. Must NOT be truncated to
+		// 32 bits: two assets whose ObjectIDs collide in the low 32 bits would
+		// otherwise alias the same SharedWorld::asset_records entry.
+		uint64_t asset_id = 0;
 		uint32_t flags = 0;
         uint32_t last_lod = 0;
         bool casts_shadow = false;
@@ -375,7 +392,7 @@ private:
             uint32_t refcount = 0;
             uint32_t edited_version = 0;
         };
-        HashMap<uint32_t, AssetRecord> asset_records;
+        HashMap<uint64_t, AssetRecord> asset_records;
     };
 
     static GaussianSplatSceneDirector *singleton;
@@ -404,10 +421,17 @@ private:
     static uint32_t _build_scene_effector_mask_for_record(const InstanceRecord &p_record,
             const LocalVector<SphereEffectorSelection> &p_payload);
 
+	// Single source of truth for the SharedWorld::asset_records key. The key is
+	// the FULL 64-bit ObjectID; it must never be truncated to 32 bits or two
+	// assets whose ObjectIDs share the low 32 bits would alias the same record.
+	static uint64_t _asset_records_key(ObjectID p_asset_object_id) {
+		return p_asset_object_id;
+	}
+
 	static bool _populate_gaussian_data_from_asset(const Ref<GaussianSplatAsset> &p_asset, Ref<GaussianData> &r_data);
-	static bool _retain_asset_record(SharedWorld &p_world, const Ref<GaussianSplatAsset> &p_asset, uint32_t p_asset_id);
-	static bool _refresh_asset_record(SharedWorld &p_world, const Ref<GaussianSplatAsset> &p_asset, uint32_t p_asset_id);
-	static void _release_asset_record(SharedWorld &p_world, uint32_t p_asset_id);
+	static bool _retain_asset_record(SharedWorld &p_world, const Ref<GaussianSplatAsset> &p_asset, uint64_t p_asset_id);
+	static bool _refresh_asset_record(SharedWorld &p_world, const Ref<GaussianSplatAsset> &p_asset, uint64_t p_asset_id);
+	static void _release_asset_record(SharedWorld &p_world, uint64_t p_asset_id);
 	static bool _is_world_submission_owner_live(ObjectID p_owner_id);
 	static void _store_world_submission_record(SharedWorld::WorldSubmissionRecord &r_record, const WorldSubmission &p_submission);
 	static bool _world_submission_record_has_renderable_payload(const SharedWorld::WorldSubmissionRecord &p_record);

--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.h
@@ -136,8 +136,16 @@ public:
     void update_instance_lods_for_renderer(const GaussianSplatRenderer *p_renderer, const Vector3 &p_camera_pos,
             const LODConfig &p_lod_config, float p_hysteresis_zone);
     void build_instance_buffer(LocalVector<InstanceDataGPU> &out) const;
+	// Builds the per-instance GPU rows. When r_submission_asset_ids is non-null it is
+	// filled parallel to `out` with each instance's FULL 64-bit submission asset
+	// identity (the asset_records key). The GPU InstanceDataGPU::ids[0] field is only
+	// 32 bits and therefore cannot carry that identity losslessly once 64-bit ObjectIDs
+	// are in play; update_instance_buffer() uses this parallel array as the collision-
+	// free key into PublishedInstanceAssetRemap before overwriting ids[0] with the
+	// resolved dense slot.
 	void build_instance_buffer_for_renderer(const GaussianSplatRenderer *p_renderer, LocalVector<InstanceDataGPU> &out,
-			bool p_shadow_casters_only = false) const;
+			bool p_shadow_casters_only = false,
+			LocalVector<uint64_t> *r_submission_asset_ids = nullptr) const;
 	// Build the per-instance color grading SSBO for the supplied renderer. Walks the same
 	// instance list as build_instance_buffer_for_renderer; falls back to the renderer's
 	// RenderConfig::color_grading when a record has no per-instance ref. When no director

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
@@ -2795,7 +2795,8 @@ void GaussianSplatRenderer::publish_route_skip_stage_metrics(const String &p_rou
     }
 }
 
-bool GaussianSplatRenderer::update_instance_buffer(LocalVector<InstanceDataGPU> &p_instances, const PublishedInstanceAssetRemap &p_remap) {
+bool GaussianSplatRenderer::update_instance_buffer(LocalVector<InstanceDataGPU> &p_instances, const PublishedInstanceAssetRemap &p_remap,
+        const LocalVector<uint64_t> *p_submission_asset_ids) {
     if (!_ensure_rendering_device("update_instance_buffer")) {
         return false;
     }
@@ -2812,16 +2813,32 @@ bool GaussianSplatRenderer::update_instance_buffer(LocalVector<InstanceDataGPU> 
         return false;
     }
 
+    // The GPU InstanceDataGPU::ids[0] field is only 32 bits, so it cannot carry the
+    // full 64-bit host submission identity once ObjectIDs differ above the low 32 bits.
+    // Prefer the parallel 64-bit submission-id array (collision-free key into the
+    // published remap); fall back to the truncated ids[0] tag only when the caller has
+    // no 64-bit identities to supply (e.g. legacy/test callers with small ids).
+    const bool use_wide_keys = p_submission_asset_ids != nullptr &&
+            p_submission_asset_ids->size() == instance_count;
+    if (p_submission_asset_ids != nullptr && p_submission_asset_ids->size() != instance_count) {
+        WARN_PRINT_ONCE(vformat("[GaussianSplatRenderer] submission_asset_ids size (%u) != instance count (%u); "
+                                "falling back to 32-bit ids[0] keys.",
+                p_submission_asset_ids->size(), instance_count));
+    }
+
     const uint32_t published_generation = p_remap.generation == 0
             ? 1u
             : uint32_t(p_remap.generation & uint64_t(UINT32_MAX));
     for (uint32_t i = 0; i < instance_count; i++) {
-        const uint32_t incoming_asset_id = p_instances[i].ids[0];
+        const uint64_t incoming_asset_id = use_wide_keys
+                ? (*p_submission_asset_ids)[i]
+                : uint64_t(p_instances[i].ids[0]);
         uint32_t dense_id = 0u;
         if (const uint32_t *mapped_dense_id = p_remap.asset_to_dense_id.getptr(incoming_asset_id)) {
             dense_id = *mapped_dense_id;
         } else {
-            WARN_PRINT_ONCE(vformat("[GaussianSplatRenderer] Instance asset_id %u is not published; using primary resident asset.", incoming_asset_id));
+            WARN_PRINT_ONCE(vformat("[GaussianSplatRenderer] Instance asset_id %s is not published; using primary resident asset.",
+                    String::num_uint64(incoming_asset_id)));
         }
         p_instances[i].ids[0] = dense_id;
         p_instances[i].lod[1] = published_generation;

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
@@ -99,7 +99,13 @@ class GaussianSplatShaderRD;
 class GsShadowBlitShaderRD;
 
 struct InstanceAssetRegistration {
-    uint32_t asset_id = 0;
+    // Full 64-bit host submission identity (the asset Node3D's ObjectID). This is
+    // the collision-free key into PublishedInstanceAssetRemap::asset_to_dense_id.
+    // It must NOT be truncated to 32 bits: two assets whose ObjectIDs collide in
+    // the low 32 bits would otherwise resolve to the same dense atlas slot and
+    // render as the same asset. The GPU-facing dense id (InstanceDataGPU::ids[0])
+    // stays 32-bit because it is a sequential, collision-free index.
+    uint64_t asset_id = 0;
     Ref<GaussianData> data;
     uint32_t edited_version = 0;
     bool requests_full_fidelity_runtime = false;
@@ -845,7 +851,15 @@ public:
     Error restore_world_submission_runtime_state(const WorldSubmissionRuntimeStateSnapshot &p_snapshot);
     Error apply_world_submission_contract(const WorldSubmissionContract &p_contract);
     void clear_world_submission_contract();
-    bool update_instance_buffer(LocalVector<InstanceDataGPU> &p_instances, const PublishedInstanceAssetRemap &p_remap);
+    // Resolves each instance's published asset identity to its dense atlas slot and
+    // uploads the instance buffer. When p_submission_asset_ids is non-null and sized
+    // 1:1 with p_instances, it supplies the FULL 64-bit submission identity used as
+    // the collision-free key into p_remap.asset_to_dense_id; the resolved 32-bit dense
+    // id is then written into InstanceDataGPU::ids[0]. When null (or size-mismatched),
+    // the lookup falls back to the truncated 32-bit ids[0] tag for backward
+    // compatibility with callers that have no 64-bit identity to thread through.
+    bool update_instance_buffer(LocalVector<InstanceDataGPU> &p_instances, const PublishedInstanceAssetRemap &p_remap,
+            const LocalVector<uint64_t> *p_submission_asset_ids = nullptr);
     // Upload the per-instance color grading SSBO. Called alongside update_instance_buffer
     // from both the resident and streaming contract-publish paths.
     bool update_instance_grading_buffer(const LocalVector<InstanceGradingGPU> &p_gradings);

--- a/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
@@ -92,17 +92,17 @@ static uint64_t _compute_instance_asset_remap_fingerprint(const PublishedInstanc
 		return generation;
 	}
 
-	LocalVector<uint32_t> asset_ids;
+	LocalVector<uint64_t> asset_ids;
 	asset_ids.reserve(p_remap.asset_to_dense_id.size());
-	for (const KeyValue<uint32_t, uint32_t> &entry : p_remap.asset_to_dense_id) {
+	for (const KeyValue<uint64_t, uint32_t> &entry : p_remap.asset_to_dense_id) {
 		asset_ids.push_back(entry.key);
 	}
-	uint32_t *asset_ids_ptr = asset_ids.ptr();
+	uint64_t *asset_ids_ptr = asset_ids.ptr();
 	std::sort(asset_ids_ptr, asset_ids_ptr + asset_ids.size());
 	for (uint32_t i = 0; i < asset_ids.size(); i++) {
-		const uint32_t asset_id = asset_ids[i];
+		const uint64_t asset_id = asset_ids[i];
 		const uint32_t *dense_id = p_remap.asset_to_dense_id.getptr(asset_id);
-		generation = _mix_u32_generation(generation, asset_id);
+		generation = _mix_content_generation(generation, asset_id);
 		generation = _mix_u32_generation(generation, dense_id ? *dense_id : UINT32_MAX);
 	}
 	return generation;
@@ -132,35 +132,47 @@ static PublishedInstanceAssetRemap _build_streaming_instance_asset_remap(
 		GaussianStreamingSystem *p_streaming_system,
 		const LocalVector<InstanceAssetRegistration> &p_asset_cache,
 		const LocalVector<InstanceDataGPU> &p_instances,
+		const LocalVector<uint64_t> &p_submission_asset_ids,
 		uint64_t p_generation) {
 	PublishedInstanceAssetRemap remap;
 	if (p_streaming_system == nullptr) {
 		return remap;
 	}
 
+	// The remap KEY is the FULL 64-bit submission identity (collision-free) so it
+	// matches the key update_instance_buffer() resolves against. The streaming dense
+	// registry is itself still 32-bit keyed (a separate, GPU-atlas-coupled follow-up);
+	// its get_dense_asset_id() takes a uint32_t, so we truncate ONLY for that internal
+	// dense lookup while keeping the published key 64-bit.
 	const uint32_t primary_dense_id = p_streaming_system->get_dense_asset_id(kPrimaryStreamingAssetId) !=
 					kInvalidStreamingAssetId
 			? p_streaming_system->get_dense_asset_id(kPrimaryStreamingAssetId)
 			: kPrimaryStreamingAssetId;
-	remap.asset_to_dense_id.insert(kPrimaryStreamingAssetId, primary_dense_id);
+	remap.asset_to_dense_id.insert(uint64_t(kPrimaryStreamingAssetId), primary_dense_id);
 
 	for (const InstanceAssetRegistration &entry : p_asset_cache) {
 		if (entry.asset_id == 0) {
 			continue;
 		}
-		uint32_t dense_id = p_streaming_system->get_dense_asset_id(entry.asset_id);
+		uint32_t dense_id = p_streaming_system->get_dense_asset_id(static_cast<uint32_t>(entry.asset_id));
 		if (dense_id == kInvalidStreamingAssetId) {
 			dense_id = primary_dense_id;
 		}
 		remap.asset_to_dense_id.insert(entry.asset_id, dense_id);
 	}
 
-	for (const InstanceDataGPU &entry : p_instances) {
-		const uint32_t asset_id = entry.ids[0];
+	// Fallback for any instance whose submission id was not covered by the asset cache.
+	// Key on the parallel 64-bit submission id (NOT the truncated ids[0] GPU tag) so the
+	// published key stays collision-free.
+	const bool have_wide_ids = p_submission_asset_ids.size() == p_instances.size();
+	for (uint32_t i = 0; i < p_instances.size(); i++) {
+		const uint64_t asset_id = have_wide_ids
+				? p_submission_asset_ids[i]
+				: uint64_t(p_instances[i].ids[0]);
 		if (remap.asset_to_dense_id.has(asset_id)) {
 			continue;
 		}
-		uint32_t dense_id = p_streaming_system->get_dense_asset_id(asset_id);
+		uint32_t dense_id = p_streaming_system->get_dense_asset_id(static_cast<uint32_t>(asset_id));
 		if (dense_id == kInvalidStreamingAssetId) {
 			dense_id = primary_dense_id;
 		}
@@ -628,6 +640,7 @@ void RenderStreamingOrchestrator::invalidate_instance_pipeline_caches() {
 	instance_pipeline_assets_to_remove.clear();
 	instance_pipeline_assets_cache.clear();
 	instance_pipeline_instance_cache.clear();
+	instance_pipeline_submission_asset_ids_cache.clear();
 	instance_pipeline_asset_versions.clear();
 	instance_pipeline_lod_mask_cache.clear();
 	instance_pipeline_asset_snapshot_generation = 0;
@@ -709,8 +722,9 @@ const RenderStreamingOrchestrator::VisibleLODSelection &RenderStreamingOrchestra
 	}
 
 	visible_lod_selection._internal_get_instances().clear();
+	visible_lod_selection._internal_get_submission_asset_ids().clear();
 	p_director->build_instance_buffer_for_renderer(renderer, visible_lod_selection._internal_get_instances(),
-			shadow_only);
+			shadow_only, &visible_lod_selection._internal_get_submission_asset_ids());
 	visible_lod_selection_generation = instance_generation;
 	visible_lod_selection_shadow_only = shadow_only;
 
@@ -1244,10 +1258,14 @@ void RenderStreamingOrchestrator::sync_instance_pipeline_assets(GaussianStreamin
 		if (entry.asset_id == 0 || entry.data.is_null()) {
 			continue;
 		}
-		if (deterministic_asset_id == UINT32_MAX || entry.asset_id < deterministic_asset_id) {
-			deterministic_asset_id = entry.asset_id;
+		// The streaming registry's identity space is 32-bit (a separate follow-up to
+		// widen). Project the 64-bit submission id into it explicitly here; the
+		// collision-free 64-bit key is preserved in the published remap above.
+		const uint32_t streaming_asset_id = static_cast<uint32_t>(entry.asset_id);
+		if (deterministic_asset_id == UINT32_MAX || streaming_asset_id < deterministic_asset_id) {
+			deterministic_asset_id = streaming_asset_id;
 		}
-		if (entry.asset_id == static_layout_bound_asset_id) {
+		if (streaming_asset_id == static_layout_bound_asset_id) {
 			bound_asset_present = true;
 		}
 	}
@@ -1306,14 +1324,16 @@ void RenderStreamingOrchestrator::sync_instance_pipeline_assets(GaussianStreamin
 			if (entry.asset_id == 0 || entry.data.is_null()) {
 				if (trace_enabled) {
 					GaussianSplatting::debug_trace_record_event("instance_pipeline",
-							vformat("SyncAssets SKIP asset_id=%d data=%s",
-									entry.asset_id, entry.data.is_valid() ? "valid" : "null"),
+							vformat("SyncAssets SKIP asset_id=%s data=%s",
+									String::num_uint64(entry.asset_id), entry.data.is_valid() ? "valid" : "null"),
 							true);
 				}
 				continue;
 			}
-			instance_pipeline_assets_next.insert(entry.asset_id);
-			const uint32_t asset_id = entry.asset_id;
+			// Streaming registry identity is 32-bit (separate follow-up); project the
+			// 64-bit submission id explicitly. The published remap keeps the 64-bit key.
+			const uint32_t asset_id = static_cast<uint32_t>(entry.asset_id);
+			instance_pipeline_assets_next.insert(asset_id);
 			uint32_t *version_ptr = instance_pipeline_asset_versions.getptr(asset_id);
 			const bool version_changed = !version_ptr || *version_ptr != entry.edited_version;
 			const bool layout_rebind_for_asset = static_layout_rebind_required &&
@@ -1332,7 +1352,7 @@ void RenderStreamingOrchestrator::sync_instance_pipeline_assets(GaussianStreamin
 						false);
 			}
 			if (needs_register) {
-				p_streaming_system->register_asset(entry.asset_id, entry.data);
+				p_streaming_system->register_asset(asset_id, entry.data);
 				if (trace_enabled) {
 					GaussianSplatting::debug_trace_record_event("instance_pipeline",
 							vformat("SyncAssets REGISTERED asset_id=%d", asset_id),
@@ -1545,6 +1565,7 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 		return false;
 	}
 	instance_pipeline_instance_cache.clear();
+	instance_pipeline_submission_asset_ids_cache.clear();
 	if (director && streaming_system) {
 		sync_instance_pipeline_assets(streaming_system);
 		const VisibleLODSelection &selection = produce_visible_lod_selection(
@@ -1552,6 +1573,7 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 				streaming_system,
 				p_camera_to_world_transform.origin);
 		instance_pipeline_instance_cache = selection.get_instances();
+		instance_pipeline_submission_asset_ids_cache = selection.get_submission_asset_ids();
 		consume_visible_lod_selection_for_residency(selection, streaming_system, trace_enabled);
 	}
 	const uint32_t registered_assets_with_data = streaming_system->get_registered_asset_count_with_data();
@@ -1858,7 +1880,7 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 		instance_buffers_atlas_required = atlas_buffers_required;
 		const PublishedInstanceAssetRemap published_remap = _build_streaming_instance_asset_remap(
 				streaming_system, instance_pipeline_assets_cache, instance_pipeline_instance_cache,
-				base_content_generation);
+				instance_pipeline_submission_asset_ids_cache, base_content_generation);
 		const bool atlas_ready_preupload = GaussianSplatting::InstancePipelineContract::has_atlas_buffers(buffers);
 		uint64_t contract_fingerprint = _compute_instance_pipeline_resource_fingerprint(resource_state_mut, buffers);
 		const bool contract_changed = previous_contract_generation != contract_generation ||
@@ -1884,7 +1906,8 @@ bool RenderStreamingOrchestrator::render_streaming_frame(RenderDataRD *p_render_
 						"atlas_emulation");
 			}
 			if (upload_changed) {
-				if (!(renderer->*runtime_ports.update_instance_buffer)(instance_pipeline_instance_cache, published_remap)) {
+				if (!(renderer->*runtime_ports.update_instance_buffer)(instance_pipeline_instance_cache, published_remap,
+							&instance_pipeline_submission_asset_ids_cache)) {
 					buffers = renderer->get_instance_pipeline_buffers();
 					renderer->clear_instance_pipeline_buffers();
 				} else {
@@ -2277,6 +2300,7 @@ void RenderStreamingOrchestrator::tick_streaming_only(const Transform3D &p_camer
 				streaming_system,
 				p_camera_to_world_transform.origin);
 		instance_pipeline_instance_cache = selection.get_instances();
+		instance_pipeline_submission_asset_ids_cache = selection.get_submission_asset_ids();
 		const uint32_t registered_assets_with_data = streaming_system->get_registered_asset_count_with_data();
 		if (!instance_pipeline_instance_cache.is_empty() && registered_assets_with_data == 0) {
 			ERR_PRINT("[GaussianSplatRenderer] Streaming tick found instances but no registered streaming assets with data; resetting streaming system.");

--- a/modules/gaussian_splatting/renderer/render_streaming_orchestrator.h
+++ b/modules/gaussian_splatting/renderer/render_streaming_orchestrator.h
@@ -20,7 +20,8 @@ struct RenderStreamingOrchestratorDependencies {
 				const Projection &p_cull_projection, const char *p_context) = &GaussianSplatRenderer::validate_cull_projection_contract;
 		void (GaussianSplatRenderer::*clear_instance_pipeline_buffers)() = &GaussianSplatRenderer::clear_instance_pipeline_buffers;
 		bool (GaussianSplatRenderer::*update_instance_buffer)(LocalVector<InstanceDataGPU> &p_instances,
-				const GaussianSplatRenderer::PublishedInstanceAssetRemap &p_remap) = &GaussianSplatRenderer::update_instance_buffer;
+				const GaussianSplatRenderer::PublishedInstanceAssetRemap &p_remap,
+				const LocalVector<uint64_t> *p_submission_asset_ids) = &GaussianSplatRenderer::update_instance_buffer;
 		void (GaussianSplatRenderer::*run_cull_sort_pipeline_frame)(RenderDataRD *p_render_data, const Transform3D &p_world_to_camera_transform,
 				const Projection &p_projection, const Projection &p_render_projection, RenderSceneBuffersRD *p_render_buffers,
 				bool p_has_render_data, const String &p_cull_skip_reason, const String &p_sort_skip_reason,
@@ -54,9 +55,16 @@ public:
 		bool has_instances() const { return !instances.is_empty(); }
 		const LocalVector<InstanceDataGPU> &get_instances() const { return instances; }
 		LocalVector<InstanceDataGPU> &_internal_get_instances() { return instances; }
+		// Parallel to instances: each row's FULL 64-bit submission asset identity (the
+		// collision-free key into PublishedInstanceAssetRemap). Kept here so the
+		// streaming instance upload can resolve dense slots without truncating through
+		// the 32-bit InstanceDataGPU::ids[0] field.
+		const LocalVector<uint64_t> &get_submission_asset_ids() const { return submission_asset_ids; }
+		LocalVector<uint64_t> &_internal_get_submission_asset_ids() { return submission_asset_ids; }
 
 	private:
 		LocalVector<InstanceDataGPU> instances;
+		LocalVector<uint64_t> submission_asset_ids;
 	};
 
 private:
@@ -70,6 +78,9 @@ private:
 	LocalVector<uint32_t> instance_pipeline_assets_to_remove;
 	LocalVector<InstanceAssetRegistration> instance_pipeline_assets_cache;
 	LocalVector<InstanceDataGPU> instance_pipeline_instance_cache;
+	// Parallel to instance_pipeline_instance_cache: 64-bit submission asset ids used as
+	// the collision-free key when resolving dense atlas slots in update_instance_buffer.
+	LocalVector<uint64_t> instance_pipeline_submission_asset_ids_cache;
 	HashMap<uint32_t, uint32_t> instance_pipeline_lod_mask_cache;
 	HashMap<uint32_t, uint32_t> instance_pipeline_asset_versions;
 	uint64_t instance_pipeline_asset_snapshot_generation = 0;

--- a/modules/gaussian_splatting/renderer/render_types/render_pipeline_io_types.h
+++ b/modules/gaussian_splatting/renderer/render_types/render_pipeline_io_types.h
@@ -167,7 +167,12 @@ inline const char *instance_backend_policy_to_string(InstanceBackendPolicy p_pol
 }
 
 struct PublishedInstanceAssetRemap {
-	HashMap<uint32_t, uint32_t> asset_to_dense_id;
+	// Key: full 64-bit host submission asset identity (asset Node3D ObjectID).
+	// Value: sequential dense atlas slot id (collision-free, fits uint32_t and is
+	// what lands in the GPU InstanceDataGPU::ids[0] field). The key must stay
+	// 64-bit so two assets whose ObjectIDs collide in the low 32 bits map to
+	// distinct dense slots instead of aliasing the same rendered asset.
+	HashMap<uint64_t, uint32_t> asset_to_dense_id;
 	uint64_t generation = 0;
 	bool valid = false;
 

--- a/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
+++ b/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
@@ -28,7 +28,10 @@ struct ResidentChunkDescriptor {
 };
 
 struct ResidentAssetDescriptor {
-	uint32_t submission_asset_id = 0;
+	// Full 64-bit host submission identity (asset_records key / ObjectID). Must stay
+	// 64-bit so it remains the collision-free key into the published remap. The dense
+	// atlas slot below stays 32-bit (sequential, collision-free, GPU-facing).
+	uint64_t submission_asset_id = 0;
 	uint32_t dense_asset_id = 0;
 	Ref<GaussianData> data;
 	Vector<GaussianSplatRenderer::StaticChunk> static_chunks;
@@ -296,6 +299,11 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 	}
 
 	LocalVector<InstanceDataGPU> instances;
+	// Parallel to `instances`: each instance's FULL 64-bit submission asset identity,
+	// the collision-free key into the published remap. Threaded into
+	// update_instance_buffer() so two assets whose ObjectIDs collide in the low 32 bits
+	// resolve to distinct dense atlas slots instead of aliasing.
+	LocalVector<uint64_t> instance_submission_asset_ids;
 	// Director "owns" this renderer's instance set when there's a world
 	// submission for it. In that case an empty `instances` result is
 	// intentional — e.g. a shadow-filtered pass that legitimately produced
@@ -309,7 +317,7 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 			director->has_world_submission_for_renderer(p_renderer);
 	if (director != nullptr) {
 		director->build_instance_buffer_for_renderer(p_renderer, instances,
-				p_renderer->is_shadow_instance_filter_enabled());
+				p_renderer->is_shadow_instance_filter_enabled(), &instance_submission_asset_ids);
 	}
 	if (instances.is_empty() && has_primary_data && !director_owns_instance_set) {
 		InstanceDataGPU bootstrap_instance = {};
@@ -327,6 +335,7 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 				GS_INSTANCE_FLAG_SCALE_IDENTITY |
 				GS_INSTANCE_FLAG_TRANSLATION_ZERO;
 		instances.push_back(bootstrap_instance);
+		instance_submission_asset_ids.push_back(uint64_t(kPrimaryResidentAssetId));
 	}
 
 	if (instances.is_empty()) {
@@ -749,7 +758,7 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 	resource_state.instance_pipeline_upload_generation = source_generation;
 	resource_state.instance_pipeline_upload_fingerprint = 0;
 
-	if (!p_renderer->update_instance_buffer(instances, remap)) {
+	if (!p_renderer->update_instance_buffer(instances, remap, &instance_submission_asset_ids)) {
 		if (r_reason) {
 			*r_reason = "resident_instance_upload_failed";
 		}

--- a/modules/gaussian_splatting/tests/test_gaussian_splatting.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splatting.h
@@ -58,6 +58,7 @@
 #include "test_shadow_pass_isolation.h"
 #include "test_shadow_instance_subset.h"
 #include "test_scene_director_submission_scaffolding.h"
+#include "test_scene_director_asset_id_collision.h"
 #include "test_sentinel_tier_defaults.h"
 #include "generate_synthetic_ply_fixtures.h"
 

--- a/modules/gaussian_splatting/tests/test_renderer_pipeline.h
+++ b/modules/gaussian_splatting/tests/test_renderer_pipeline.h
@@ -963,6 +963,87 @@ TEST_CASE("[GaussianSplatting][RequiresGPU] Instance buffer upload uses the publ
     renderer.unref();
 }
 
+TEST_CASE("[GaussianSplatting][RequiresGPU] Instance buffer upload keeps low-32-bit-colliding submission ids on distinct dense slots") {
+    RenderingServer *rs = RenderingServer::get_singleton();
+    if (rs == nullptr) {
+        MESSAGE("Skipping test - Rendering server unavailable");
+        return;
+    }
+
+    ScopedGaussianManagerPipeline manager_scope;
+    GaussianSplatManager *manager = manager_scope.get();
+    if (manager == nullptr) {
+        MESSAGE("Skipping test - GaussianSplatManager unavailable");
+        return;
+    }
+
+    ScopedRenderingDeviceLease device_lease;
+    RenderingDevice *primary_rd = device_lease.acquire(rs, manager);
+    if (primary_rd == nullptr) {
+        MESSAGE("Skipping test - Rendering device unavailable");
+        return;
+    }
+
+    Ref<GaussianSplatRenderer> renderer;
+    renderer.instantiate(primary_rd);
+    CHECK(renderer.is_valid());
+    if (!renderer.is_valid()) {
+        return;
+    }
+    renderer->initialize();
+
+    // Two distinct 64-bit submission ids that collide in the low 32 bits. The GPU
+    // ids[0] field is only 32 bits, so both instances carry the SAME truncated tag;
+    // the collision-free resolution must come from the parallel 64-bit submission
+    // id array threaded into update_instance_buffer().
+    const uint64_t submission_a = 0x0000'0000'1234'5678ULL;
+    const uint64_t submission_b = 0xABCD'0000'1234'5678ULL;
+    REQUIRE(static_cast<uint32_t>(submission_a) == static_cast<uint32_t>(submission_b));
+
+    GaussianRenderPipeline::PublishedInstanceAssetRemap remap;
+    remap.asset_to_dense_id.insert(0ULL, 0u);
+    remap.asset_to_dense_id.insert(submission_a, 11u);
+    remap.asset_to_dense_id.insert(submission_b, 22u);
+    remap.generation = 5u;
+    remap.valid = true;
+    renderer->publish_instance_pipeline_contract(
+            GaussianRenderPipeline::InstancePipelineBuffers(),
+            remap,
+            GaussianRenderPipeline::InstanceBackendPolicy::RESIDENT,
+            remap.generation,
+            "atlas_emulation");
+
+    auto make_instance = [](uint32_t p_truncated_tag) {
+        InstanceDataGPU instance = {};
+        instance.rotation[3] = 1.0f;
+        instance.inv_rotation[3] = 1.0f;
+        instance.translation_scale[3] = 1.0f;
+        instance.params[0] = 1.0f;
+        instance.params[1] = 1.0f;
+        instance.params[2] = 1.0f;
+        instance.wind_params[3] = 1.0f;
+        instance.ids[0] = p_truncated_tag; // intentionally collides for both rows
+        return instance;
+    };
+
+    LocalVector<InstanceDataGPU> instances;
+    instances.push_back(make_instance(static_cast<uint32_t>(submission_a)));
+    instances.push_back(make_instance(static_cast<uint32_t>(submission_b)));
+
+    LocalVector<uint64_t> submission_ids;
+    submission_ids.push_back(submission_a);
+    submission_ids.push_back(submission_b);
+
+    CHECK(renderer->update_instance_buffer(instances, remap, &submission_ids));
+    REQUIRE(instances.size() == 2);
+    // Each instance must resolve to its OWN dense slot despite identical ids[0] tags.
+    CHECK(instances[0].ids[0] == 11u);
+    CHECK(instances[1].ids[0] == 22u);
+    CHECK(instances[0].ids[0] != instances[1].ids[0]);
+
+    renderer.unref();
+}
+
 TEST_CASE("[GaussianSplatting] Clearing the published instance contract also clears the renderer-side remap") {
     Ref<GaussianSplatRenderer> renderer;
     renderer.instantiate();

--- a/modules/gaussian_splatting/tests/test_scene_director_asset_id_collision.h
+++ b/modules/gaussian_splatting/tests/test_scene_director_asset_id_collision.h
@@ -15,6 +15,7 @@
 #include "../core/gaussian_data.h"
 #include "../core/gaussian_splat_asset.h"
 #include "../core/gaussian_splat_scene_director.h"
+#include "../renderer/render_types/render_pipeline_io_types.h"
 #include "scene/3d/node_3d.h"
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
@@ -149,6 +150,53 @@ TEST_CASE("[GaussianSplatting][SceneDirector][SceneTree] distinct assets retain 
 	if (owns_director) {
 		memdelete(director);
 	}
+}
+
+// Renderer-boundary invariant (headless): the published asset->dense remap must be
+// keyed on the FULL 64-bit submission identity. Two submission ids that collide in
+// the low 32 bits must resolve to DISTINCT dense atlas slots. This mirrors what
+// GaussianSplatRenderer::update_instance_buffer() does when it looks up each
+// instance's parallel 64-bit submission id (NOT the truncated 32-bit ids[0] GPU tag).
+// The previous "keep the 32-bit GPU tag" remap would alias both ids to one slot, so
+// both instances would render as the SAME asset.
+TEST_CASE("[GaussianSplatting][SceneDirector] published remap keeps low-32-bit-colliding submission ids on distinct dense slots") {
+	using GaussianRenderPipeline::PublishedInstanceAssetRemap;
+
+	// Two distinct 64-bit submission ids sharing the low 32 bits (the regression's
+	// exact precondition).
+	const uint64_t submission_a = 0x0000'0000'1234'5678ULL;
+	const uint64_t submission_b = 0xABCD'0000'1234'5678ULL;
+	REQUIRE(submission_a != submission_b);
+	REQUIRE(static_cast<uint32_t>(submission_a) == static_cast<uint32_t>(submission_b)); // aliasing precondition
+
+	// Build the remap the way the resident/streaming publishers do: 64-bit submission
+	// key -> sequential, collision-free 32-bit dense slot.
+	PublishedInstanceAssetRemap remap;
+	remap.asset_to_dense_id.insert(0ULL, 0u); // primary
+	remap.asset_to_dense_id.insert(submission_a, 1u);
+	remap.asset_to_dense_id.insert(submission_b, 2u);
+
+	// Both colliding ids must survive as independent keys.
+	CHECK_EQ(remap.asset_to_dense_id.size(), 3u);
+
+	const uint32_t *dense_a = remap.asset_to_dense_id.getptr(submission_a);
+	const uint32_t *dense_b = remap.asset_to_dense_id.getptr(submission_b);
+	REQUIRE(dense_a != nullptr);
+	REQUIRE(dense_b != nullptr);
+
+	// The collision-free 64-bit lookup resolves each submission id to its OWN dense slot.
+	CHECK(*dense_a == 1u);
+	CHECK(*dense_b == 2u);
+	CHECK(*dense_a != *dense_b);
+
+	// Sanity: a 32-bit-truncating lookup (the old behavior) would collapse both keys.
+	const uint32_t truncated_a = static_cast<uint32_t>(submission_a);
+	const uint32_t truncated_b = static_cast<uint32_t>(submission_b);
+	CHECK_EQ(truncated_a, truncated_b);
+	// The dense slot is what lands in the GPU InstanceDataGPU::ids[0] field, and it is
+	// 32-bit precisely because dense ids are sequential and collision-free.
+	CHECK(*dense_a <= UINT32_MAX);
+	CHECK(*dense_b <= UINT32_MAX);
 }
 
 #endif // TESTS_ENABLED || TOOLS_ENABLED

--- a/modules/gaussian_splatting/tests/test_scene_director_asset_id_collision.h
+++ b/modules/gaussian_splatting/tests/test_scene_director_asset_id_collision.h
@@ -1,0 +1,154 @@
+#pragma once
+
+// Regression test for the SharedWorld::asset_records aliasing bug.
+//
+// register_instance() used to derive the asset_records key with
+// `static_cast<uint32_t>(p_asset->get_instance_id())`, truncating the 64-bit
+// ObjectID to 32 bits. Two assets whose ObjectIDs collide in the low 32 bits
+// would then alias the same AssetRecord — one asset's GaussianData would
+// silently shadow the other's, and releasing one instance would tear down the
+// record still referenced by the other. The fix keys asset_records on the full
+// 64-bit ObjectID.
+
+#include "test_macros.h"
+
+#include "../core/gaussian_data.h"
+#include "../core/gaussian_splat_asset.h"
+#include "../core/gaussian_splat_scene_director.h"
+#include "scene/3d/node_3d.h"
+#include "scene/main/scene_tree.h"
+#include "scene/main/window.h"
+
+#if defined(TESTS_ENABLED) || defined(TOOLS_ENABLED)
+
+namespace {
+
+Ref<GaussianSplatAsset> _make_collision_test_asset(float p_x_offset) {
+	Ref<GaussianSplatAsset> asset;
+	asset.instantiate();
+	asset->set_splat_count(1);
+
+	PackedFloat32Array positions;
+	positions.resize(3);
+	positions.set(0, p_x_offset);
+	positions.set(1, 0.0f);
+	positions.set(2, 0.0f);
+	asset->set_positions(positions);
+
+	PackedFloat32Array scales;
+	scales.resize(3);
+	scales.set(0, 1.0f);
+	scales.set(1, 1.0f);
+	scales.set(2, 1.0f);
+	asset->set_scales(scales);
+
+	PackedFloat32Array rotations;
+	rotations.resize(4);
+	rotations.set(0, 1.0f);
+	rotations.set(1, 0.0f);
+	rotations.set(2, 0.0f);
+	rotations.set(3, 0.0f);
+	asset->set_rotations(rotations);
+
+	PackedFloat32Array sh_dc;
+	sh_dc.resize(3);
+	sh_dc.set(0, 1.0f);
+	sh_dc.set(1, 1.0f);
+	sh_dc.set(2, 1.0f);
+	asset->set_sh_dc_coefficients(sh_dc);
+
+	PackedFloat32Array opacity_logits;
+	opacity_logits.resize(1);
+	opacity_logits.set(0, 10.0f);
+	asset->set_opacity_logits(opacity_logits);
+
+	return asset;
+}
+
+} // namespace
+
+// Pure keying invariant: the asset_records key must be injective over a pair of
+// ObjectIDs that share the low 32 bits. This is the exact condition the old
+// `static_cast<uint32_t>` truncation violated, so it fails on the pre-fix
+// keying expression and passes once the full 64-bit ObjectID is used.
+TEST_CASE("[GaussianSplatting][SceneDirector] asset_records key does not alias ObjectIDs colliding in the low 32 bits") {
+	// Two distinct 64-bit ids that are identical in their low 32 bits.
+	const uint64_t low = 0x0000'0000'1234'5678ULL;
+	const uint64_t high = 0xABCD'0000'1234'5678ULL;
+	REQUIRE(low != high);
+	REQUIRE(static_cast<uint32_t>(low) == static_cast<uint32_t>(high)); // the aliasing precondition
+
+	const uint64_t key_low = GaussianSplatSceneDirector::test_asset_records_key(ObjectID(low));
+	const uint64_t key_high = GaussianSplatSceneDirector::test_asset_records_key(ObjectID(high));
+
+	// The full-width key must keep them apart; a 32-bit truncating key would not.
+	CHECK(key_low != key_high);
+	CHECK(key_low == low);
+	CHECK(key_high == high);
+}
+
+// End-to-end: register two instances backed by two distinct assets in the same
+// world and confirm each asset gets its own record keyed on its full ObjectID.
+// Runs headless (no RenderingDevice required) because asset_records are built
+// before any renderer is attached.
+TEST_CASE("[GaussianSplatting][SceneDirector][SceneTree] distinct assets retain distinct asset_records") {
+	SceneTree *tree = SceneTree::get_singleton();
+	REQUIRE_MESSAGE(tree != nullptr, "SceneTree must exist (provided by [SceneTree] tag)");
+
+	Window *root = tree->get_root();
+	REQUIRE_MESSAGE(root != nullptr, "SceneTree root window must exist");
+
+	Ref<World3D> world = root->get_world_3d();
+	REQUIRE(world.is_valid());
+	const RID scenario = world->get_scenario();
+	REQUIRE(scenario.is_valid());
+
+	GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton();
+	const bool owns_director = (director == nullptr);
+	if (!director) {
+		director = memnew(GaussianSplatSceneDirector);
+	}
+	REQUIRE(director != nullptr);
+
+	const uint32_t baseline_records = director->test_asset_record_count_for_scenario(scenario);
+
+	Node3D *node_a = memnew(Node3D);
+	Node3D *node_b = memnew(Node3D);
+	root->add_child(node_a);
+	root->add_child(node_b);
+	tree->process(0.0);
+
+	Ref<GaussianSplatAsset> asset_a = _make_collision_test_asset(0.0f);
+	Ref<GaussianSplatAsset> asset_b = _make_collision_test_asset(10.0f);
+	REQUIRE(asset_a.is_valid());
+	REQUIRE(asset_b.is_valid());
+	// Two distinct assets => two distinct ObjectIDs => two distinct records.
+	REQUIRE(asset_a->get_instance_id() != asset_b->get_instance_id());
+
+	director->register_instance(node_a->get_instance_id(), asset_a, Transform3D(), 1.0f, 0.0f, 0u);
+	director->register_instance(node_b->get_instance_id(), asset_b, Transform3D(), 1.0f, 0.0f, 0u);
+
+	CHECK_EQ(director->test_asset_record_count_for_scenario(scenario), baseline_records + 2);
+	CHECK(director->test_has_asset_record_for_scenario(scenario, asset_a->get_instance_id()));
+	CHECK(director->test_has_asset_record_for_scenario(scenario, asset_b->get_instance_id()));
+
+	// Releasing one instance must drop only that asset's record; the other must survive.
+	director->unregister_instance(node_a->get_instance_id());
+	CHECK_FALSE(director->test_has_asset_record_for_scenario(scenario, asset_a->get_instance_id()));
+	CHECK(director->test_has_asset_record_for_scenario(scenario, asset_b->get_instance_id()));
+
+	director->unregister_instance(node_b->get_instance_id());
+	CHECK_EQ(director->test_asset_record_count_for_scenario(scenario), baseline_records);
+
+	root->remove_child(node_b);
+	root->remove_child(node_a);
+	memdelete(node_b);
+	memdelete(node_a);
+	tree->process(0.0);
+
+	if (owns_director) {
+		memdelete(director);
+	}
+}
+
+#endif // TESTS_ENABLED || TOOLS_ENABLED


### PR DESCRIPTION
**Verified bug:** `gaussian_splat_scene_director.cpp` truncated `get_instance_id()` to `uint32_t` and keyed `SharedWorld::asset_records` on uint32 → two ObjectIDs sharing the low 32 bits aliased one record. Threads the full 64-bit ObjectID through the identity (map key, the 3 `_*_asset_record` sigs, instance field, dedupe set); the GPU/dense-id 32-bit tags stay explicit by design. + collision regression test (low-32-collision must not alias) + a SceneTree retain test. Guards green. **Risk low, no visual gate.** (audit-fix-wave)