### PR TITLE
gaussian_splatting: preset_low uses 64-bit sort keys (no silent 32-bit flicker path)

### DIFF
--- a/modules/gaussian_splatting/renderer/gpu_sorting_config.cpp
+++ b/modules/gaussian_splatting/renderer/gpu_sorting_config.cpp
@@ -202,9 +202,13 @@ void GPUSortingConfig::reset_to_defaults() {
     max_raster_splats_per_tile = 65536;
     radix_bits = GPUSortingConstants::DEFAULT_RADIX_BITS;
     workgroup_size = GPUSortingConstants::DEFAULT_WORKGROUP_SIZE;
-    key_bits = 32;  // Default 32-bit for 8 passes instead of 16
-    tile_bits = 16;
-    depth_bits = 16;
+    // 64-bit keys (32 tile + 32 depth) are the only shippable layout; 32-bit (16 depth bits)
+    // bands/flickers on real-scan content (GS-298). reset_to_defaults() is also the recovery
+    // path used by initialize_gpu_sorting_config() after a validation failure, so it must NOT
+    // yield the 32-bit layout without an explicit gpu_preset="custom" opt-in.
+    key_bits = 64;
+    tile_bits = 32;
+    depth_bits = 32;
     enable_tie_breaker = false;
     enable_performance_logging = false;
     performance_log_interval = 100;

--- a/modules/gaussian_splatting/renderer/gpu_sorting_config.cpp
+++ b/modules/gaussian_splatting/renderer/gpu_sorting_config.cpp
@@ -62,11 +62,13 @@ void GPUSortingConfig::load_from_project_settings() {
             // overrides that are orthogonal to the sort layout. Per Codex P2 on
             // PR #325: reading max_raster_splats_per_tile / key_bits / tile_bits
             // / depth_bits / enable_tie_breaker here would silently promote the
-            // preset's layout back to the GLOBAL_DEF defaults (65536/64/32/32/0),
-            // defeating preset_low() which intentionally sets 32-bit keys at
-            // 16/16. Users who want a custom layout should select
-            // gpu_sorting/preset="custom", which falls through to the manual
-            // config block below and reads every knob individually.
+            // preset's layout back to the GLOBAL_DEF defaults, overriding a
+            // preset's intentional layout choice. Every preset now uses 64-bit
+            // keys (the only shippable layout); 32-bit keys are reachable ONLY via
+            // gpu_sorting/preset="custom", which falls through to the manual config
+            // block below and reads every knob individually. This keeps the
+            // flickering 32-bit depth-key path an explicit opt-in, never a silent
+            // default or preset side effect.
             enable_performance_logging = ps->get_setting(PERFORMANCE_LOGGING_PATH, enable_performance_logging);
             performance_log_interval = ps->get_setting(LOG_INTERVAL_PATH, performance_log_interval);
             enable_bandwidth_monitoring = ps->get_setting(BANDWIDTH_MONITORING_PATH, enable_bandwidth_monitoring);
@@ -370,10 +372,17 @@ GPUSortingConfig GPUSortingConfig::preset_low() {
     config.radix_bits = GPUSortingConstants::DEFAULT_RADIX_BITS; // 4-bit radix (DEFAULT_RADIX_BITS); 8-bit measured slower for our workload
     config.workgroup_size = 128;             // Smaller workgroups for limited compute units
 
-    // Key layout - 32-bit keys to reduce memory bandwidth
-    config.key_bits = 32;                    // 32-bit keys reduce bandwidth by 50%
-    config.tile_bits = 16;                   // 16 bits for tile_id (65K tiles max)
-    config.depth_bits = 16;                  // 16 bits for depth (sufficient precision)
+    // Key layout - 64-bit keys. The 32-bit quantized depth key is the ONLY way a
+    // user could SILENTLY select the flickering/banding path: 32-bit keys give just
+    // 16 depth bits, which band and flicker on real-scan content (see project memory
+    // "64-bit sort keys are the only shippable config"). preset_low must therefore
+    // keep full-precision 64-bit keys; the modest extra VRAM (8-byte vs 4-byte keys)
+    // is acceptable on low-end GPUs versus shipping visibly wrong images. 32-bit keys
+    // remain reachable only via an EXPLICIT gpu_preset="custom" + key_bits=32 opt-in,
+    // never as a default or preset side effect.
+    config.key_bits = 64;                    // 64-bit keys: full depth precision, no banding
+    config.tile_bits = 32;                   // 32 bits for tile_id
+    config.depth_bits = 32;                  // 32 bits for depth
     config.enable_tie_breaker = false;       // Disable to save bits
     // Performance monitoring - minimal overhead
     config.enable_performance_logging = false;

--- a/modules/gaussian_splatting/renderer/gpu_sorting_config.h
+++ b/modules/gaussian_splatting/renderer/gpu_sorting_config.h
@@ -64,9 +64,9 @@ struct GPUSortingConfig {
     uint32_t workgroup_size = GPUSortingConstants::DEFAULT_WORKGROUP_SIZE; // GPU workgroup size
 
     // Key layout
-    uint32_t key_bits = 32;                  // Sort key width (32 or 64)
-    uint32_t tile_bits = 16;                 // Bits reserved for tile_id in the key
-    uint32_t depth_bits = 16;                // Bits reserved for depth in the key
+    uint32_t key_bits = 64;                  // Sort key width (32 or 64); 64 is the only shippable default (32-bit flickers on real scans, GS-298)
+    uint32_t tile_bits = 32;                 // Bits reserved for tile_id in the key
+    uint32_t depth_bits = 32;                // Bits reserved for depth in the key
     bool enable_tie_breaker = false;         // Reserve low bits for splat_id tie-breaks
 
     // Performance monitoring and logging

--- a/modules/gaussian_splatting/renderer/gpu_sorting_config.h
+++ b/modules/gaussian_splatting/renderer/gpu_sorting_config.h
@@ -105,7 +105,9 @@ struct GPUSortingConfig {
     // LOW TIER: Integrated GPUs (Intel UHD, AMD Vega), older discrete GPUs
     //   - Minimizes memory usage and compute load
     //   - Smaller workgroups for better occupancy on limited hardware
-    //   - 32-bit keys to reduce bandwidth
+    //   - 64-bit keys (the only shippable layout): 32-bit depth keys band and
+    //     flicker on real-scan content, so no preset selects them. 32-bit keys are
+    //     an explicit gpu_preset="custom" + key_bits=32 opt-in only.
     //
     // MEDIUM TIER: Mid-range discrete GPUs (GTX 1060, RTX 3050, RX 5600)
     //   - Balanced settings for good performance and quality

--- a/modules/gaussian_splatting/tests/test_config_validation.h
+++ b/modules/gaussian_splatting/tests/test_config_validation.h
@@ -494,7 +494,11 @@ TEST_CASE("[GaussianSplatting][Config] Project settings apply preset layouts unl
 			bool tie_breaker;
 		};
 		const PresetExpectation preset_expectations[] = {
-			{ "low", 32, 16, 16, false },
+			// "low" deliberately uses 64-bit keys too: 32-bit depth keys band and
+			// flicker on real-scan content, so NO preset is allowed to silently
+			// select them (see GS-298 / project memory "64-bit keys are the only
+			// shippable config"). 32-bit keys are an explicit "custom" opt-in only.
+			{ "low", 64, 32, 32, false },
 			{ "medium", 64, 32, 32, false },
 			{ "high", 64, 32, 32, false },
 			{ "ultra", 64, 32, 32, true },
@@ -554,6 +558,78 @@ TEST_CASE("[GaussianSplatting][Config] Project settings apply preset layouts unl
 	}
 
 	g_gpu_sorting_config = previous_global_config;
+}
+
+TEST_CASE("[GaussianSplatting][Config] No preset or default path silently yields 32-bit sort keys") {
+	// GS-298 regression guard. 32-bit quantized depth keys give only 16 depth bits,
+	// which band and flicker on real-scan content; 64-bit keys are the only shippable
+	// layout. A user must never end up on the 32-bit path WITHOUT an explicit opt-in.
+	// This guards every selectable preset AND the documented default preset.
+
+	SUBCASE("Every named preset uses 64-bit keys") {
+		CHECK(GPUSortingConfig::preset_low().key_bits == 64u);
+		CHECK(GPUSortingConfig::preset_medium().key_bits == 64u);
+		CHECK(GPUSortingConfig::preset_high().key_bits == 64u);
+		CHECK(GPUSortingConfig::preset_ultra().key_bits == 64u);
+	}
+
+	SUBCASE("apply_preset by name never installs 32-bit keys") {
+		const char *names[] = { "low", "performance", "medium", "balanced",
+				"high", "quality", "ultra", "maximum" };
+		for (const char *name : names) {
+			GPUSortingConfig config;
+			REQUIRE(config.apply_preset(name));
+			CHECK_MESSAGE(config.key_bits == 64u,
+					vformat("Preset '%s' silently selected %d-bit keys", name, config.key_bits));
+		}
+	}
+
+	SUBCASE("The documented default gpu_preset loads 64-bit keys") {
+		ProjectSettings *project_settings = ProjectSettings::get_singleton();
+		REQUIRE(project_settings != nullptr);
+
+		const GPUSortingConfig previous_global_config = g_gpu_sorting_config;
+		const String preset_path = GPUSortingConfig::GPU_PRESET_PATH;
+		ProjectSettingGuard preset_guard(project_settings, preset_path);
+
+		// "high" is the GLOBAL_DEF default (see initialize_gpu_sorting_config).
+		project_settings->set_setting(preset_path, "high");
+		g_gpu_sorting_config.load_from_project_settings();
+		CHECK(g_gpu_sorting_config.key_bits == 64u);
+
+		g_gpu_sorting_config = previous_global_config;
+	}
+
+	SUBCASE("32-bit keys remain reachable ONLY via an explicit custom opt-in") {
+		ProjectSettings *project_settings = ProjectSettings::get_singleton();
+		REQUIRE(project_settings != nullptr);
+
+		const GPUSortingConfig previous_global_config = g_gpu_sorting_config;
+		const String preset_path = GPUSortingConfig::GPU_PRESET_PATH;
+		const String key_bits_path = GPUSortingConfig::KEY_BITS_PATH;
+		const String tile_bits_path = GPUSortingConfig::TILE_BITS_PATH;
+		const String depth_bits_path = GPUSortingConfig::DEPTH_BITS_PATH;
+		ProjectSettingGuard preset_guard(project_settings, preset_path);
+		ProjectSettingGuard key_bits_guard(project_settings, key_bits_path);
+		ProjectSettingGuard tile_bits_guard(project_settings, tile_bits_path);
+		ProjectSettingGuard depth_bits_guard(project_settings, depth_bits_path);
+
+		// Selecting a named preset ignores an explicit key_bits=32: the layout is
+		// the preset's own (64-bit), so the 32-bit request cannot silently apply.
+		project_settings->set_setting(preset_path, "low");
+		project_settings->set_setting(key_bits_path, 32);
+		project_settings->set_setting(tile_bits_path, 16);
+		project_settings->set_setting(depth_bits_path, 16);
+		g_gpu_sorting_config.load_from_project_settings();
+		CHECK(g_gpu_sorting_config.key_bits == 64u);
+
+		// Only the explicit "custom" path honors key_bits=32 — an intentional opt-in.
+		project_settings->set_setting(preset_path, "custom");
+		g_gpu_sorting_config.load_from_project_settings();
+		CHECK(g_gpu_sorting_config.key_bits == 32u);
+
+		g_gpu_sorting_config = previous_global_config;
+	}
 }
 
 TEST_CASE("[GaussianSplatting][Config] Explicit max_overlap_records overrides a named preset's budget") {

--- a/modules/gaussian_splatting/tests/test_config_validation.h
+++ b/modules/gaussian_splatting/tests/test_config_validation.h
@@ -573,6 +573,23 @@ TEST_CASE("[GaussianSplatting][Config] No preset or default path silently yields
 		CHECK(GPUSortingConfig::preset_ultra().key_bits == 64u);
 	}
 
+	SUBCASE("struct defaults and reset_to_defaults() (the recovery path) yield 64-bit keys") {
+		// initialize_gpu_sorting_config() falls back to reset_to_defaults() after a validation
+		// failure, so a project with an invalid GPU sorting setting must NOT silently run on the
+		// 32-bit layout. Guards both the struct member default and the explicit reset.
+		GPUSortingConfig fresh_defaults;
+		CHECK(fresh_defaults.key_bits == 64u);
+		CHECK(fresh_defaults.tile_bits == 32u);
+		CHECK(fresh_defaults.depth_bits == 32u);
+
+		GPUSortingConfig recovered;
+		recovered.key_bits = 32; // simulate a bad/legacy value before recovery
+		recovered.reset_to_defaults();
+		CHECK(recovered.key_bits == 64u);
+		CHECK(recovered.tile_bits == 32u);
+		CHECK(recovered.depth_bits == 32u);
+	}
+
 	SUBCASE("apply_preset by name never installs 32-bit keys") {
 		const char *names[] = { "low", "performance", "medium", "balanced",
 				"high", "quality", "ultra", "maximum" };


### PR DESCRIPTION
**Verified:** `preset_low()` set `key_bits=32` and validate() accepted it — but 32-bit quantized keys flicker/band on real-scan data (64-bit is the only shippable config). `preset_low` now uses 64-bit keys (64/32/32) like the other presets; 32-bit is reachable only via explicit `gpu_preset=custom + key_bits=32`. Updates the `[Config]` preset-layout test expectation. **Needs the visual gate** (preset change). Risk low. (audit-fix-wave)