### PR TITLE
gaussian_splatting: count the persistent buffer in reported VRAM

### DIFF
--- a/modules/gaussian_splatting/core/gaussian_streaming.cpp
+++ b/modules/gaussian_splatting/core/gaussian_streaming.cpp
@@ -4493,10 +4493,16 @@ void GaussianStreamingSystem::end_frame() {
     // reported figure is not under-counted by the unfilled buffer remainder.
     const uint64_t payload_vram_bytes = budget.vram_usage;
     const uint64_t overhead_vram_bytes = _get_auxiliary_vram_overhead_bytes();
+    // Mirror the live-RID gate in _get_total_vram_usage_bytes(): a failed
+    // storage_buffer_create() leaves persistent_buffer_size nonzero with an invalid
+    // RID, so report the allocation only when it actually exists. Otherwise vram_mb
+    // (gated) and vram_persistent_buffer_mb (ungated) would disagree on the
+    // allocation-failure path. (Codex #411)
+    const uint64_t allocated_persistent_bytes = persistent_buffer.is_valid() ? uint64_t(persistent_buffer_size) : 0;
     analytics_snapshot["vram_mb"] = double(_get_total_vram_usage_bytes()) / (1024.0 * 1024.0);
     analytics_snapshot["vram_payload_mb"] = double(payload_vram_bytes) / (1024.0 * 1024.0);
     analytics_snapshot["vram_overhead_mb"] = double(overhead_vram_bytes) / (1024.0 * 1024.0);
-    analytics_snapshot["vram_persistent_buffer_mb"] = double(persistent_buffer_size) / (1024.0 * 1024.0);
+    analytics_snapshot["vram_persistent_buffer_mb"] = double(allocated_persistent_bytes) / (1024.0 * 1024.0);
     analytics_snapshot["loaded_chunks"] = get_loaded_chunks();
     analytics_snapshot["atlas_published_chunks"] = global_atlas_registry.get_atlas_published_chunks();
     analytics_snapshot["visible_splats"] = get_visible_count();

--- a/modules/gaussian_splatting/core/gaussian_streaming.cpp
+++ b/modules/gaussian_splatting/core/gaussian_streaming.cpp
@@ -3342,14 +3342,18 @@ uint64_t GaussianStreamingSystem::_get_total_vram_usage_bytes() const {
 }
 
 uint64_t GaussianStreamingSystem::_get_evictable_vram_usage_bytes() const {
-    // Eviction/regulation basis. Only the loaded chunk payload (budget.vram_usage) is
-    // reclaimable by evicting chunks; the persistent buffer ALLOCATION (the resident_buffer
-    // term in _get_total_vram_usage_bytes) is NOT freed by eviction. Gating eviction on the
-    // full allocation would, whenever the preallocated buffer is sized above the budget
-    // (e.g. a small vram_budget_mb with a large initial chunk capacity), keep the loop over
-    // budget forever and evict every loaded/visible chunk each frame without freeing any
-    // VRAM. Reporting (get_vram_usage / analytics) uses the full allocation; eviction uses this.
-    return budget.vram_usage + _get_auxiliary_vram_overhead_bytes();
+    // Eviction/regulation/admission decision basis: ONLY the bytes that evicting chunks can
+    // actually reclaim. Evicting a chunk frees only its slot in the persistent buffer, i.e. it
+    // reduces budget.vram_usage. It does NOT free either non-reclaimable fixed cost:
+    //   - the persistent-buffer ALLOCATION (the resident_buffer term in _get_total_vram_usage_bytes), nor
+    //   - the auxiliary atlas/quantization overhead (_get_auxiliary_vram_overhead_bytes).
+    // Including EITHER here would, whenever that fixed cost is large relative to the budget,
+    // keep the decision basis above threshold even after every chunk is evicted — recreating
+    // the infinite-pressure / evict-every-visible-chunk loop with no VRAM actually freed. The
+    // only quantity that always falls to zero as chunks are evicted is the payload itself, so
+    // that is the reclaimable basis. Reporting (get_vram_usage / analytics / overlay) and the
+    // budget warning use the full allocation-inclusive total; decisions use this. (Codex #411)
+    return budget.vram_usage;
 }
 
 uint32_t GaussianStreamingSystem::_get_reserved_chunk_count() const {

--- a/modules/gaussian_splatting/core/gaussian_streaming.cpp
+++ b/modules/gaussian_splatting/core/gaussian_streaming.cpp
@@ -3819,17 +3819,15 @@ void GaussianStreamingSystem::_update_vram_regulator() {
         return;
     }
 
-    // Regulator decisions (eviction trigger, admission gate via can_load_more_chunks,
-    // max-chunk regulation) must run on the *reclaimable* usage. Evicting chunks frees
-    // only budget.vram_usage, never the persistent-buffer allocation. Feeding the
-    // allocation-inclusive total here would pin usage_percent over threshold whenever
-    // the preallocated buffer alone exceeds the budget, so the regulator would keep
-    // denying admissions and ratchet the max chunk count down while no VRAM can actually
-    // be freed. The full allocation is still reported via get_vram_usage() / analytics;
-    // only the decision basis uses the evictable figure. (Codex #411)
-    budget.vram_regulator->update(_get_evictable_vram_usage_bytes(), budget.loaded_chunks_count,
-            budget.chunks_loaded_this_frame, eviction_controller.get_chunks_evicted_this_frame(),
-            total_frame_count);
+    // Feed the regulator BOTH bases: the allocation-inclusive total for reporting (debug
+    // overlay + budget warning, matching get_vram_usage()) and the reclaimable/evictable
+    // figure for decisions (admission gate + auto-regulation). Evicting/regulating frees only
+    // budget.vram_usage, never the persistent-buffer allocation, so decisions must not gate on
+    // the non-reclaimable allocation (it would deny loads / ratchet the cap down while no VRAM
+    // can be freed); but the overlay must still show the true footprint. (Codex #411)
+    budget.vram_regulator->update(_get_total_vram_usage_bytes(), _get_evictable_vram_usage_bytes(),
+            budget.loaded_chunks_count, budget.chunks_loaded_this_frame,
+            eviction_controller.get_chunks_evicted_this_frame(), total_frame_count);
 }
 
 void GaussianStreamingSystem::_log_streaming_frame_stats(uint32_t effective_max) {

--- a/modules/gaussian_splatting/core/gaussian_streaming.cpp
+++ b/modules/gaussian_splatting/core/gaussian_streaming.cpp
@@ -3301,7 +3301,17 @@ uint64_t GaussianStreamingSystem::_get_auxiliary_vram_overhead_bytes() const {
 }
 
 uint64_t GaussianStreamingSystem::_get_total_vram_usage_bytes() const {
-    return budget.vram_usage + _get_auxiliary_vram_overhead_bytes();
+    // budget.vram_usage tracks the *loaded chunk payload* that currently lives
+    // inside the persistent storage buffer. The persistent buffer itself is the
+    // single largest streaming VRAM allocation (sized for the resident chunk set
+    // plus growth headroom), and chunk payloads are uploaded into it — so the
+    // reserved VRAM is the whole buffer allocation, not just the bytes uploaded
+    // so far. Reporting only the payload under-counts the regulator's true
+    // footprint by the unfilled remainder of the buffer. Count the full
+    // allocation (MAX guards against any transient payload > size accounting
+    // skew, and degrades to the payload when the buffer is not yet allocated).
+    const uint64_t resident_buffer_bytes = MAX(budget.vram_usage, uint64_t(persistent_buffer_size));
+    return resident_buffer_bytes + _get_auxiliary_vram_overhead_bytes();
 }
 
 uint32_t GaussianStreamingSystem::_get_reserved_chunk_count() const {
@@ -4453,12 +4463,15 @@ void GaussianStreamingSystem::end_frame() {
     }
     analytics_snapshot = memory_stream_proxy.is_valid() ? memory_stream_proxy->get_task_debug_state() : Dictionary();
 
-    // Add VRAM usage stats to analytics
+    // Add VRAM usage stats to analytics. vram_mb mirrors the regulator-facing
+    // total (full persistent buffer allocation + auxiliary overhead), so the
+    // reported figure is not under-counted by the unfilled buffer remainder.
     const uint64_t payload_vram_bytes = budget.vram_usage;
     const uint64_t overhead_vram_bytes = _get_auxiliary_vram_overhead_bytes();
-    analytics_snapshot["vram_mb"] = double(payload_vram_bytes + overhead_vram_bytes) / (1024.0 * 1024.0);
+    analytics_snapshot["vram_mb"] = double(_get_total_vram_usage_bytes()) / (1024.0 * 1024.0);
     analytics_snapshot["vram_payload_mb"] = double(payload_vram_bytes) / (1024.0 * 1024.0);
     analytics_snapshot["vram_overhead_mb"] = double(overhead_vram_bytes) / (1024.0 * 1024.0);
+    analytics_snapshot["vram_persistent_buffer_mb"] = double(persistent_buffer_size) / (1024.0 * 1024.0);
     analytics_snapshot["loaded_chunks"] = get_loaded_chunks();
     analytics_snapshot["atlas_published_chunks"] = global_atlas_registry.get_atlas_published_chunks();
     analytics_snapshot["visible_splats"] = get_visible_count();

--- a/modules/gaussian_splatting/core/gaussian_streaming.cpp
+++ b/modules/gaussian_splatting/core/gaussian_streaming.cpp
@@ -1082,7 +1082,7 @@ bool GaussianStreamingSystem::_try_grow_persistent_buffer_for_atlas_pressure(uin
         return false;
     }
 
-    const uint64_t target64 = MIN<uint64_t>(uint64_t(streaming_current_capacity) * 2u,
+    uint64_t target64 = MIN<uint64_t>(uint64_t(streaming_current_capacity) * 2u,
             uint64_t(growth_ceiling));
 
     // Allocation-inclusive growth gate. The regulator is fed the *evictable* usage so
@@ -1090,21 +1090,30 @@ bool GaussianStreamingSystem::_try_grow_persistent_buffer_for_atlas_pressure(uin
     // (see _update_vram_regulator). Growth is different: it ENLARGES that allocation, so
     // p_vram_regulator_allows_load (derived from can_load_more_chunks on reclaimable usage)
     // would stay under threshold and let the buffer grow past budget while get_vram_usage()
-    // is already over. Gate growth on the projected allocation-inclusive total instead, so
-    // we never grow the persistent buffer beyond the configured VRAM budget. (Codex #411)
+    // is already over. Bound the growth target by the budget instead, so we never grow the
+    // persistent buffer beyond the configured VRAM budget. CLAMP the target down to the
+    // largest in-budget slot count rather than refusing growth outright: with room for some
+    // (but not the doubled) slots we should still grow as far as the budget allows, or a
+    // low-budget config would plateau the atlas below its usable capacity. (Codex #411)
     if (p_enforce_vram_regulator_gate && budget.vram_regulator.is_valid()) {
         const uint64_t budget_bytes = budget.vram_regulator->get_debug_stats().budget_bytes;
         if (budget_bytes > 0) {
             const uint64_t chunk_bytes = uint64_t(CHUNK_SIZE) * sizeof(PackedGaussian);
-            const uint64_t projected_persistent_bytes = target64 * chunk_bytes;
-            const uint64_t projected_total_bytes =
-                    MAX(budget.vram_usage, projected_persistent_bytes) + _get_auxiliary_vram_overhead_bytes();
-            if (projected_total_bytes > budget_bytes) {
-                return false;
+            const uint64_t aux_bytes = _get_auxiliary_vram_overhead_bytes();
+            // Largest persistent-buffer slot count whose allocation-inclusive total
+            // (slots*chunk_bytes + aux; the grown buffer dominates the payload) fits the budget.
+            const uint64_t budget_for_persistent = budget_bytes > aux_bytes ? (budget_bytes - aux_bytes) : 0;
+            const uint64_t budget_max_slots = chunk_bytes > 0 ? budget_for_persistent / chunk_bytes : 0;
+            if (budget_max_slots <= uint64_t(streaming_current_capacity)) {
+                return false; // no in-budget headroom to grow into
             }
+            target64 = MIN(target64, budget_max_slots);
         }
     }
 
+    if (target64 <= uint64_t(streaming_current_capacity)) {
+        return false;
+    }
     return _grow_persistent_buffer(static_cast<uint32_t>(target64));
 }
 

--- a/modules/gaussian_splatting/core/gaussian_streaming.cpp
+++ b/modules/gaussian_splatting/core/gaussian_streaming.cpp
@@ -1084,6 +1084,27 @@ bool GaussianStreamingSystem::_try_grow_persistent_buffer_for_atlas_pressure(uin
 
     const uint64_t target64 = MIN<uint64_t>(uint64_t(streaming_current_capacity) * 2u,
             uint64_t(growth_ceiling));
+
+    // Allocation-inclusive growth gate. The regulator is fed the *evictable* usage so
+    // eviction/admission-into-existing-slots ignore the non-reclaimable persistent buffer
+    // (see _update_vram_regulator). Growth is different: it ENLARGES that allocation, so
+    // p_vram_regulator_allows_load (derived from can_load_more_chunks on reclaimable usage)
+    // would stay under threshold and let the buffer grow past budget while get_vram_usage()
+    // is already over. Gate growth on the projected allocation-inclusive total instead, so
+    // we never grow the persistent buffer beyond the configured VRAM budget. (Codex #411)
+    if (p_enforce_vram_regulator_gate && budget.vram_regulator.is_valid()) {
+        const uint64_t budget_bytes = budget.vram_regulator->get_debug_stats().budget_bytes;
+        if (budget_bytes > 0) {
+            const uint64_t chunk_bytes = uint64_t(CHUNK_SIZE) * sizeof(PackedGaussian);
+            const uint64_t projected_persistent_bytes = target64 * chunk_bytes;
+            const uint64_t projected_total_bytes =
+                    MAX(budget.vram_usage, projected_persistent_bytes) + _get_auxiliary_vram_overhead_bytes();
+            if (projected_total_bytes > budget_bytes) {
+                return false;
+            }
+        }
+    }
+
     return _grow_persistent_buffer(static_cast<uint32_t>(target64));
 }
 

--- a/modules/gaussian_splatting/core/gaussian_streaming.cpp
+++ b/modules/gaussian_splatting/core/gaussian_streaming.cpp
@@ -3310,7 +3310,13 @@ uint64_t GaussianStreamingSystem::_get_total_vram_usage_bytes() const {
     // footprint by the unfilled remainder of the buffer. Count the full
     // allocation (MAX guards against any transient payload > size accounting
     // skew, and degrades to the payload when the buffer is not yet allocated).
-    const uint64_t resident_buffer_bytes = MAX(budget.vram_usage, uint64_t(persistent_buffer_size));
+    // Only count the allocation when the RID is actually live: initialize() and
+    // initialize_empty() set persistent_buffer_size *before* the storage_buffer_create()
+    // that may fail and leave an invalid RID with a stale nonzero size. Without this
+    // gate get_vram_usage()/diagnostics would report a phantom allocation after a failed
+    // init instead of degrading to the payload as documented. (Codex #411)
+    const uint64_t allocated_persistent_bytes = persistent_buffer.is_valid() ? uint64_t(persistent_buffer_size) : 0;
+    const uint64_t resident_buffer_bytes = MAX(budget.vram_usage, allocated_persistent_bytes);
     return resident_buffer_bytes + _get_auxiliary_vram_overhead_bytes();
 }
 
@@ -3792,7 +3798,15 @@ void GaussianStreamingSystem::_update_vram_regulator() {
         return;
     }
 
-    budget.vram_regulator->update(_get_total_vram_usage_bytes(), budget.loaded_chunks_count,
+    // Regulator decisions (eviction trigger, admission gate via can_load_more_chunks,
+    // max-chunk regulation) must run on the *reclaimable* usage. Evicting chunks frees
+    // only budget.vram_usage, never the persistent-buffer allocation. Feeding the
+    // allocation-inclusive total here would pin usage_percent over threshold whenever
+    // the preallocated buffer alone exceeds the budget, so the regulator would keep
+    // denying admissions and ratchet the max chunk count down while no VRAM can actually
+    // be freed. The full allocation is still reported via get_vram_usage() / analytics;
+    // only the decision basis uses the evictable figure. (Codex #411)
+    budget.vram_regulator->update(_get_evictable_vram_usage_bytes(), budget.loaded_chunks_count,
             budget.chunks_loaded_this_frame, eviction_controller.get_chunks_evicted_this_frame(),
             total_frame_count);
 }

--- a/modules/gaussian_splatting/core/gaussian_streaming.cpp
+++ b/modules/gaussian_splatting/core/gaussian_streaming.cpp
@@ -3314,6 +3314,17 @@ uint64_t GaussianStreamingSystem::_get_total_vram_usage_bytes() const {
     return resident_buffer_bytes + _get_auxiliary_vram_overhead_bytes();
 }
 
+uint64_t GaussianStreamingSystem::_get_evictable_vram_usage_bytes() const {
+    // Eviction/regulation basis. Only the loaded chunk payload (budget.vram_usage) is
+    // reclaimable by evicting chunks; the persistent buffer ALLOCATION (the resident_buffer
+    // term in _get_total_vram_usage_bytes) is NOT freed by eviction. Gating eviction on the
+    // full allocation would, whenever the preallocated buffer is sized above the budget
+    // (e.g. a small vram_budget_mb with a large initial chunk capacity), keep the loop over
+    // budget forever and evict every loaded/visible chunk each frame without freeing any
+    // VRAM. Reporting (get_vram_usage / analytics) uses the full allocation; eviction uses this.
+    return budget.vram_usage + _get_auxiliary_vram_overhead_bytes();
+}
+
 uint32_t GaussianStreamingSystem::_get_reserved_chunk_count() const {
     return budget.loaded_chunks_count + budget.pending_upload_slots;
 }
@@ -3379,21 +3390,21 @@ void GaussianStreamingSystem::_evict_for_vram_budget(uint32_t &evictions_left, b
     evictions_left = max_evictions_per_frame == 0 ? UINT32_MAX : max_evictions_per_frame;
     eviction_blocked = false;
     bool force_visible_eviction = false;
-    const uint64_t total_vram_usage = _get_total_vram_usage_bytes();
+    const uint64_t evictable_vram_usage = _get_evictable_vram_usage_bytes();
 
     if (budget.vram_regulator.is_valid()) {
         const VRAMBudgetConfig &budget_config = budget.vram_regulator->get_config();
         const uint64_t budget_bytes = uint64_t(budget_config.budget_mb) * BYTES_PER_MB;
-        force_visible_eviction = budget_bytes > 0 && total_vram_usage > budget_bytes;
+        force_visible_eviction = budget_bytes > 0 && evictable_vram_usage > budget_bytes;
     }
 
     if (!budget.vram_regulator.is_valid() ||
-            !budget.vram_regulator->should_trigger_eviction(total_vram_usage)) {
+            !budget.vram_regulator->should_trigger_eviction(evictable_vram_usage)) {
         return;
     }
 
     while (budget.loaded_chunks_count > 0 &&
-            budget.vram_regulator->should_trigger_eviction(_get_total_vram_usage_bytes()) &&
+            budget.vram_regulator->should_trigger_eviction(_get_evictable_vram_usage_bytes()) &&
             evictions_left > 0) {
         // Non-primary-first eviction keeps primary visible residency stable
         // under budget pressure. _evict_non_primary_lru() now returns

--- a/modules/gaussian_splatting/core/gaussian_streaming.h
+++ b/modules/gaussian_splatting/core/gaussian_streaming.h
@@ -360,6 +360,11 @@ public:
         return _begin_chunk_upload(p_asset_id, p_chunk_idx, p_chunk, p_buffer_slot);
     }
     uint32_t _test_get_reserved_chunk_count() const { return _get_reserved_chunk_count(); }
+    // Persistent storage-buffer allocation size in bytes. Test-only window onto the
+    // single largest streaming VRAM allocation so the VRAM-accounting tests can
+    // assert get_vram_usage() folds it in, without the `#define private public`
+    // hack that breaks the GCC ODR build.
+    uint32_t _test_get_persistent_buffer_size() const { return persistent_buffer_size; }
     uint32_t _test_get_retired_upload_slots_this_frame() const { return budget.retired_upload_slots_this_frame; }
     uint64_t _test_get_retired_upload_bytes_this_frame() const { return budget.retired_upload_bytes_this_frame; }
     uint64_t _test_get_failed_upload_retirements() const { return budget.failed_upload_retirements; }

--- a/modules/gaussian_splatting/core/gaussian_streaming.h
+++ b/modules/gaussian_splatting/core/gaussian_streaming.h
@@ -441,6 +441,7 @@ private:
     uint32_t _compute_runtime_chunk_capacity_limit() const;
     uint64_t _get_auxiliary_vram_overhead_bytes() const;
     uint64_t _get_total_vram_usage_bytes() const;
+    uint64_t _get_evictable_vram_usage_bytes() const;
     uint32_t _get_reserved_chunk_count() const;
     uint64_t _get_pending_upload_bytes_for_diagnostics() const;
     void _load_zero_visible_recovery_config_from_project_settings();

--- a/modules/gaussian_splatting/core/streaming_vram_regulator.cpp
+++ b/modules/gaussian_splatting/core/streaming_vram_regulator.cpp
@@ -387,24 +387,31 @@ void VRAMBudgetRegulator::_query_device_memory() {
     }
 }
 
-void VRAMBudgetRegulator::update(uint64_t current_vram_usage, uint32_t loaded_chunks,
+void VRAMBudgetRegulator::update(uint64_t p_reported_usage, uint64_t p_decision_usage, uint32_t loaded_chunks,
                                   uint32_t loads_this_frame, uint32_t evictions_this_frame,
                                   uint64_t current_frame) {
-    // Update stats
-    stats.current_usage_bytes = current_vram_usage;
+    // p_reported_usage is the allocation-inclusive footprint (persistent buffer + payload +
+    // auxiliary overhead) — it mirrors get_vram_usage()/end-frame vram_mb and is what the debug
+    // overlay and the budget warning must show. p_decision_usage is the reclaimable/evictable
+    // subset that admission and auto-regulation act on; gating those on the non-reclaimable
+    // allocation would deny loads or ratchet the chunk cap down while no VRAM can be freed.
+    // Keep the two separate so reporting is never under-counted by the decision basis. (Codex #411)
+    stats.current_usage_bytes = p_reported_usage;
     stats.loaded_chunks = loaded_chunks;
     stats.loaded_this_frame = loads_this_frame;
     stats.evicted_this_frame = evictions_this_frame;
     stats.current_max_chunks = current_max_chunks;
 
-    // Calculate usage percentage
+    decision_usage_bytes = p_decision_usage;
     if (stats.budget_bytes > 0) {
-        stats.usage_percent = (float(current_vram_usage) / float(stats.budget_bytes)) * 100.0f;
+        stats.usage_percent = (float(p_reported_usage) / float(stats.budget_bytes)) * 100.0f;
+        decision_usage_percent = (float(p_decision_usage) / float(stats.budget_bytes)) * 100.0f;
     } else {
         stats.usage_percent = 0.0f;
+        decision_usage_percent = 0.0f;
     }
 
-    // Check if we need to warn
+    // Warn on the true footprint approaching budget (reported, not the reclaimable subset).
     bool was_warning = stats.budget_warning_active;
     stats.budget_warning_active = (stats.usage_percent >= config.warning_threshold_percent);
 
@@ -412,15 +419,16 @@ void VRAMBudgetRegulator::update(uint64_t current_vram_usage, uint32_t loaded_ch
     if (stats.budget_warning_active && !was_warning) {
         WARN_PRINT(vformat("[VRAM Budget] Approaching VRAM limit: %.1f%% of %d MB budget used (%d MB)",
                 stats.usage_percent, config.budget_mb,
-                current_vram_usage / (1024 * 1024)));
+                p_reported_usage / (1024 * 1024)));
     }
 
     // Record activity for thrashing detection
     _record_activity(loads_this_frame, evictions_this_frame);
 
-    // Perform regulation if enabled
+    // Auto-regulation chases the budget by raising/lowering the chunk cap; reducing the cap only
+    // frees payload, so it must act on the reclaimable decision usage, not the full allocation.
     if (config.auto_regulate_enabled) {
-        _update_regulation(current_vram_usage, current_frame);
+        _update_regulation(p_decision_usage, current_frame);
     }
 }
 
@@ -429,6 +437,13 @@ void VRAMBudgetRegulator::_update_regulation(uint64_t current_usage, uint64_t cu
     if (current_frame - last_adjustment_frame < MIN_FRAMES_BETWEEN_ADJUSTMENTS) {
         return;
     }
+
+    // Regulate against the reclaimable basis the caller passes (decision usage), NOT
+    // stats.usage_percent which now reflects the full allocation-inclusive footprint:
+    // lowering the chunk cap frees only payload, never the persistent buffer. (Codex #411)
+    const float decision_percent = stats.budget_bytes > 0
+            ? (float(current_usage) / float(stats.budget_bytes)) * 100.0f
+            : 0.0f;
 
     // Check for thrashing - if detected, reduce chunks more aggressively
     if (_detect_thrashing()) {
@@ -453,7 +468,7 @@ void VRAMBudgetRegulator::_update_regulation(uint64_t current_usage, uint64_t cu
     uint32_t step_size = MAX(1u, uint32_t(float(config.max_chunks) * config.regulation_step_percent / 100.0f));
 
     // If over budget, reduce chunks
-    if (stats.usage_percent > float(config.warning_threshold_percent)) {
+    if (decision_percent > float(config.warning_threshold_percent)) {
         uint32_t new_max = MAX(config.min_chunks, current_max_chunks - step_size);
         if (new_max != current_max_chunks) {
             current_max_chunks = new_max;
@@ -461,11 +476,11 @@ void VRAMBudgetRegulator::_update_regulation(uint64_t current_usage, uint64_t cu
             stats.regulation_adjustments++;
 
             GS_LOG_STREAMING_DEBUG(vformat("[VRAM Regulator] Reducing max chunks: %d -> %d (usage: %.1f%%)",
-                    current_max_chunks + step_size, current_max_chunks, stats.usage_percent));
+                    current_max_chunks + step_size, current_max_chunks, decision_percent));
         }
     }
     // If well under budget and not at max, increase chunks
-    else if (stats.usage_percent < float(config.warning_threshold_percent) * 0.7f) {
+    else if (decision_percent < float(config.warning_threshold_percent) * 0.7f) {
         if (current_max_chunks < config.max_chunks) {
             uint32_t new_max = MIN(config.max_chunks, current_max_chunks + step_size);
             if (new_max != current_max_chunks) {
@@ -479,7 +494,7 @@ void VRAMBudgetRegulator::_update_regulation(uint64_t current_usage, uint64_t cu
                 }
 
                 GS_LOG_STREAMING_DEBUG(vformat("[VRAM Regulator] Increasing max chunks: %d -> %d (usage: %.1f%%)",
-                        current_max_chunks - step_size, current_max_chunks, stats.usage_percent));
+                        current_max_chunks - step_size, current_max_chunks, decision_percent));
             }
         }
     }
@@ -514,8 +529,11 @@ bool VRAMBudgetRegulator::can_load_more_chunks(uint32_t current_loaded) const {
         return false;
     }
 
-    // If approaching budget, be more conservative
-    if (stats.usage_percent >= float(config.warning_threshold_percent)) {
+    // If approaching budget, be more conservative. Gate on the reclaimable decision usage,
+    // not the reported allocation-inclusive percentage: loading a chunk into an existing slot
+    // grows payload, not the persistent-buffer allocation, so the non-reclaimable allocation
+    // must not block admission. Buffer growth has its own allocation-inclusive gate. (Codex #411)
+    if (decision_usage_percent >= float(config.warning_threshold_percent)) {
         // Only allow loading if we have significant headroom
         return current_loaded < current_max_chunks / 2;
     }

--- a/modules/gaussian_splatting/core/streaming_vram_regulator.cpp
+++ b/modules/gaussian_splatting/core/streaming_vram_regulator.cpp
@@ -310,6 +310,8 @@ void VRAMBudgetRegulator::set_config_override(const VRAMBudgetConfig &p_config) 
     if (config.source_max_chunks.is_empty() || config.source_max_chunks == "project_default") {
         config.source_max_chunks = "runtime_override";
     }
+    // Pick up any trusted capacity carried on the override before applying.
+    _query_device_memory();
     _apply_config();
 }
 
@@ -322,12 +324,20 @@ void VRAMBudgetRegulator::clear_config_override() {
 }
 
 void VRAMBudgetRegulator::_query_device_memory() {
+    // A trusted device VRAM capacity may be supplied out-of-band (config override
+    // or an explicit project pin resolved in load_from_project_settings()). When
+    // present it is authoritative and must survive a re-query — RenderingDevice
+    // exposes no portable capacity API, so the only way the capacity-known path
+    // (and its precise budget clamp) becomes reachable is to honor that value
+    // instead of unconditionally forcing "unknown".
+    const bool config_capacity_known = config.device_capacity_known && config.device_capacity_bytes > 0;
+
     if (!rd) {
         stats.device_reported_usage_bytes = 0;
-        stats.device_capacity_bytes = 0;
         stats.device_available_bytes = 0;
         stats.device_memory_queryable = false;
-        stats.device_capacity_known = false;
+        stats.device_capacity_bytes = config_capacity_known ? config.device_capacity_bytes : 0;
+        stats.device_capacity_known = config_capacity_known;
         return;
     }
 
@@ -335,13 +345,18 @@ void VRAMBudgetRegulator::_query_device_memory() {
     stats.device_reported_usage_bytes = rd->get_memory_usage(RenderingDevice::MEMORY_TOTAL);
     stats.device_memory_queryable = (stats.device_reported_usage_bytes > 0);
 
-    // Capacity query fallback chain placeholder: unknown until platform-specific sources are wired.
-    stats.device_capacity_bytes = 0;
+    // Capacity is known only when a trusted source supplied it; otherwise it
+    // stays unknown until platform-specific query sources are wired.
+    stats.device_capacity_bytes = config_capacity_known ? config.device_capacity_bytes : 0;
     stats.device_available_bytes = 0;
-    stats.device_capacity_known = false;
+    stats.device_capacity_known = config_capacity_known;
 
     if (GaussianSplatting::is_debug_frame_logging_enabled()) {
-        if (stats.device_memory_queryable) {
+        if (stats.device_capacity_known) {
+            GS_LOG_STREAMING_INFO(vformat("[VRAM Regulator] Device capacity known: %d MB (reported usage %d MB)",
+                    stats.device_capacity_bytes / (1024 * 1024),
+                    stats.device_reported_usage_bytes / (1024 * 1024)));
+        } else if (stats.device_memory_queryable) {
             GS_LOG_STREAMING_INFO(vformat("[VRAM Regulator] Device usage queryable: %d MB reported usage (capacity unknown)",
                     stats.device_reported_usage_bytes / (1024 * 1024)));
         } else {

--- a/modules/gaussian_splatting/core/streaming_vram_regulator.cpp
+++ b/modules/gaussian_splatting/core/streaming_vram_regulator.cpp
@@ -242,13 +242,26 @@ void VRAMBudgetRegulator::initialize(RenderingDevice *p_rd) {
             config.budget_mb, config.auto_regulate_enabled ? "enabled" : "disabled", current_max_chunks));
 }
 
+void VRAMBudgetRegulator::_capture_requested_budget() {
+    // Snapshot the caller's original ask BEFORE any clamp/fallback mutates
+    // config.budget_mb. _apply_config() rewrites budget_mb in place, so it can no
+    // longer recover the pre-clamp request on a second pass — initialize() applies
+    // an already-mutated config a second time. Capturing the request here, at the
+    // genuine config-establishment points, keeps requested_budget_mb stable across
+    // those re-applications (Codex #411).
+    config.requested_budget_mb = config.budget_mb;
+    config.requested_source_budget_mb = config.source_budget_mb;
+}
+
 void VRAMBudgetRegulator::_apply_config() {
     config.min_chunks = MAX(1u, config.min_chunks);
     config.max_chunks = MAX(config.min_chunks, config.max_chunks);
     config.warning_threshold_percent = CLAMP(config.warning_threshold_percent, 50u, 99u);
     config.regulation_step_percent = CLAMP(config.regulation_step_percent, 0.1f, 10.0f);
-    config.requested_budget_mb = config.budget_mb;
-    config.requested_source_budget_mb = config.source_budget_mb;
+    // requested_budget_mb / requested_source_budget_mb are captured by the
+    // config-establishment entry points (reload_config / set_config_override)
+    // before the clamp below runs; do NOT overwrite them here or a second
+    // _apply_config() pass would replace the original ask with the clamped value.
     config.budget_capacity_verified = stats.device_capacity_known;
     config.budget_uses_unknown_capacity_fallback = false;
     config.budget_unverified = false;
@@ -295,6 +308,14 @@ void VRAMBudgetRegulator::reload_config() {
         return;
     }
     config = VRAMBudgetConfig::load_from_project_settings();
+    // Re-derive device capacity from the freshly loaded config. clear_config_override()
+    // reaches here after dropping an override that may have carried a trusted capacity;
+    // without a re-query, stats.device_capacity_* would stay populated from the cleared
+    // override and a now-unknown-capacity project would be falsely capacity-verified or
+    // clamped to the stale capacity instead of following the unknown-capacity path
+    // (Codex #411).
+    _query_device_memory();
+    _capture_requested_budget();
     _apply_config();
 }
 
@@ -312,6 +333,7 @@ void VRAMBudgetRegulator::set_config_override(const VRAMBudgetConfig &p_config) 
     }
     // Pick up any trusted capacity carried on the override before applying.
     _query_device_memory();
+    _capture_requested_budget();
     _apply_config();
 }
 

--- a/modules/gaussian_splatting/core/streaming_vram_regulator.h
+++ b/modules/gaussian_splatting/core/streaming_vram_regulator.h
@@ -40,6 +40,12 @@ struct VRAMBudgetConfig {
     bool budget_uses_unknown_capacity_fallback = false;
     bool budget_unverified = false;
 
+    // Real device VRAM capacity, when the caller can supply it from a trusted
+    // source (e.g. a platform query or an explicit project pin). 0 / false means
+    // capacity is genuinely unknown and the conservative fallback path applies.
+    uint64_t device_capacity_bytes = 0;
+    bool device_capacity_known = false;
+
     static VRAMBudgetConfig load_from_project_settings();
 };
 

--- a/modules/gaussian_splatting/core/streaming_vram_regulator.h
+++ b/modules/gaussian_splatting/core/streaming_vram_regulator.h
@@ -81,6 +81,15 @@ private:
     // Dynamic chunk limit (adjusted based on VRAM pressure)
     uint32_t current_max_chunks = 32;
 
+    // Decision-basis usage (reclaimable/evictable), kept distinct from the reported
+    // allocation-inclusive usage published in `stats`. Eviction, admission, and
+    // auto-regulation act on what they can actually free; the overlay + budget warning
+    // report the true footprint. Gating decisions on the non-reclaimable persistent-buffer
+    // allocation would ratchet limits down or deny loads while no VRAM can be freed, and
+    // publishing the decision basis as the reported usage would under-count the overlay. (Codex #411)
+    uint64_t decision_usage_bytes = 0;
+    float decision_usage_percent = 0.0f;
+
     // Thrashing prevention state
     static constexpr uint32_t THRASHING_HISTORY_SIZE = 16;
     uint32_t load_history[THRASHING_HISTORY_SIZE] = {};
@@ -116,8 +125,10 @@ public:
     void set_config_override(const VRAMBudgetConfig &p_config);
     void clear_config_override();
 
-    // Called each frame with current usage stats
-    void update(uint64_t current_vram_usage, uint32_t loaded_chunks,
+    // Called each frame with current usage stats. p_reported_usage is the
+    // allocation-inclusive footprint (overlay + warning); p_decision_usage is the
+    // reclaimable/evictable subset that admission + auto-regulation act on. (Codex #411)
+    void update(uint64_t p_reported_usage, uint64_t p_decision_usage, uint32_t loaded_chunks,
                 uint32_t loads_this_frame, uint32_t evictions_this_frame,
                 uint64_t current_frame);
 

--- a/modules/gaussian_splatting/core/streaming_vram_regulator.h
+++ b/modules/gaussian_splatting/core/streaming_vram_regulator.h
@@ -100,6 +100,7 @@ private:
     void _update_regulation(uint64_t current_usage, uint64_t current_frame);
     bool _detect_thrashing() const;
     void _record_activity(uint32_t loads, uint32_t evictions);
+    void _capture_requested_budget();
     void _apply_config();
 
 protected:

--- a/modules/gaussian_splatting/tests/test_gpu_streaming.cpp
+++ b/modules/gaussian_splatting/tests/test_gpu_streaming.cpp
@@ -3677,3 +3677,38 @@ TEST_CASE("[Streaming Pipeline] Combined pressure with in-flight pack jobs valid
     CHECK(summary.reason == String(StreamingQueuePressureController::REASON_QUEUE_AND_CAPS));
     CHECK(StreamingQueuePressureController::validate_summary_invariants(summary, sample));
 }
+
+TEST_CASE("[Streaming VRAM] Reported total folds in the persistent buffer allocation") {
+    RenderingServer *rs = RenderingServer::get_singleton();
+    if (!rs) {
+        MESSAGE("Skipping - Rendering server unavailable");
+        return;
+    }
+
+    RenderingDevice *rd = RenderingDevice::get_singleton();
+    if (!rd) {
+        rd = rs->create_local_rendering_device();
+    }
+    if (!rd) {
+        MESSAGE("Skipping - Rendering device unavailable");
+        return;
+    }
+
+    Ref<GaussianStreamingSystem> system;
+    system.instantiate();
+    system->initialize_with_device(create_test_gaussian_data(GaussianStreamingSystem::CHUNK_SIZE), rd);
+    if (!system->is_runtime_ready()) {
+        MESSAGE("Skipping - Streaming runtime not ready");
+        return;
+    }
+
+    // The persistent storage buffer is allocated at init even before any chunk
+    // payload is uploaded. It is the single largest streaming VRAM allocation,
+    // so the reported total must account for the whole allocation, not just the
+    // (currently zero) loaded payload. Regression guard for the under-count:
+    // pre-fix get_vram_usage() returned only the auxiliary overhead here.
+    REQUIRE(system->persistent_buffer_size > 0u);
+    const uint64_t reported = system->get_vram_usage();
+    CHECK(reported >= uint64_t(system->persistent_buffer_size));
+    CHECK(reported > 0u);
+}

--- a/modules/gaussian_splatting/tests/test_gpu_streaming.cpp
+++ b/modules/gaussian_splatting/tests/test_gpu_streaming.cpp
@@ -2516,7 +2516,17 @@ TEST_CASE("[Streaming Pipeline] VRAM accounting includes auxiliary atlas overhea
 
     CHECK(payload_after_mb >= payload_before_mb);
     CHECK(overhead_after_mb >= overhead_before_mb);
-    CHECK(total_after > total_before);
+    // get_vram_usage() reports the real allocation now: MAX(loaded payload,
+    // persistent-buffer allocation) folded together with the auxiliary atlas
+    // overhead. Loading a single sub-capacity chunk need not grow the reported
+    // total — the up-front persistent buffer dominates the tiny 1024-splat payload,
+    // so the MAX is unchanged. Assert the accounting invariants instead of strict
+    // per-payload growth: the total never shrinks, and because the auxiliary
+    // overhead is non-zero it stays strictly above the persistent allocation alone
+    // (i.e. the overhead really is folded in on top of the buffer allocation).
+    const uint32_t persistent_bytes = system->_test_get_persistent_buffer_size();
+    CHECK(total_after >= total_before);
+    CHECK(total_after > uint64_t(persistent_bytes));
 }
 
 TEST_CASE("[Streaming Pipeline] Invalid camera/projection input is rejected safely") {
@@ -3707,8 +3717,9 @@ TEST_CASE("[Streaming VRAM] Reported total folds in the persistent buffer alloca
     // so the reported total must account for the whole allocation, not just the
     // (currently zero) loaded payload. Regression guard for the under-count:
     // pre-fix get_vram_usage() returned only the auxiliary overhead here.
-    REQUIRE(system->persistent_buffer_size > 0u);
+    const uint32_t persistent_bytes = system->_test_get_persistent_buffer_size();
+    REQUIRE(persistent_bytes > 0u);
     const uint64_t reported = system->get_vram_usage();
-    CHECK(reported >= uint64_t(system->persistent_buffer_size));
+    CHECK(reported >= uint64_t(persistent_bytes));
     CHECK(reported > 0u);
 }

--- a/modules/gaussian_splatting/tests/test_vram_budget_regulator.h
+++ b/modules/gaussian_splatting/tests/test_vram_budget_regulator.h
@@ -92,3 +92,61 @@ TEST_CASE("[GaussianSplatting][VRAMBudgetRegulator] Unknown capacity preserves p
     CHECK_FALSE(bool(stats.get("budget_uses_unknown_capacity_fallback", true)));
     CHECK(bool(stats.get("budget_unverified", false)));
 }
+
+TEST_CASE("[GaussianSplatting][VRAMBudgetRegulator] Known device capacity verifies budget under capacity (#321)") {
+    Ref<VRAMBudgetRegulator> regulator;
+    regulator.instantiate();
+    REQUIRE(regulator.is_valid());
+
+    VRAMBudgetConfig override_config;
+    override_config.budget_mb = 4096;
+    override_config.min_chunks = 2;
+    override_config.max_chunks = 16;
+    override_config.auto_regulate_enabled = false;
+    // Trusted capacity supplied out-of-band: 8 GB device, budget fits under it.
+    override_config.device_capacity_bytes = uint64_t(8192) * 1024u * 1024u;
+    override_config.device_capacity_known = true;
+
+    regulator->set_config_override(override_config);
+    regulator->initialize(nullptr);
+
+    Dictionary stats = regulator->get_debug_stats_dictionary();
+    // The capacity-known path must be reachable and reported as such (#321):
+    // previously _query_device_memory() unconditionally forced unknown.
+    CHECK(bool(stats.get("device_capacity_known", false)));
+    CHECK(uint64_t(stats.get("device_capacity_bytes", uint64_t(0))) == uint64_t(8192) * 1024u * 1024u);
+    // Budget fits under the real capacity, so it is verified and not clamped or
+    // routed through the conservative unknown-capacity fallback.
+    CHECK(Math::is_equal_approx(float(stats.get("budget_mb", -1.0f)), 4096.0f));
+    CHECK(bool(stats.get("budget_capacity_verified", false)));
+    CHECK_FALSE(bool(stats.get("budget_uses_unknown_capacity_fallback", true)));
+    CHECK_FALSE(bool(stats.get("budget_unverified", true)));
+}
+
+TEST_CASE("[GaussianSplatting][VRAMBudgetRegulator] Known device capacity clamps an over-large budget (#321)") {
+    Ref<VRAMBudgetRegulator> regulator;
+    regulator.instantiate();
+    REQUIRE(regulator.is_valid());
+
+    VRAMBudgetConfig override_config;
+    // Request more than the device actually has; must clamp to real capacity.
+    override_config.budget_mb = 12288;
+    override_config.min_chunks = 2;
+    override_config.max_chunks = 16;
+    override_config.auto_regulate_enabled = false;
+    override_config.device_capacity_bytes = uint64_t(4096) * 1024u * 1024u; // 4 GB device.
+    override_config.device_capacity_known = true;
+
+    regulator->set_config_override(override_config);
+    regulator->initialize(nullptr);
+
+    Dictionary stats = regulator->get_debug_stats_dictionary();
+    CHECK(bool(stats.get("device_capacity_known", false)));
+    // requested_budget_mb preserves the pre-clamp ask; budget_mb is clamped to
+    // the detected device capacity rather than left at the unsafe request.
+    CHECK(int64_t(stats.get("requested_budget_mb", int64_t(-1))) == int64_t(12288));
+    CHECK(Math::is_equal_approx(float(stats.get("budget_mb", -1.0f)), 4096.0f));
+    CHECK(String(stats.get("source_budget_mb", String())) == String("detected_capacity_clamp"));
+    CHECK(bool(stats.get("budget_capacity_verified", false)));
+    CHECK_FALSE(bool(stats.get("budget_uses_unknown_capacity_fallback", true)));
+}

--- a/modules/gaussian_splatting/tests/test_vram_budget_regulator.h
+++ b/modules/gaussian_splatting/tests/test_vram_budget_regulator.h
@@ -123,6 +123,54 @@ TEST_CASE("[GaussianSplatting][VRAMBudgetRegulator] Known device capacity verifi
     CHECK_FALSE(bool(stats.get("budget_unverified", true)));
 }
 
+TEST_CASE("[GaussianSplatting][VRAMBudgetRegulator] Clearing a capacity override drops stale device capacity (Codex #411)") {
+    ProjectSettings *project_settings = ProjectSettings::get_singleton();
+    REQUIRE(project_settings != nullptr);
+
+    const String tier_apply_setting = "rendering/gaussian_splatting/quality/tier_apply_streaming_budgets";
+    const String vram_budget_setting = "rendering/gaussian_splatting/streaming/vram_budget_mb";
+    ProjectSettingGuard tier_apply_guard(project_settings, tier_apply_setting);
+    ProjectSettingGuard vram_budget_guard(project_settings, vram_budget_setting);
+
+    // A project that asks for a large budget while true device capacity is unknown.
+    project_settings->set_setting(tier_apply_setting, false);
+    project_settings->set_setting(vram_budget_setting, 12288);
+
+    Ref<VRAMBudgetRegulator> regulator;
+    regulator.instantiate();
+    REQUIRE(regulator.is_valid());
+
+    // First install an override that carries a trusted (small) device capacity.
+    VRAMBudgetConfig override_config;
+    override_config.budget_mb = 12288;
+    override_config.min_chunks = 2;
+    override_config.max_chunks = 16;
+    override_config.auto_regulate_enabled = false;
+    override_config.device_capacity_bytes = uint64_t(4096) * 1024u * 1024u; // 4 GB device.
+    override_config.device_capacity_known = true;
+    regulator->set_config_override(override_config);
+
+    Dictionary override_stats = regulator->get_debug_stats_dictionary();
+    CHECK(bool(override_stats.get("device_capacity_known", false)));
+    CHECK(Math::is_equal_approx(float(override_stats.get("budget_mb", -1.0f)), 4096.0f));
+
+    // Clearing the override must NOT leave the regulator believing the device still
+    // has a known 4 GB capacity. The project config carries no trusted capacity, so
+    // it must follow the unknown-capacity path (not stay verified / clamped to 4 GB).
+    regulator->clear_config_override();
+
+    Dictionary cleared_stats = regulator->get_debug_stats_dictionary();
+    CHECK_FALSE(bool(cleared_stats.get("device_capacity_known", true)));
+    CHECK(uint64_t(cleared_stats.get("device_capacity_bytes", uint64_t(1))) == uint64_t(0));
+    CHECK_FALSE(bool(cleared_stats.get("budget_capacity_verified", true)));
+    CHECK(String(cleared_stats.get("source_budget_mb", String())) != String("detected_capacity_clamp"));
+    // 12288 MB from a project override with unknown capacity is unverified, not
+    // clamped to the cleared override's 4 GB.
+    CHECK(bool(cleared_stats.get("budget_unverified", false)));
+    CHECK(int64_t(cleared_stats.get("requested_budget_mb", int64_t(-1))) == int64_t(12288));
+    CHECK(Math::is_equal_approx(float(cleared_stats.get("budget_mb", -1.0f)), 12288.0f));
+}
+
 TEST_CASE("[GaussianSplatting][VRAMBudgetRegulator] Known device capacity clamps an over-large budget (#321)") {
     Ref<VRAMBudgetRegulator> regulator;
     regulator.instantiate();


### PR DESCRIPTION
**Verified:** the streaming regulator's reported VRAM total omitted its largest allocation. Folds `persistent_buffer_size` into the reported total (`MAX(budget.vram_usage, persistent_buffer_size)` + aux) and mirrors it in end-frame analytics; uses real `device_capacity_known` when available. + GPU-gated test. **NOTE:** the `12288` hardcode in `quality_tier_config` (the other half of #321) is **NOT** in this PR — separate follow-up. **Risk medium.** (audit-fix-wave)