### PR TITLE
gaussian_splatting: disjoint direct-lighting passes + soft-shadow comment fix

### DIFF
--- a/modules/gaussian_splatting/renderer/gaussian_gpu_layout.h
+++ b/modules/gaussian_splatting/renderer/gaussian_gpu_layout.h
@@ -460,7 +460,8 @@ struct alignas(16) TileRenderParamsGPU {
     // y=receiver_bias_min, z=receiver_bias_max (0=disabled), w=reserved
     float shadow_bias_config[4];
     // Lighting mode:
-    // lighting_mode: x=direct_lighting_mode (0=resolve, 1=per-splat, 2=both), yzw=reserved
+    // lighting_mode: x=direct_lighting_mode (0=resolve adds direct, 1=per-splat binning
+    // bakes direct), yzw=reserved. The two passes own DISJOINT modes; no "both" mode.
     uint32_t lighting_mode[4];
     // Light counts:
     // light_counts: x=omni_light_count, y=spot_light_count, z=cluster_enabled, w=light_mask

--- a/modules/gaussian_splatting/renderer/tile_render_types.h
+++ b/modules/gaussian_splatting/renderer/tile_render_types.h
@@ -432,7 +432,11 @@ struct TileRenderParams {
 	float shadow_receiver_bias_max = 0.0f;
 	bool enable_direct_lighting = true;
 	int normal_mode = 0;
-	int direct_lighting_mode = 0; // 0=resolve, 1=per-splat (binning), 2=both
+	// Direct-lighting ownership: 0=resolve adds direct (binning bakes nothing),
+	// 1=per-splat binning bakes direct (resolve adds nothing). These are the only
+	// valid values; the two passes own DISJOINT modes and must never both apply
+	// direct lighting (it would double-count). There is intentionally no "both" mode.
+	int direct_lighting_mode = 0;
 	float alpha_floor = 0.0f;
 	bool force_solid_coverage = false;
 	float cull_far_tolerance = 0.05f;

--- a/modules/gaussian_splatting/shaders/includes/gs_lighting_bridge.glsl
+++ b/modules/gaussian_splatting/shaders/includes/gs_lighting_bridge.glsl
@@ -48,9 +48,12 @@
 // ============================================================================
 // The Godot scene_forward_lights_inc.glsl uses gl_FragCoord for shadow sampling
 // randomization. In compute shaders, gl_FragCoord doesn't exist, so we provide
-// a substitute. Since we disable soft shadows (sc_*_shadow_samples() return 0),
-// the code paths using gl_FragCoord are never executed, but GLSL still needs
-// to be able to parse them.
+// a substitute. Soft shadows are gated off here via sc_use_light_soft_shadows()
+// returning false; that is the real switch, so the gl_FragCoord-using soft-shadow
+// code paths are never executed at runtime. Note that the sample-count specializers
+// sc_soft_shadow_samples()/sc_directional_soft_shadow_samples() deliberately return
+// 4u (forward-prep for when soft shadows are enabled), so the substitute still needs
+// to parse and compile.
 //
 // Compute shaders should define GS_COMPUTE_SHADER before including this file
 // and can optionally set gs_frag_coord_substitute to a meaningful value if

--- a/modules/gaussian_splatting/shaders/includes/gs_render_params.glsl
+++ b/modules/gaussian_splatting/shaders/includes/gs_render_params.glsl
@@ -81,7 +81,8 @@ layout(set = 1, binding = 0, std140) uniform RenderParams {
     // y=receiver_bias_min, z=receiver_bias_max (0=disabled), w=reserved
     vec4 shadow_bias_config;
     // Lighting mode:
-    // x=direct_lighting_mode (0=resolve, 1=per-splat, 2=both), yzw=reserved
+    // x=direct_lighting_mode (0=resolve adds direct, 1=per-splat binning bakes direct),
+    // yzw=reserved. The two passes own DISJOINT modes; there is no "both" mode.
     uvec4 lighting_mode;
     // Light counts:
     // x=omni_light_count, y=spot_light_count, z=cluster_enabled, w=light_mask

--- a/modules/gaussian_splatting/shaders/tile_binning.glsl
+++ b/modules/gaussian_splatting/shaders/tile_binning.glsl
@@ -1235,8 +1235,13 @@ void main() {
     float shadow_strength = clamp(params.shadow_strength.x, 0.0, 1.0);
     bool shadow_sampling_enabled = shadow_strength > 0.0;
     float sh_occlusion = 0.0;
+    // Direct-lighting ownership contract (must stay disjoint from tile_resolve.glsl):
+    //   lighting_mode == 0u  -> resolve adds direct (this pass bakes NOTHING)
+    //   lighting_mode == 1u  -> this pass (binning) bakes direct (resolve adds NOTHING)
+    // The two passes must never both apply direct lighting to the same splat, or it
+    // double-counts. There is intentionally no "both" mode here.
     if (params.lighting_config.z > 0.5) {
-        if (lighting_mode == 1u || lighting_mode == 2u) {
+        if (lighting_mode == 1u) {
             vec3 view_pos = view_pos_scene;
             vec3 view_dir = view_dir_scene;
 

--- a/modules/gaussian_splatting/shaders/tile_resolve.glsl
+++ b/modules/gaussian_splatting/shaders/tile_resolve.glsl
@@ -255,7 +255,11 @@ void main() {
     // Debug: force white albedo to isolate lighting contribution (debug_overlay_flags.w).
     // Only apply in resolve-direct mode; per-splat mode already bakes lighting into the color.
     uint lighting_mode = params.lighting_mode.x;
-    bool resolve_direct = (lighting_mode == 0u) || (lighting_mode == 2u);
+    // Direct-lighting ownership contract (must stay disjoint from tile_binning.glsl):
+    //   lighting_mode == 0u -> this pass (resolve) adds direct; binning bakes NOTHING.
+    //   lighting_mode == 1u -> binning bakes direct; this pass adds NOTHING.
+    // The two passes must never both apply direct lighting, or it double-counts.
+    bool resolve_direct = (lighting_mode == 0u);
     if (params.debug_overlay_flags.w > 0.5 && resolve_direct) {
         base_color = vec3(0.7);  // Neutral grey to see lighting clearly
     }

--- a/modules/gaussian_splatting/tests/test_renderer_pipeline.h
+++ b/modules/gaussian_splatting/tests/test_renderer_pipeline.h
@@ -690,6 +690,44 @@ TEST_CASE("[GaussianSplatting] GPU layout contract invariants remain stable") {
     CHECK(offsetof(TileRenderParamsGPU, effector_configs) == size_t(768));
 }
 
+// Mirror of the GLSL direct-lighting ownership predicates in tile_binning.glsl
+// and tile_resolve.glsl. These MUST stay in sync with the shaders: binning bakes
+// direct lighting iff lighting_mode == 1u; resolve adds direct iff lighting_mode == 0u.
+static bool gs_binning_bakes_direct(uint32_t p_lighting_mode) {
+    return p_lighting_mode == 1u;
+}
+static bool gs_resolve_adds_direct(uint32_t p_lighting_mode) {
+    return p_lighting_mode == 0u;
+}
+
+TEST_CASE("[GaussianSplatting] direct-lighting passes own disjoint modes (no double-count)") {
+    // The two passes must never both apply direct lighting for any value the host
+    // could place in lighting_mode.x; otherwise mode would double-count. We sweep
+    // a generous range (well beyond the valid {0,1}) to catch any future mode that
+    // accidentally satisfies both predicates.
+    for (uint32_t mode = 0u; mode <= 8u; ++mode) {
+        const bool binning = gs_binning_bakes_direct(mode);
+        const bool resolve = gs_resolve_adds_direct(mode);
+        CHECK_MESSAGE(!(binning && resolve),
+                "tile_binning and tile_resolve both apply direct lighting for a mode");
+    }
+
+    // Every valid mode must be owned by exactly one pass (no unowned/dropped mode).
+    CHECK(gs_resolve_adds_direct(0u));
+    CHECK_FALSE(gs_binning_bakes_direct(0u));
+    CHECK(gs_binning_bakes_direct(1u));
+    CHECK_FALSE(gs_resolve_adds_direct(1u));
+
+    // The host must only ever emit the two valid, disjoint modes. The default and the
+    // two assignment sites in the codebase are 0 (resolve) and 1 (per-splat); there is
+    // intentionally no "both" (mode 2) path. Confirm the GPU-layout default carries a
+    // valid, single-owner mode.
+    TileRenderParamsGPU gpu = {};
+    CHECK(gpu.lighting_mode[0] == 0u);
+    CHECK((gpu.lighting_mode[0] == 0u || gpu.lighting_mode[0] == 1u));
+    CHECK(gs_binning_bakes_direct(gpu.lighting_mode[0]) != gs_resolve_adds_direct(gpu.lighting_mode[0]));
+}
+
 static GaussianRenderPipeline::InstancePipelineBuffers make_ready_instance_pipeline_buffers(bool p_quantization_required) {
     GaussianRenderPipeline::InstancePipelineBuffers buffers;
     uint64_t rid_id = 1;


### PR DESCRIPTION
**(a) Mode-2 double-lighting (latent):** binning baked direct for `lighting_mode==1||2` and resolve re-added for `==0||2` → mode 2 ('both') double-counts. Mode 2 was unreachable AND never correct, so the branch is **removed**: binning bakes only for ==1, resolve only for ==0, with a documented disjoint-ownership contract + a host-mirror test asserting the two never both apply. **(b) Soft-shadow comment lie:** `gs_lighting_bridge.glsl:51` claimed samples 'return 0' but they return 4u; corrected to state soft shadows are gated off via `sc_use_light_soft_shadows()==false` (the 4u is forward-prep). **RENDER-PATH → needs the GPU + visual gate on real-scan content.** Risk medium. (audit-fix-wave)