### PR TITLE
gaussian_splatting: fix stale backend-plan test for direct-data force-resident

### DIFF
--- a/modules/gaussian_splatting/tests/test_renderer_pipeline.h
+++ b/modules/gaussian_splatting/tests/test_renderer_pipeline.h
@@ -4836,7 +4836,7 @@ TEST_CASE("[GaussianSplatting] runtime fidelity policy centralizes route policy 
 	CHECK(runtime_policy.runtime_budget_splats == 8);
 }
 
-TEST_CASE("[GaussianSplatting] frame backend plan centralizes streaming bootstrap without synthetic primary fallback") {
+TEST_CASE("[GaussianSplatting] frame backend plan forces resident for direct data with no submission (no synthetic primary fallback)") {
 	ProjectSettings *project_settings = ProjectSettings::get_singleton();
 	if (project_settings == nullptr) {
 		MESSAGE("Skipping test - ProjectSettings unavailable");
@@ -4859,12 +4859,20 @@ TEST_CASE("[GaussianSplatting] frame backend plan centralizes streaming bootstra
 	GaussianSplatRenderer::SceneState &scene_state = renderer->get_scene_state();
 	scene_state.gaussian_data = data;
 
+	// Direct gaussian_data on a standalone renderer (no world submission) has no instance
+	// to populate the streaming instance cache. The synthetic primary-data bootstrap
+	// instance that used to cover this case was pruned (commit de71685b08), so the streaming
+	// backend would now emit zero splats. build_frame_backend_plan() therefore forces resident
+	// for direct-data-without-submission (reason "direct_data_no_submission") and suppresses the
+	// streaming bootstrap, even though the route policy requests streaming. The genuine
+	// streaming-bootstrap path is exercised by the file-backed-payload test below.
 	const GaussianSplatRenderer::FrameBackendPlan backend_plan = renderer->build_frame_backend_plan(false);
 	CHECK(backend_plan.streaming_requested);
-	CHECK_FALSE(backend_plan.prefer_resident_backend);
+	CHECK(backend_plan.prefer_resident_backend);
 	CHECK_FALSE(backend_plan.streaming_ready);
-	CHECK(backend_plan.should_attempt_streaming_bootstrap);
+	CHECK_FALSE(backend_plan.should_attempt_streaming_bootstrap);
 	CHECK_FALSE(backend_plan.has_active_world_submission);
+	CHECK(backend_plan.resident_backend_reason == String("direct_data_no_submission"));
 }
 
 TEST_CASE("[GaussianSplatting] frame backend plan preserves resident request semantics") {


### PR DESCRIPTION
## Summary
Fixes a pre-existing failing doctest (not from any merged audit PR): `[GaussianSplatting] frame backend plan centralizes streaming bootstrap without synthetic primary fallback`. Its expectations contradicted `build_frame_backend_plan` since commit `de71685b08` pruned the synthetic-instance shim — direct `gaussian_data` with no world submission now **forces resident** (reason `"direct_data_no_submission"`) instead of attempting a streaming bootstrap that would emit zero splats.

## Change
- Risk class: **R1** (test-only).
- Base SHA: `bc47945a92`.
- Rewrites the test to assert the current, intended contract (previously **uncovered**): direct data + no submission + streaming route → `prefer_resident_backend`, no streaming bootstrap, `resident_backend_reason == "direct_data_no_submission"`.
- The genuine streaming-bootstrap path remains covered by the existing file-backed-payload test.

## Non-goals
No production logic change; only the test + an explanatory comment.

## Validation
- `run_module_tests.py --guard-only` passed.
- Built dev editor (`target=editor tests=yes`); the rewritten test now passes: **1 case, 7 assertions, 0 failed** (`--test-case="*forces resident for direct data*"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)