### PR TITLE
gaussian_splatting: remove the no-op _check_dual_state_sync guardrail

### DIFF
--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
@@ -2015,19 +2015,13 @@ RID GaussianSplatRenderer::_get_viewport_color_target(RenderSceneBuffersRD *p_re
     return RID();
 }
 
-void GaussianSplatRenderer::_check_dual_state_sync(const char *p_context) const {
-#ifdef DEV_ENABLED
-    if (!debug_state_orchestrator || !get_debug_config().enable_state_guardrails) {
-        return;
-    }
-    if (!config_orchestrator || !data_orchestrator || !instancing_orchestrator || !device_orchestrator || !resource_orchestrator
-            || !sorting_orchestrator || !quality_orchestrator) {
-        return;
-    }
-
-    (void)p_context;
-#endif
-}
+// _check_dual_state_sync was removed: it was advertised as the canonical-vs-derived
+// state guardrail but only null-checked the orchestrators and validated nothing
+// (a (void)p_context no-op). Keeping it gave false confidence in a codebase with a
+// desync-bug history, so the no-op and its call site were deleted outright rather
+// than silently retained. If a real canonical-vs-derived comparison is implemented
+// later, gate it on get_debug_config().enable_state_guardrails (still exposed via
+// set_debug_state_guardrails_enabled) and reintroduce an explicit check here.
 
 void GaussianSplatRenderer::_set_manual_viewport_format(RD::DataFormat p_format, const char *p_context) {
     (void)p_context;
@@ -2183,7 +2177,7 @@ void GaussianSplatRenderer::render_scene_instance(RenderDataRD *p_render_data) {
     }
 
     get_resource_state().deletion_queue.process_frame();
-    _check_dual_state_sync("render_scene_instance");
+    // Dual-state-sync guardrail removed (was a no-op); see _check_dual_state_sync deletion note.
 
     if (get_subsystem_state().output_compositor.is_valid()) {
         auto &output_cache = get_subsystem_state().output_compositor->get_cache_state();

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.h
@@ -186,7 +186,8 @@ private:
     // Phase 15: _push_texture_trace removed (dead code)
     void _push_cross_device_operation(const String &p_context, RenderingDevice *p_source, RenderingDevice *p_target);
     Dictionary _build_device_capability_report() const;
-    void _check_dual_state_sync(const char *p_context) const;
+    // _check_dual_state_sync removed: it was a documented canonical-vs-derived state
+    // guardrail but never validated anything (no-op). See the .cpp deletion note.
 
 public:
     // State types (public for orchestrator access)

--- a/tests/ci/run_module_tests.py
+++ b/tests/ci/run_module_tests.py
@@ -220,6 +220,20 @@ STATIC_FORMAT_GUARDS: tuple[tuple[str, Path, tuple[str, ...]], ...] = (
             r"bool can_direct_copy = .*?!format_mismatch.*?;",
         ),
     ),
+    # The _check_dual_state_sync canonical-vs-derived guardrail was a documented
+    # no-op (it null-checked the orchestrators then validated nothing) and was
+    # deleted outright rather than silently retained. This guard locks in the
+    # honest decision: the deletion note must stay present, so the misleading
+    # no-op cannot be reintroduced without a reviewer re-reading why it is gone.
+    # If a real check is implemented, replace the note with the real method and
+    # update this guard to assert the real validation instead.
+    (
+        "dual_state_sync_guardrail_removed_not_silently_kept",
+        MODULE_SOURCE_DIR / "renderer" / "gaussian_splat_renderer.cpp",
+        (
+            r"_check_dual_state_sync was removed:.*?validated nothing",
+        ),
+    ),
 )
 
 _approved_tracked_synthetic_ply_fixtures_cache: set[str] | None = None


### PR DESCRIPTION
**Verified:** `_check_dual_state_sync` (gaussian_splat_renderer.cpp) was DEV-only, null-checked the orchestrators then `(void)p_context;` — validated nothing while named/documented as the canonical-vs-derived guardrail and called every frame. **False confidence.** Deletes the no-op + its call site + decl, with an explicit removal note (a real per-frame canonical/derived comparison across 7 orchestrators is large/uncertain — out of scope). Guards green. **Risk low.** (audit-fix-wave)