### PR TITLE
gaussian_splatting: clamp resident atlas to device VRAM via importance LOD (#321 follow-up)

### DIFF
--- a/modules/gaussian_splatting/config/project_settings_manifest.json
+++ b/modules/gaussian_splatting/config/project_settings_manifest.json
@@ -1068,6 +1068,16 @@
       "test_coverage": "inventory_only"
     },
     {
+      "effective_state": "ResidentInstanceContractPublisher effective atlas VRAM cap (importance-LOD clamp).",
+      "key": "rendering/gaussian_splatting/resident/atlas_vram_budget_override_mb",
+      "owner": "ResidentInstanceContractPublisher VRAM clamp",
+      "publicness": "public",
+      "reload_semantics": "settings_changed",
+      "scope": "runtime",
+      "test_coverage": "partial",
+      "visibility": "editor_visible"
+    },
+    {
       "effective_state": "GaussianSplatManager global stats/config.shared_submission_device_enabled",
       "key": "rendering/gaussian_splatting/shared_submission_device_enabled",
       "test_coverage": "inventory_only"

--- a/modules/gaussian_splatting/config/project_settings_public_api_baseline.json
+++ b/modules/gaussian_splatting/config/project_settings_public_api_baseline.json
@@ -115,6 +115,7 @@
     "rendering/gaussian_splatting/rasterization/low_pass_filter",
     "rendering/gaussian_splatting/renderdoc_compatibility",
     "rendering/gaussian_splatting/rendering/sh_bands",
+    "rendering/gaussian_splatting/resident/atlas_vram_budget_override_mb",
     "rendering/gaussian_splatting/shared_submission_device_enabled",
     "rendering/gaussian_splatting/sorting/bitonic_max_elements",
     "rendering/gaussian_splatting/sorting/force_algorithm",

--- a/modules/gaussian_splatting/core/gaussian_splat_manager.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_manager.cpp
@@ -1178,6 +1178,16 @@ void GaussianSplatManager::initialize_module() {
 	// Step size for budget adjustments (1% as recommended by Virtual Memory 3DGS paper)
 	GLOBAL_DEF("rendering/gaussian_splatting/streaming/regulation_step_percent", 1.0f);
 
+	// Resident-path (GaussianSplatNode3D) atlas VRAM budget override, in MB.
+	//   0 (default) = off: the resident atlas is clamped to the queried device VRAM budget
+	//     (#321) and only thinned (importance-ordered LOD) when it would not otherwise fit,
+	//     so capable GPUs are unaffected.
+	//   >0 = pin an explicit atlas byte budget; forces the importance-LOD clamp even on a
+	//     capable GPU. Useful to cap resident VRAM on a known target and to validate the
+	//     clamp on real-scan content. See renderer/resident_atlas_budget.h.
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/gaussian_splatting/resident/atlas_vram_budget_override_mb",
+			PROPERTY_HINT_RANGE, "0,8192,1"), 0);
+
 	// Sorting configuration settings from master
 	GLOBAL_DEF("rendering/gaussian_splatting/sorting/bitonic_max_elements", (int)sorting_bitonic_max);
 	GLOBAL_DEF("rendering/gaussian_splatting/sorting/radix_max_elements", (int)sorting_radix_max);

--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
@@ -1450,6 +1450,9 @@ void GaussianSplatRenderer::_release_resident_contract_buffers() {
     resource_state.resident_atlas_gaussian_count = 0;
     resource_state.resident_dispatch_chunk_count = 0;
     resource_state.resident_max_chunk_splats = 0;
+    resource_state.resident_atlas_reduced = false;
+    resource_state.resident_atlas_source_count = 0;
+    resource_state.resident_atlas_keep_ratio = 1.0f;
 }
 
 void GaussianSplatRenderer::_release_shared_dynamic_asset() {

--- a/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_diagnostics_orchestrator.cpp
@@ -1481,6 +1481,13 @@ Dictionary RenderDiagnosticsOrchestrator::build_render_stats() const {
 	stats["payload_source_active"] = payload_source_active;
 	stats["resident_payload_active"] = resident_payload_active;
 	stats["payload_resident_only_reason"] = payload_resident_only_reason;
+	// Resident atlas VRAM-budget LOD clamp telemetry (#321 follow-up). `reduced` is true when
+	// the atlas was thinned by importance to fit the device VRAM budget; surfaced so the
+	// degradation is observable in the residency HUD / debug stats rather than silent.
+	stats["resident_atlas_reduced"] = resource_state.resident_atlas_reduced;
+	stats["resident_atlas_source_count"] = static_cast<int64_t>(resource_state.resident_atlas_source_count);
+	stats["resident_atlas_packed_count"] = static_cast<int64_t>(resource_state.resident_atlas_gaussian_count);
+	stats["resident_atlas_keep_ratio"] = resource_state.resident_atlas_keep_ratio;
 	stats["instance_backend_policy"] = debug_state.instance_backend_policy;
 	stats["backend_selection_reason"] = debug_state.backend_selection_reason;
 	stats["backend_selection_reason_label"] =

--- a/modules/gaussian_splatting/renderer/render_types/render_facade_state_types.h
+++ b/modules/gaussian_splatting/renderer/render_types/render_facade_state_types.h
@@ -109,6 +109,15 @@ struct ResourceState {
 	// pack loop. Lets regression tests assert that per-instance state changes (visibility,
 	// transform, opacity, etc) do NOT trigger an atlas repack.
 	uint64_t resident_atlas_pack_count = 0;
+	// Resident atlas VRAM-budget LOD clamp telemetry (#321 follow-up). Cached on the slow
+	// path so the fast (instance-only) path re-surfaces the same values. `source_count` is
+	// the full atlas splat count; the packed count is resident_atlas_gaussian_count above
+	// (== source_count when not reduced); `keep_ratio` is the global importance-thinning
+	// fraction applied per chunk. `reduced` is true whenever the atlas was clamped to fit
+	// the device VRAM budget (observable, never a silent drop).
+	bool resident_atlas_reduced = false;
+	uint32_t resident_atlas_source_count = 0;
+	float resident_atlas_keep_ratio = 1.0f;
 };
 
 struct TestDataState {

--- a/modules/gaussian_splatting/renderer/resident_atlas_budget.h
+++ b/modules/gaussian_splatting/renderer/resident_atlas_budget.h
@@ -106,11 +106,16 @@ inline uint32_t compute_chunk_keep_count(uint32_t count, double keep_ratio) {
 }
 
 // The project's own per-splat importance metric (interfaces/gpu_culler.cpp:291-293):
-// opacity (clamped) * (max scale axis + epsilon), floored to epsilon. Reused here so
-// the subset is selected by the same definition the culler uses, not a new heuristic.
+// opacity (clamped) * (max scale axis + epsilon), floored to epsilon. Reused so the subset
+// is selected by the same definition the culler uses, not a new heuristic -- with one
+// deliberate refinement for this DESTRUCTIVE selection: use the scale MAGNITUDE
+// (max(abs(scale))) rather than the signed axis. The covariance build squares scale and
+// GaussianData::compute_radius() treats scale by magnitude, so a large negative-scale splat
+// (e.g. (-5,-4,-3)) is visibly large and must not be forced to the minimum importance and
+// preferentially dropped (Codex #420).
 inline float gaussian_importance(const Gaussian &p_g) {
     const float opacity = CLAMP(p_g.opacity, 0.0f, 1.0f);
-    const float size_factor = MAX(MAX(p_g.scale.x, p_g.scale.y), p_g.scale.z);
+    const float size_factor = MAX(MAX(Math::abs(p_g.scale.x), Math::abs(p_g.scale.y)), Math::abs(p_g.scale.z));
     return MAX(0.0001f, opacity * (size_factor + 0.0001f));
 }
 
@@ -153,13 +158,25 @@ inline void select_top_k_indices(const float *p_importance, uint32_t p_count, ui
 // Compact a captured chunk snapshot down to its top-importance subset in place,
 // moving both the Gaussian payload and its parallel high-order SH block (stride =
 // p_sh_stride coefficients per gaussian, gaussian-major, per capture_*_snapshot).
-// Returns the number of kept gaussians (== count when keep_ratio implies no thinning).
+// `r_remaining_budget` is the global cap on cumulative kept splats across all chunks: the
+// per-chunk keep is clamped to it and it is decremented by the kept count, so the resident
+// atlas honors the device VRAM target even when many per-chunk floors would otherwise
+// overshoot it (e.g. a dataset of many one-splat static chunks) -- Codex #420. Returns the
+// number of kept gaussians (0 when the budget is exhausted -> the caller drops the chunk).
 inline uint32_t compact_chunk_by_importance(LocalVector<Gaussian> &r_gaussians,
-        LocalVector<Vector3> &r_sh_high_order, uint32_t p_sh_stride, double p_keep_ratio) {
+        LocalVector<Vector3> &r_sh_high_order, uint32_t p_sh_stride, double p_keep_ratio,
+        uint32_t &r_remaining_budget) {
     const uint32_t count = r_gaussians.size();
-    const uint32_t keep = compute_chunk_keep_count(count, p_keep_ratio);
+    uint32_t keep = compute_chunk_keep_count(count, p_keep_ratio);
+    keep = MIN(keep, r_remaining_budget); // hard global cap
     if (keep >= count) {
+        r_remaining_budget -= count;
         return count;
+    }
+    if (keep == 0) {
+        r_gaussians.clear();
+        r_sh_high_order.clear();
+        return 0;
     }
 
     LocalVector<float> importance;
@@ -196,6 +213,7 @@ inline uint32_t compact_chunk_by_importance(LocalVector<Gaussian> &r_gaussians,
         }
         r_sh_high_order.resize(keep * p_sh_stride);
     }
+    r_remaining_budget -= keep;
     return keep;
 }
 

--- a/modules/gaussian_splatting/renderer/resident_atlas_budget.h
+++ b/modules/gaussian_splatting/renderer/resident_atlas_budget.h
@@ -133,7 +133,16 @@ inline uint32_t compute_chunk_keep_count(uint32_t count, double keep_ratio) {
 inline float gaussian_importance(const Gaussian &p_g) {
     const float opacity = CLAMP(p_g.opacity, 0.0f, 1.0f);
     const float size_factor = MAX(MAX(Math::abs(p_g.scale.x), Math::abs(p_g.scale.y)), Math::abs(p_g.scale.z));
-    return MAX(0.0001f, opacity * (size_factor + 0.0001f));
+    const float importance = opacity * (size_factor + 0.0001f);
+    // Scan/training PLY data can carry NaN/Inf scale or opacity. A non-finite importance would
+    // make the strict-weak-ordering comparator in select_top_k_indices non-transitive, which is
+    // undefined behavior for std::nth_element / std::sort in this DESTRUCTIVE selection. Floor
+    // any non-finite value so the metric is always finite and orderable (deterministic), and
+    // such degenerate splats sort to the bottom rather than corrupting the kept set.
+    if (!Math::is_finite(importance)) {
+        return 0.0001f;
+    }
+    return MAX(0.0001f, importance);
 }
 
 // Select the `keep` highest-importance indices in [0, count), ties broken by

--- a/modules/gaussian_splatting/renderer/resident_atlas_budget.h
+++ b/modules/gaussian_splatting/renderer/resident_atlas_budget.h
@@ -86,6 +86,23 @@ inline SubsetPlan compute_subset_plan(uint64_t total_gaussians, uint64_t effecti
     return plan;
 }
 
+// Per-asset slice of the global keep budget when the resident atlas spans multiple assets.
+// Each asset gets a share proportional to its splat count (ceil, so a non-empty asset keeps
+// >=1), capped by the budget still globally available. This keeps any one asset -- including
+// the currently visible/casting ones -- from being starved to zero by an earlier large
+// (possibly hidden) asset processed first in the stable superset. The split is a pure function
+// of per-device counts, NOT visibility, so the atlas stays stable across visibility flips
+// (Codex #420 round 3).
+inline uint32_t resident_asset_budget(uint64_t p_target_keep, uint64_t p_asset_count,
+        uint64_t p_total_gaussians, uint32_t p_global_remaining) {
+    if (p_asset_count == 0u || p_total_gaussians == 0u) {
+        return 0u;
+    }
+    const uint64_t proportional = (p_target_keep * p_asset_count + p_total_gaussians - 1u) / p_total_gaussians;
+    const uint64_t share = MAX<uint64_t>(uint64_t(1), proportional);
+    return uint32_t(MIN<uint64_t>(uint64_t(p_global_remaining), share));
+}
+
 // Per-chunk keep count under a global keep_ratio. Floors at 1 for any non-empty
 // chunk so thinning never deletes a whole spatial region (preserves coverage on
 // real-scan content); the per-chunk floor remainder is the documented soft

--- a/modules/gaussian_splatting/renderer/resident_atlas_budget.h
+++ b/modules/gaussian_splatting/renderer/resident_atlas_budget.h
@@ -1,0 +1,204 @@
+#ifndef GS_RESIDENT_ATLAS_BUDGET_H
+#define GS_RESIDENT_ATLAS_BUDGET_H
+
+// Pure, device-independent helpers for clamping the resident atlas to the
+// device VRAM budget (#321) and packing an importance-ordered subset (a coarse
+// LOD) when the full atlas would not fit. Deliberately free of RenderingDevice /
+// RID / global-config dependencies so the budget math and the subset selection
+// are unit-testable on the host without a GPU. See
+// resident_instance_contract_publisher.cpp for the single production caller.
+
+#include "../core/gaussian_data.h" // Gaussian
+
+#include "core/math/math_funcs.h"
+#include "core/math/vector3.h"
+#include "core/templates/local_vector.h"
+
+#include <algorithm>
+#include <cstdint>
+
+namespace ResidentAtlasBudget {
+
+// Static device-local VRAM capacity below which RenderingDevice::get_device_memory_budget()
+// is treated as unknown. Mirrors streaming_vram_regulator.cpp's
+// MIN_TRUSTED_DEVICE_CAPACITY_BYTES (#321): a degenerate small-positive value would
+// otherwise clamp the atlas to nonsense.
+static constexpr uint64_t kMinTrustedDeviceBudgetBytes = uint64_t(256) * 1024 * 1024;
+
+// Absolute single-upload staging ceiling, shared with the resident publisher's
+// kMaxResidentUploadBytes. Datasets above this still hard-reject (streaming is the
+// right answer); the budget cap below only ever tightens beneath it.
+static constexpr uint64_t kResidentStagingCeilingBytes = uint64_t(2) * 1024 * 1024 * 1024;
+
+// Fraction of device-local VRAM the resident atlas may occupy. The remainder is
+// reserved for the same frame's sort / splat-ref / visible-chunk buffers, engine
+// framebuffers, and driver reserve (get_device_memory_budget() is the device heap,
+// not net of this app's non-atlas allocations). The 0.60 * budget term only binds
+// below ~3.3 GB device VRAM (0.60 * budget < 2 GB); at/above that, the staging
+// ceiling dominates and capable GPUs are byte-identical to today.
+static constexpr double kResidentAtlasHeadroomFraction = 0.60;
+
+// Effective byte cap for the packed resident atlas.
+//  - device_budget_bytes == 0 or below the sane floor => capacity unknown =>
+//    cap stays at the staging ceiling (do-no-harm on UMA/iGPU/software/non-Vulkan).
+//  - override_mb > 0 pins an explicit cap (low-end clamp + on-capable-GPU validation).
+inline uint64_t compute_effective_atlas_cap_bytes(uint64_t device_budget_bytes, uint32_t override_mb,
+        uint64_t staging_ceiling_bytes = kResidentStagingCeilingBytes,
+        double headroom_fraction = kResidentAtlasHeadroomFraction,
+        uint64_t min_trusted_budget_bytes = kMinTrustedDeviceBudgetBytes) {
+    uint64_t cap = staging_ceiling_bytes;
+    if (device_budget_bytes >= min_trusted_budget_bytes) {
+        const uint64_t budget_cap = uint64_t(double(device_budget_bytes) * headroom_fraction);
+        cap = MIN(cap, budget_cap);
+    }
+    if (override_mb > 0) {
+        const uint64_t override_bytes = uint64_t(override_mb) * 1024u * 1024u;
+        cap = MIN(cap, override_bytes);
+    }
+    return cap;
+}
+
+struct SubsetPlan {
+    bool reduced = false;       // true when the atlas must be thinned to fit
+    double keep_ratio = 1.0;    // global fraction of splats to keep (1.0 == full)
+    uint64_t target_keep = 0;   // soft splat target (cap_bytes / packed_size)
+    uint64_t source_count = 0;  // full atlas splat count
+    uint64_t cap_bytes = 0;     // effective byte cap that produced this plan
+};
+
+// Decide whether the full atlas fits the cap and, if not, the global keep ratio.
+inline SubsetPlan compute_subset_plan(uint64_t total_gaussians, uint64_t effective_cap_bytes,
+        uint32_t packed_gaussian_size = 144u) {
+    SubsetPlan plan;
+    plan.source_count = total_gaussians;
+    plan.cap_bytes = effective_cap_bytes;
+    plan.target_keep = total_gaussians;
+    if (packed_gaussian_size == 0u || total_gaussians == 0u) {
+        return plan;
+    }
+    const uint64_t cap_splats = effective_cap_bytes / uint64_t(packed_gaussian_size);
+    if (cap_splats >= total_gaussians) {
+        return plan; // fits: keep_ratio == 1.0, reduced == false
+    }
+    plan.reduced = true;
+    plan.target_keep = cap_splats;
+    plan.keep_ratio = double(cap_splats) / double(total_gaussians);
+    return plan;
+}
+
+// Per-chunk keep count under a global keep_ratio. Floors at 1 for any non-empty
+// chunk so thinning never deletes a whole spatial region (preserves coverage on
+// real-scan content); the per-chunk floor remainder is the documented soft
+// overshoot bounded by the hard staging ceiling.
+inline uint32_t compute_chunk_keep_count(uint32_t count, double keep_ratio) {
+    if (count == 0u) {
+        return 0u;
+    }
+    if (keep_ratio >= 1.0) {
+        return count;
+    }
+    if (keep_ratio <= 0.0) {
+        return 1u;
+    }
+    uint32_t keep = uint32_t(Math::round(double(count) * keep_ratio));
+    keep = MAX(1u, keep);
+    return MIN(keep, count);
+}
+
+// The project's own per-splat importance metric (interfaces/gpu_culler.cpp:291-293):
+// opacity (clamped) * (max scale axis + epsilon), floored to epsilon. Reused here so
+// the subset is selected by the same definition the culler uses, not a new heuristic.
+inline float gaussian_importance(const Gaussian &p_g) {
+    const float opacity = CLAMP(p_g.opacity, 0.0f, 1.0f);
+    const float size_factor = MAX(MAX(p_g.scale.x, p_g.scale.y), p_g.scale.z);
+    return MAX(0.0001f, opacity * (size_factor + 0.0001f));
+}
+
+// Select the `keep` highest-importance indices in [0, count), ties broken by
+// ascending index (a strict total order => a unique, deterministic kept set), and
+// return them SORTED ASCENDING so the caller can compact in place forward-only.
+inline void select_top_k_indices(const float *p_importance, uint32_t p_count, uint32_t p_keep,
+        LocalVector<uint32_t> &r_indices) {
+    r_indices.clear();
+    if (p_count == 0u || p_keep == 0u) {
+        return;
+    }
+    if (p_keep >= p_count) {
+        r_indices.resize(p_count);
+        for (uint32_t i = 0; i < p_count; i++) {
+            r_indices[i] = i;
+        }
+        return;
+    }
+    LocalVector<uint32_t> order;
+    order.resize(p_count);
+    for (uint32_t i = 0; i < p_count; i++) {
+        order[i] = i;
+    }
+    const float *importance = p_importance;
+    const auto better = [importance](uint32_t a, uint32_t b) {
+        if (importance[a] != importance[b]) {
+            return importance[a] > importance[b];
+        }
+        return a < b; // deterministic tie-break
+    };
+    std::nth_element(order.ptr(), order.ptr() + p_keep, order.ptr() + p_count, better);
+    r_indices.resize(p_keep);
+    for (uint32_t i = 0; i < p_keep; i++) {
+        r_indices[i] = order[i];
+    }
+    std::sort(r_indices.ptr(), r_indices.ptr() + p_keep);
+}
+
+// Compact a captured chunk snapshot down to its top-importance subset in place,
+// moving both the Gaussian payload and its parallel high-order SH block (stride =
+// p_sh_stride coefficients per gaussian, gaussian-major, per capture_*_snapshot).
+// Returns the number of kept gaussians (== count when keep_ratio implies no thinning).
+inline uint32_t compact_chunk_by_importance(LocalVector<Gaussian> &r_gaussians,
+        LocalVector<Vector3> &r_sh_high_order, uint32_t p_sh_stride, double p_keep_ratio) {
+    const uint32_t count = r_gaussians.size();
+    const uint32_t keep = compute_chunk_keep_count(count, p_keep_ratio);
+    if (keep >= count) {
+        return count;
+    }
+
+    LocalVector<float> importance;
+    importance.resize(count);
+    for (uint32_t i = 0; i < count; i++) {
+        importance[i] = gaussian_importance(r_gaussians[i]);
+    }
+
+    LocalVector<uint32_t> keep_indices;
+    select_top_k_indices(importance.ptr(), count, keep, keep_indices);
+
+    // Forward in-place compaction: keep_indices is ascending and keep <= count, so
+    // keep_indices[j] >= j for every j -- writing slot j never clobbers an as-yet
+    // unread source slot.
+    for (uint32_t j = 0; j < keep_indices.size(); j++) {
+        const uint32_t src = keep_indices[j];
+        if (src != j) {
+            r_gaussians[j] = r_gaussians[src];
+        }
+    }
+    r_gaussians.resize(keep);
+
+    if (p_sh_stride > 0u && uint64_t(r_sh_high_order.size()) >= uint64_t(count) * uint64_t(p_sh_stride)) {
+        Vector3 *sh = r_sh_high_order.ptr();
+        for (uint32_t j = 0; j < keep_indices.size(); j++) {
+            const uint32_t src = keep_indices[j];
+            if (src != j) {
+                const uint64_t dst_base = uint64_t(j) * uint64_t(p_sh_stride);
+                const uint64_t src_base = uint64_t(src) * uint64_t(p_sh_stride);
+                for (uint32_t c = 0; c < p_sh_stride; c++) {
+                    sh[dst_base + c] = sh[src_base + c];
+                }
+            }
+        }
+        r_sh_high_order.resize(keep * p_sh_stride);
+    }
+    return keep;
+}
+
+} // namespace ResidentAtlasBudget
+
+#endif // GS_RESIDENT_ATLAS_BUDGET_H

--- a/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
+++ b/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
@@ -461,6 +461,14 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 
 		uint32_t max_chunk_count_per_asset = 0;
 		uint32_t max_chunk_splats = 0;
+		// Hard global budget for the importance-LOD clamp. The per-chunk thinning below keeps
+		// at least one splat from each non-empty chunk for coverage, which can overshoot the
+		// device VRAM target on datasets with many tiny chunks; capping the cumulative kept
+		// count here guarantees the resident atlas never exceeds the budget (Codex #420).
+		// UINT32_MAX == unbounded when the atlas is not being thinned.
+		uint32_t resident_remaining_budget = subset_plan.reduced
+				? uint32_t(MIN<uint64_t>(subset_plan.target_keep, uint64_t(UINT32_MAX)))
+				: UINT32_MAX;
 
 		for (uint32_t asset_index = 0; asset_index < assets.size(); asset_index++) {
 			const ResidentAssetDescriptor &asset = assets[asset_index];
@@ -488,9 +496,9 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 			asset_meta.bounds_center_local[2] = asset_center.z;
 			asset_meta.bounds_radius_local = asset_half.length();
 			asset_meta.chunk_index_base = asset_chunk_index_cpu.size();
-			asset_meta.chunk_index_count = chunk_descriptors.size();
-			asset_meta.lod_ranges[0].base = asset_meta.chunk_index_base;
-			asset_meta.lod_ranges[0].count = asset_meta.chunk_index_count;
+			// chunk_index_count / lod_ranges are finalized AFTER the chunk loop: importance
+			// thinning under the global budget may drop whole chunks (0 kept), so the count
+			// must reflect the chunks actually emitted, not chunk_descriptors.size().
 
 			max_chunk_count_per_asset = MAX<uint32_t>(max_chunk_count_per_asset, chunk_descriptors.size());
 
@@ -516,15 +524,22 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 					return false;
 				}
 
-				// Importance-ordered LOD: when the atlas is over the VRAM budget, keep the
-				// top splats of THIS chunk (by the culler's opacity*scale importance) so every
-				// spatial region survives the thinning -- preserves coverage on real-scan
-				// content. Compacts the gaussian payload and its parallel high-order SH block
-				// in place, so sh_coeffs is taken AFTER compaction.
+				// Importance-ordered LOD: when the atlas is over the VRAM budget, keep the top
+				// splats of THIS chunk (by the culler's opacity*scale importance) so every
+				// spatial region keeps its most important splats -- preserves coverage on
+				// real-scan content while the global budget below bounds the total. Compacts the
+				// gaussian payload and its parallel high-order SH block in place, so sh_coeffs is
+				// taken AFTER compaction.
 				uint32_t chunk_pack_count = descriptor.count;
 				if (subset_plan.reduced) {
 					chunk_pack_count = ResidentAtlasBudget::compact_chunk_by_importance(
-							gaussian_snapshot, sh_high_order_snapshot, sh_high_order, subset_plan.keep_ratio);
+							gaussian_snapshot, sh_high_order_snapshot, sh_high_order,
+							subset_plan.keep_ratio, resident_remaining_budget);
+					if (chunk_pack_count == 0) {
+						// Global VRAM budget exhausted (or this chunk's quota rounded to 0):
+						// drop the chunk rather than emit a zero-splat ChunkMeta.
+						continue;
+					}
 				}
 
 				SHCompressionMetrics sh_metrics;
@@ -559,6 +574,11 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 				max_chunk_splats = MAX(max_chunk_splats, chunk_pack_count);
 			}
 
+			// Finalize the asset's chunk-index range from the chunks actually emitted (some
+			// may have been dropped to 0 splats by the importance-LOD budget above).
+			asset_meta.chunk_index_count = asset_chunk_index_cpu.size() - asset_meta.chunk_index_base;
+			asset_meta.lod_ranges[0].base = asset_meta.chunk_index_base;
+			asset_meta.lod_ranges[0].count = asset_meta.chunk_index_count;
 			asset_meta_cpu.write[asset.dense_asset_id] = asset_meta;
 		}
 

--- a/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
+++ b/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
@@ -423,21 +423,28 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 					resource_state.resident_asset_chunk_index_buffer_size);
 		}
 
-		// Early-out: estimate total packed size across all assets.  If it would
-		// exceed the staging limit, skip the expensive per-chunk packing loop
-		// entirely.  The streaming path should handle datasets this large.
+		// Estimate the total source size, then decide the clamp plan. A default resident
+		// GaussianSplatNode3D has no streaming fallback (resident-only by contract), so an
+		// over-budget atlas is THINNED to fit rather than rejected -- rejecting would black-frame
+		// the node under the #351 single-route invariant. The thinned atlas is hard-capped at
+		// target_keep (<= effective cap <= the 2 GB per-buffer staging limit) by the global budget
+		// below, so it always fits the upload regardless of source size. We only reject a source
+		// beyond a generous COST ceiling: the slow-path pack loop still scans the whole source
+		// once (generation-gated), so an absurdly large single resident asset (use streaming for
+		// that) is bounded here.
 		ResidentAtlasBudget::SubsetPlan subset_plan;
 		{
-			static constexpr uint64_t kMaxResidentUploadBytes = uint64_t(2) * 1024 * 1024 * 1024;
+			static constexpr uint64_t kResidentStagingUploadBytes = uint64_t(2) * 1024 * 1024 * 1024;
+			static constexpr uint64_t kMaxResidentClampSourceBytes = uint64_t(4) * kResidentStagingUploadBytes;
 			uint64_t total_gaussians = 0;
 			for (const ResidentAssetDescriptor &asset : assets) {
 				if (asset.data.is_valid()) {
 					total_gaussians += uint64_t(asset.data->get_count());
 				}
 			}
-			if (total_gaussians * sizeof(PackedGaussian) > kMaxResidentUploadBytes) {
+			if (total_gaussians * sizeof(PackedGaussian) > kMaxResidentClampSourceBytes) {
 				if (r_reason) {
-					*r_reason = "resident_dataset_exceeds_staging_limit";
+					*r_reason = "resident_dataset_exceeds_clamp_source_limit";
 				}
 				// Do NOT clear instance pipeline buffers here — the streaming
 				// orchestrator may have already published its own atlas/cull
@@ -446,9 +453,10 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 				// ever becoming valid.
 				return false;
 			}
-			// Within the hard staging ceiling: decide whether the atlas still fits the
-			// (possibly tighter) device VRAM budget, and if not, the global keep ratio for
-			// the importance-ordered subset packed per chunk below.
+			// Decide whether the atlas fits the device VRAM budget, and if not, the global keep
+			// ratio + target for the importance-ordered subset packed per chunk below. A source
+			// above the staging limit clamps down to target_keep <= staging limit and renders
+			// reduced instead of black-framing.
 			subset_plan = ResidentAtlasBudget::compute_subset_plan(total_gaussians,
 					effective_atlas_cap_bytes, sizeof(PackedGaussian));
 		}

--- a/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
+++ b/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
@@ -501,6 +501,17 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 			// (0 kept), so both the asset's chunk count and the dispatch / auxiliary-buffer sizing
 			// must reflect the chunks actually emitted, not chunk_descriptors.size().
 
+			// Give this asset a share of the keep budget proportional to its splat count so a
+			// later (e.g. currently visible/casting) asset cannot be starved to zero chunks by
+			// an earlier large asset in the stable superset. Visibility-independent, so the atlas
+			// stays stable across visibility flips (Codex #420).
+			uint32_t asset_remaining_budget = resident_remaining_budget;
+			if (subset_plan.reduced) {
+				asset_remaining_budget = ResidentAtlasBudget::resident_asset_budget(subset_plan.target_keep,
+						uint64_t(asset.data->get_count()), subset_plan.source_count, resident_remaining_budget);
+			}
+			const uint32_t asset_budget_start = asset_remaining_budget;
+
 			for (uint32_t chunk_index = 0; chunk_index < chunk_descriptors.size(); chunk_index++) {
 				const ResidentChunkDescriptor &descriptor = chunk_descriptors[chunk_index];
 				LocalVector<Gaussian> gaussian_snapshot;
@@ -533,7 +544,7 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 				if (subset_plan.reduced) {
 					chunk_pack_count = ResidentAtlasBudget::compact_chunk_by_importance(
 							gaussian_snapshot, sh_high_order_snapshot, sh_high_order,
-							subset_plan.keep_ratio, resident_remaining_budget);
+							subset_plan.keep_ratio, asset_remaining_budget);
 					if (chunk_pack_count == 0) {
 						// Global VRAM budget exhausted (or this chunk's quota rounded to 0):
 						// drop the chunk rather than emit a zero-splat ChunkMeta.
@@ -571,6 +582,11 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 				chunk_index_gpu.chunk_id = chunk_meta_cpu.size() - 1;
 				asset_chunk_index_cpu.push_back(chunk_index_gpu);
 				max_chunk_splats = MAX(max_chunk_splats, chunk_pack_count);
+			}
+
+			// Return this asset's unspent budget to the global pool so later assets can use it.
+			if (subset_plan.reduced) {
+				resident_remaining_budget -= (asset_budget_start - asset_remaining_budget);
 			}
 
 			// Finalize the asset's chunk-index range from the chunks actually emitted (some may

--- a/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
+++ b/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
@@ -496,11 +496,10 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 			asset_meta.bounds_center_local[2] = asset_center.z;
 			asset_meta.bounds_radius_local = asset_half.length();
 			asset_meta.chunk_index_base = asset_chunk_index_cpu.size();
-			// chunk_index_count / lod_ranges are finalized AFTER the chunk loop: importance
-			// thinning under the global budget may drop whole chunks (0 kept), so the count
+			// chunk_index_count / lod_ranges AND max_chunk_count_per_asset are finalized AFTER
+			// the chunk loop: importance thinning under the global budget may drop whole chunks
+			// (0 kept), so both the asset's chunk count and the dispatch / auxiliary-buffer sizing
 			// must reflect the chunks actually emitted, not chunk_descriptors.size().
-
-			max_chunk_count_per_asset = MAX<uint32_t>(max_chunk_count_per_asset, chunk_descriptors.size());
 
 			for (uint32_t chunk_index = 0; chunk_index < chunk_descriptors.size(); chunk_index++) {
 				const ResidentChunkDescriptor &descriptor = chunk_descriptors[chunk_index];
@@ -574,11 +573,14 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 				max_chunk_splats = MAX(max_chunk_splats, chunk_pack_count);
 			}
 
-			// Finalize the asset's chunk-index range from the chunks actually emitted (some
-			// may have been dropped to 0 splats by the importance-LOD budget above).
+			// Finalize the asset's chunk-index range from the chunks actually emitted (some may
+			// have been dropped to 0 splats by the importance-LOD budget above), and size
+			// Stage-A dispatch + the visible-chunk/splat-ref/sort buffers from that emitted count
+			// so the clamp shrinks the auxiliary buffers too, not just the atlas (Codex #420).
 			asset_meta.chunk_index_count = asset_chunk_index_cpu.size() - asset_meta.chunk_index_base;
 			asset_meta.lod_ranges[0].base = asset_meta.chunk_index_base;
 			asset_meta.lod_ranges[0].count = asset_meta.chunk_index_count;
+			max_chunk_count_per_asset = MAX<uint32_t>(max_chunk_count_per_asset, asset_meta.chunk_index_count);
 			asset_meta_cpu.write[asset.dense_asset_id] = asset_meta;
 		}
 

--- a/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
+++ b/modules/gaussian_splatting/renderer/resident_instance_contract_publisher.cpp
@@ -8,6 +8,9 @@
 #include "../core/gaussian_splat_scene_director.h"
 #include "../interfaces/gpu_sorting_pipeline.h"
 #include "../resources/color_grading_resource.h"
+#include "resident_atlas_budget.h"
+#include "../core/gs_project_settings.h"
+#include "core/config/project_settings.h"
 #include "servers/rendering/rendering_device.h"
 
 #include <algorithm>
@@ -192,6 +195,18 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 		return false;
 	}
 
+	// Resident atlas VRAM budget (#321 follow-up). A default GaussianSplatNode3D is
+	// resident-only by contract, so an over-large atlas cannot fall back to streaming and
+	// would OOM / device-lost on a low-end GPU. Clamp the packed atlas to the device VRAM
+	// budget (or an explicit project override) and pack an importance-ordered subset below
+	// instead. Unknown/UMA budgets and capable GPUs resolve to the 2 GB staging ceiling, so
+	// the effective cap == the staging ceiling and nothing below changes.
+	const uint64_t device_budget_bytes = rd->get_device_memory_budget();
+	const uint32_t resident_atlas_override_mb = gs::settings::get_uint(ProjectSettings::get_singleton(),
+			"rendering/gaussian_splatting/resident/atlas_vram_budget_override_mb", 0u);
+	const uint64_t effective_atlas_cap_bytes =
+			ResidentAtlasBudget::compute_effective_atlas_cap_bytes(device_budget_bytes, resident_atlas_override_mb);
+
 	const Ref<GaussianData> primary_data = p_renderer->get_scene_state().gaussian_data;
 	const bool has_primary_data = primary_data.is_valid() && primary_data->get_count() > 0;
 
@@ -252,6 +267,14 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 		atlas_generation = _mix_generation(atlas_generation, asset.submission_asset_id);
 		atlas_generation = _mix_generation(atlas_generation, asset.data.is_valid() ? uint64_t(asset.data->get_instance_id()) : 0ULL);
 		atlas_generation = _mix_generation(atlas_generation, asset.data.is_valid() ? asset.data->get_content_revision() : 0ULL);
+	}
+	// Only perturb the atlas hash when the VRAM cap actually differs from the staging
+	// ceiling (low-end device budget or an explicit override). On capable GPUs the cap
+	// equals the ceiling, so the hash stays byte-identical to pre-#321 builds and there is
+	// no one-time repack on deploy. The cap is a stable per-device fixpoint, so once mixed
+	// it does not cause per-frame repacks.
+	if (effective_atlas_cap_bytes != ResidentAtlasBudget::kResidentStagingCeilingBytes) {
+		atlas_generation = _mix_generation(atlas_generation, effective_atlas_cap_bytes);
 	}
 
 	uint64_t instance_generation = 0xbb67ae8584caa73bULL;
@@ -403,6 +426,7 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 		// Early-out: estimate total packed size across all assets.  If it would
 		// exceed the staging limit, skip the expensive per-chunk packing loop
 		// entirely.  The streaming path should handle datasets this large.
+		ResidentAtlasBudget::SubsetPlan subset_plan;
 		{
 			static constexpr uint64_t kMaxResidentUploadBytes = uint64_t(2) * 1024 * 1024 * 1024;
 			uint64_t total_gaussians = 0;
@@ -422,6 +446,11 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 				// ever becoming valid.
 				return false;
 			}
+			// Within the hard staging ceiling: decide whether the atlas still fits the
+			// (possibly tighter) device VRAM budget, and if not, the global keep ratio for
+			// the importance-ordered subset packed per chunk below.
+			subset_plan = ResidentAtlasBudget::compute_subset_plan(total_gaussians,
+					effective_atlas_cap_bytes, sizeof(PackedGaussian));
 		}
 
 		Vector<AssetMetaGPU> asset_meta_cpu;
@@ -487,10 +516,21 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 					return false;
 				}
 
+				// Importance-ordered LOD: when the atlas is over the VRAM budget, keep the
+				// top splats of THIS chunk (by the culler's opacity*scale importance) so every
+				// spatial region survives the thinning -- preserves coverage on real-scan
+				// content. Compacts the gaussian payload and its parallel high-order SH block
+				// in place, so sh_coeffs is taken AFTER compaction.
+				uint32_t chunk_pack_count = descriptor.count;
+				if (subset_plan.reduced) {
+					chunk_pack_count = ResidentAtlasBudget::compact_chunk_by_importance(
+							gaussian_snapshot, sh_high_order_snapshot, sh_high_order, subset_plan.keep_ratio);
+				}
+
 				SHCompressionMetrics sh_metrics;
 				Vector<PackedGaussian> packed_chunk;
 				const Vector3 *sh_coeffs = sh_high_order_snapshot.is_empty() ? nullptr : sh_high_order_snapshot.ptr();
-				pack_gaussians_range(gaussian_snapshot, 0, descriptor.count, packed_chunk, sh_metrics, sh_coeffs,
+				pack_gaussians_range(gaussian_snapshot, 0, chunk_pack_count, packed_chunk, sh_metrics, sh_coeffs,
 						sh_first_order, sh_high_order);
 
 				const uint32_t atlas_base = atlas_gaussian_cpu.size();
@@ -500,7 +540,7 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 
 				ChunkMetaGPU chunk_meta = {};
 				chunk_meta.atlas_base = atlas_base;
-				chunk_meta.splat_count = descriptor.count;
+				chunk_meta.splat_count = chunk_pack_count;
 				const Vector3 chunk_center = descriptor.bounds.get_center();
 				const Vector3 chunk_half = descriptor.bounds.size * 0.5f;
 				chunk_meta.bounds_center_local[0] = chunk_center.x;
@@ -516,7 +556,7 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 				AssetChunkIndexGPU chunk_index_gpu = {};
 				chunk_index_gpu.chunk_id = chunk_meta_cpu.size() - 1;
 				asset_chunk_index_cpu.push_back(chunk_index_gpu);
-				max_chunk_splats = MAX(max_chunk_splats, descriptor.count);
+				max_chunk_splats = MAX(max_chunk_splats, chunk_pack_count);
 			}
 
 			asset_meta_cpu.write[asset.dense_asset_id] = asset_meta;
@@ -555,6 +595,19 @@ bool publish_resident_direct_data_contract(GaussianSplatRenderer *p_renderer, St
 		resource_state.resident_dispatch_chunk_count = atlas_max_chunk_count_per_asset;
 		resource_state.resident_max_chunk_splats = atlas_max_chunk_splats;
 		resource_state.resident_atlas_pack_count++;
+		// VRAM-budget LOD clamp telemetry (observable; never a silent drop). Cached so the
+		// fast instance-only path re-surfaces the same values; the packed count is
+		// resident_atlas_gaussian_count above.
+		resource_state.resident_atlas_reduced = subset_plan.reduced;
+		resource_state.resident_atlas_source_count = uint32_t(subset_plan.source_count);
+		resource_state.resident_atlas_keep_ratio = subset_plan.reduced ? float(subset_plan.keep_ratio) : 1.0f;
+		if (subset_plan.reduced) {
+			WARN_PRINT_ONCE(vformat("[ResidentContract] Atlas exceeds the resident VRAM budget; thinned by "
+					"importance to fit: %d -> %d splats (keep_ratio=%.3f, cap=%d MB). Reduce the asset's splat "
+					"count or render it via GaussianSplatWorld3D streaming for full density.",
+					int(subset_plan.source_count), int(atlas_gaussian_count), subset_plan.keep_ratio,
+					int(subset_plan.cap_bytes >> 20)));
+		}
 	} else {
 		// Atlas unchanged. Reuse the cached size metrics from the last slow-path publish.
 		// Atlas storage buffers (resident_atlas_gaussian_buffer etc.) keep their current

--- a/modules/gaussian_splatting/tests/test_gaussian_splatting.h
+++ b/modules/gaussian_splatting/tests/test_gaussian_splatting.h
@@ -33,6 +33,7 @@
 #include "test_output_compositor_composite_hazard.h"
 #include "test_logger_rate_limit.h"
 #include "test_vram_budget_regulator.h"
+#include "test_resident_atlas_budget.h"
 #include "test_renderer_pipeline.h"
 #include "test_tile_lighting_abi.h"
 #include "test_tile_buffer_resize.h"

--- a/modules/gaussian_splatting/tests/test_resident_atlas_budget.h
+++ b/modules/gaussian_splatting/tests/test_resident_atlas_budget.h
@@ -230,3 +230,27 @@ TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Single global ratio thins mu
     CHECK(keep_b < chunk_b);
     CHECK(double(keep_a) / double(chunk_a) == doctest::Approx(double(keep_b) / double(chunk_b)).epsilon(0.05));
 }
+
+TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Per-asset budget is proportional, floors at 1, and stays under the global cap") {
+    using namespace ResidentAtlasBudget;
+    // target_keep 100 split across two assets (300 + 100 = 400 total) -> 75 / 25.
+    uint32_t global_remaining = 100;
+    const uint32_t a = resident_asset_budget(100, 300, 400, global_remaining);
+    global_remaining -= a;
+    const uint32_t b = resident_asset_budget(100, 100, 400, global_remaining);
+    CHECK(a == 75);
+    CHECK(b == 25);
+    CHECK(a + b <= 100); // the sum never exceeds the global budget
+
+    // A later (e.g. visible) asset still gets its proportional share -- it is NOT starved to 0
+    // by the earlier larger asset, which is the Codex #420 round-3 concern.
+    CHECK(b >= 1u);
+
+    // A tiny asset against a huge total still keeps at least one splat of budget.
+    CHECK(resident_asset_budget(100, 1, 1000000, 100) == 1u);
+    // The proportional share is capped by whatever budget is globally left.
+    CHECK(resident_asset_budget(100, 300, 400, 10) == 10u);
+    // Degenerate inputs are budget 0, never a divide-by-zero.
+    CHECK(resident_asset_budget(100, 0, 400, 100) == 0u);
+    CHECK(resident_asset_budget(100, 300, 0, 100) == 0u);
+}

--- a/modules/gaussian_splatting/tests/test_resident_atlas_budget.h
+++ b/modules/gaussian_splatting/tests/test_resident_atlas_budget.h
@@ -1,0 +1,189 @@
+#pragma once
+
+#include "test_macros.h"
+
+#include "../renderer/resident_atlas_budget.h"
+
+namespace ResidentAtlasBudgetTests {
+
+static constexpr uint64_t k2GB = uint64_t(2) * 1024 * 1024 * 1024;
+static constexpr uint64_t k1GB = uint64_t(1) * 1024 * 1024 * 1024;
+static constexpr uint64_t k8GB = uint64_t(8) * 1024 * 1024 * 1024;
+
+static Gaussian make_g(float p_opacity, float p_scale, float p_marker) {
+    Gaussian g = {};
+    g.opacity = p_opacity;
+    g.scale = Vector3(p_scale, p_scale * 0.5f, p_scale * 0.25f); // max axis == p_scale
+    g.position = Vector3(p_marker, 0.0f, 0.0f); // marker to identify after compaction
+    return g;
+}
+
+} // namespace ResidentAtlasBudgetTests
+
+TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Unknown / below-floor device budget keeps the 2 GB staging cap") {
+    using namespace ResidentAtlasBudget;
+    // device budget unknown (0) -> capacity unknown -> do-no-harm, cap stays staging ceiling.
+    CHECK(compute_effective_atlas_cap_bytes(0, 0) == ResidentAtlasBudgetTests::k2GB);
+    // 200 MiB is below the 256 MiB sane floor -> treated as unknown.
+    CHECK(compute_effective_atlas_cap_bytes(uint64_t(200) * 1024 * 1024, 0) == ResidentAtlasBudgetTests::k2GB);
+    // exactly at the floor is trusted.
+    CHECK(compute_effective_atlas_cap_bytes(kMinTrustedDeviceBudgetBytes, 0) ==
+            uint64_t(double(kMinTrustedDeviceBudgetBytes) * kResidentAtlasHeadroomFraction));
+}
+
+TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Capable GPU is byte-identical to today (staging dominates)") {
+    using namespace ResidentAtlasBudget;
+    // 8 GB device: 0.60*8GB = 4.8 GB, MIN with 2 GB staging => 2 GB (no clamp on capable GPUs).
+    CHECK(compute_effective_atlas_cap_bytes(ResidentAtlasBudgetTests::k8GB, 0) == ResidentAtlasBudgetTests::k2GB);
+}
+
+TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Low-end device budget binds beneath the staging cap") {
+    using namespace ResidentAtlasBudget;
+    // 1 GB device: 0.60*1GB binds (< 2 GB staging).
+    const uint64_t expected = uint64_t(double(ResidentAtlasBudgetTests::k1GB) * kResidentAtlasHeadroomFraction);
+    CHECK(compute_effective_atlas_cap_bytes(ResidentAtlasBudgetTests::k1GB, 0) == expected);
+    CHECK(expected < ResidentAtlasBudgetTests::k2GB);
+}
+
+TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Override forces a clamp and never loosens (MIN semantics)") {
+    using namespace ResidentAtlasBudget;
+    // override forces a clamp even on a huge GPU (the validation lever).
+    CHECK(compute_effective_atlas_cap_bytes(ResidentAtlasBudgetTests::k8GB, 512) == uint64_t(512) * 1024 * 1024);
+    // an override larger than the budget term cannot loosen the cap.
+    const uint64_t budget_cap = uint64_t(double(ResidentAtlasBudgetTests::k1GB) * kResidentAtlasHeadroomFraction);
+    CHECK(compute_effective_atlas_cap_bytes(ResidentAtlasBudgetTests::k1GB, 4096) == budget_cap);
+}
+
+TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Subset plan: full atlas fits -> not reduced") {
+    using namespace ResidentAtlasBudget;
+    const SubsetPlan plan = compute_subset_plan(100000, ResidentAtlasBudgetTests::k2GB, 144);
+    CHECK_FALSE(plan.reduced);
+    CHECK(plan.keep_ratio == doctest::Approx(1.0));
+    CHECK(plan.target_keep == 100000);
+}
+
+TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Subset plan: over budget -> reduced, target never exceeds cap") {
+    using namespace ResidentAtlasBudget;
+    const uint64_t cap = compute_effective_atlas_cap_bytes(ResidentAtlasBudgetTests::k1GB, 0);
+    const SubsetPlan plan = compute_subset_plan(20000000, cap, 144);
+    CHECK(plan.reduced);
+    CHECK(plan.target_keep < plan.source_count);
+    CHECK(plan.keep_ratio < 1.0);
+    // The soft splat target must never imply more bytes than the cap.
+    CHECK(plan.target_keep * uint64_t(144) <= cap);
+}
+
+TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Per-chunk keep count floors at 1 and respects the ratio") {
+    using namespace ResidentAtlasBudget;
+    CHECK(compute_chunk_keep_count(0, 0.5) == 0);          // empty stays empty
+    CHECK(compute_chunk_keep_count(10, 1.0) == 10);        // ratio >= 1 keeps all
+    CHECK(compute_chunk_keep_count(10, 1.5) == 10);        // clamped to count
+    CHECK(compute_chunk_keep_count(10, 0.0001) == 1);      // floor: never delete a region
+    CHECK(compute_chunk_keep_count(10, 0.0) == 1);
+    CHECK(compute_chunk_keep_count(10, 0.4) == 4);         // round(4.0)
+    CHECK(compute_chunk_keep_count(10, 0.45) == 5);        // round(4.5)
+}
+
+TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Top-K selection: highest importance, ascending, deterministic ties") {
+    using namespace ResidentAtlasBudget;
+    const float importance[5] = { 0.01f, 0.90f, 0.25f, 0.04f, 2.00f };
+    LocalVector<uint32_t> keep;
+    select_top_k_indices(importance, 5, 2, keep);
+    REQUIRE(keep.size() == 2);
+    CHECK(keep[0] == 1u); // returned ascending
+    CHECK(keep[1] == 4u); // indices of the two largest (0.90, 2.00)
+
+    // determinism: identical input -> identical output.
+    LocalVector<uint32_t> keep2;
+    select_top_k_indices(importance, 5, 2, keep2);
+    REQUIRE(keep2.size() == 2);
+    CHECK(keep2[0] == keep[0]);
+    CHECK(keep2[1] == keep[1]);
+
+    // ties broken by ascending index.
+    const float tied[3] = { 1.0f, 1.0f, 1.0f };
+    LocalVector<uint32_t> keep_tied;
+    select_top_k_indices(tied, 3, 2, keep_tied);
+    REQUIRE(keep_tied.size() == 2);
+    CHECK(keep_tied[0] == 0u);
+    CHECK(keep_tied[1] == 1u);
+
+    // keep >= count returns the identity range.
+    LocalVector<uint32_t> keep_all;
+    select_top_k_indices(importance, 5, 9, keep_all);
+    REQUIRE(keep_all.size() == 5);
+    CHECK(keep_all[0] == 0u);
+    CHECK(keep_all[4] == 4u);
+}
+
+TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Chunk compaction keeps top importance and SH stays parallel") {
+    using namespace ResidentAtlasBudget;
+    using namespace ResidentAtlasBudgetTests;
+
+    LocalVector<Gaussian> gaussians;
+    gaussians.push_back(make_g(0.1f, 0.1f, 0.0f)); // idx0 importance ~0.010
+    gaussians.push_back(make_g(0.9f, 1.0f, 1.0f)); // idx1 importance ~0.900
+    gaussians.push_back(make_g(0.5f, 0.5f, 2.0f)); // idx2 importance ~0.250
+    gaussians.push_back(make_g(0.2f, 0.2f, 3.0f)); // idx3 importance ~0.040
+    gaussians.push_back(make_g(1.0f, 2.0f, 4.0f)); // idx4 importance ~2.000
+
+    const uint32_t stride = 15;
+    LocalVector<Vector3> sh;
+    sh.resize(5 * stride);
+    for (uint32_t i = 0; i < 5; i++) {
+        for (uint32_t c = 0; c < stride; c++) {
+            sh[i * stride + c] = Vector3(float(i), float(c), 0.0f); // x encodes source index
+        }
+    }
+
+    // keep_ratio 0.4 over count 5 -> round(2.0) == 2 kept (the two highest: idx1, idx4).
+    const uint32_t kept = compact_chunk_by_importance(gaussians, sh, stride, 0.4);
+    REQUIRE(kept == 2);
+    REQUIRE(gaussians.size() == 2);
+    REQUIRE(sh.size() == 2u * stride);
+
+    // Ascending-index compaction => slot0 is source idx1, slot1 is source idx4.
+    CHECK(gaussians[0].position.x == doctest::Approx(1.0f));
+    CHECK(gaussians[1].position.x == doctest::Approx(4.0f));
+    // SH block of each kept gaussian must match its original source block.
+    CHECK(sh[0 * stride + 0].x == doctest::Approx(1.0f));
+    CHECK(sh[0 * stride + 7].x == doctest::Approx(1.0f));
+    CHECK(sh[1 * stride + 0].x == doctest::Approx(4.0f));
+    CHECK(sh[1 * stride + 7].x == doctest::Approx(4.0f));
+    CHECK(sh[1 * stride + 7].y == doctest::Approx(7.0f)); // coefficient slot preserved
+}
+
+TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Compaction is a no-op when the ratio keeps everything") {
+    using namespace ResidentAtlasBudget;
+    using namespace ResidentAtlasBudgetTests;
+
+    LocalVector<Gaussian> gaussians;
+    for (uint32_t i = 0; i < 4; i++) {
+        gaussians.push_back(make_g(0.5f, 1.0f, float(i)));
+    }
+    LocalVector<Vector3> sh; // no high-order SH (stride 0) is a valid path
+    const uint32_t kept = compact_chunk_by_importance(gaussians, sh, 0, 1.0);
+    CHECK(kept == 4);
+    REQUIRE(gaussians.size() == 4);
+    CHECK(gaussians[0].position.x == doctest::Approx(0.0f));
+    CHECK(gaussians[3].position.x == doctest::Approx(3.0f));
+}
+
+TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Single global ratio thins multiple chunks proportionally within cap") {
+    using namespace ResidentAtlasBudget;
+    // Two assets/chunks of different sizes share ONE global keep_ratio.
+    const uint64_t cap = compute_effective_atlas_cap_bytes(ResidentAtlasBudgetTests::k1GB, 0);
+    const SubsetPlan plan = compute_subset_plan(20000000, cap, 144);
+    REQUIRE(plan.reduced);
+
+    const uint32_t chunk_a = 1000;
+    const uint32_t chunk_b = 250;
+    const uint32_t keep_a = compute_chunk_keep_count(chunk_a, plan.keep_ratio);
+    const uint32_t keep_b = compute_chunk_keep_count(chunk_b, plan.keep_ratio);
+    // Same ratio applied to both -> proportional thinning, each >= 1, each < its source.
+    CHECK(keep_a >= 1u);
+    CHECK(keep_b >= 1u);
+    CHECK(keep_a < chunk_a);
+    CHECK(keep_b < chunk_b);
+    CHECK(double(keep_a) / double(chunk_a) == doctest::Approx(double(keep_b) / double(chunk_b)).epsilon(0.05));
+}

--- a/modules/gaussian_splatting/tests/test_resident_atlas_budget.h
+++ b/modules/gaussian_splatting/tests/test_resident_atlas_budget.h
@@ -137,8 +137,10 @@ TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Chunk compaction keeps top i
     }
 
     // keep_ratio 0.4 over count 5 -> round(2.0) == 2 kept (the two highest: idx1, idx4).
-    const uint32_t kept = compact_chunk_by_importance(gaussians, sh, stride, 0.4);
+    uint32_t budget = 100;
+    const uint32_t kept = compact_chunk_by_importance(gaussians, sh, stride, 0.4, budget);
     REQUIRE(kept == 2);
+    CHECK(budget == 98); // budget decremented by the kept count
     REQUIRE(gaussians.size() == 2);
     REQUIRE(sh.size() == 2u * stride);
 
@@ -162,11 +164,52 @@ TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Compaction is a no-op when t
         gaussians.push_back(make_g(0.5f, 1.0f, float(i)));
     }
     LocalVector<Vector3> sh; // no high-order SH (stride 0) is a valid path
-    const uint32_t kept = compact_chunk_by_importance(gaussians, sh, 0, 1.0);
+    uint32_t budget = 100;
+    const uint32_t kept = compact_chunk_by_importance(gaussians, sh, 0, 1.0, budget);
     CHECK(kept == 4);
+    CHECK(budget == 96); // 4 kept
     REQUIRE(gaussians.size() == 4);
     CHECK(gaussians[0].position.x == doctest::Approx(0.0f));
     CHECK(gaussians[3].position.x == doctest::Approx(3.0f));
+}
+
+TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Global budget caps cumulative kept across many tiny chunks") {
+    using namespace ResidentAtlasBudget;
+    using namespace ResidentAtlasBudgetTests;
+    // Codex #420: many one-splat chunks each floor to 1 splat; without the global budget the
+    // total would be the full count and defeat the VRAM cap. With a budget of 3, only 3 survive.
+    uint32_t budget = 3;
+    uint32_t total_kept = 0;
+    const double tiny_ratio = 0.09; // round(1 * 0.09) == 0 -> floored to 1 per chunk
+    for (uint32_t c = 0; c < 10; c++) {
+        LocalVector<Gaussian> g;
+        g.push_back(make_g(0.5f, 1.0f, float(c)));
+        LocalVector<Vector3> sh;
+        total_kept += compact_chunk_by_importance(g, sh, 0, tiny_ratio, budget);
+    }
+    CHECK(total_kept == 3); // never exceeds the budget
+    CHECK(budget == 0);     // fully consumed, remaining chunks dropped to 0
+}
+
+TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Importance uses scale magnitude (negative scales survive)") {
+    using namespace ResidentAtlasBudget;
+    using namespace ResidentAtlasBudgetTests;
+    // A large negative-scale splat must out-rank a tiny positive-scale one (magnitude, not sign).
+    Gaussian big_neg = make_g(1.0f, 0.0f, 0.0f);
+    big_neg.scale = Vector3(-5.0f, -4.0f, -3.0f);
+    Gaussian small_pos = make_g(1.0f, 0.1f, 1.0f); // max |scale| == 0.1
+    CHECK(gaussian_importance(big_neg) > gaussian_importance(small_pos));
+
+    // Under a keep-1-of-2 budget the big negative-scale splat is the survivor.
+    LocalVector<Gaussian> g;
+    g.push_back(small_pos); // index 0, marker 1.0
+    g.push_back(big_neg);   // index 1, marker 0.0
+    LocalVector<Vector3> sh;
+    uint32_t budget = 1;
+    const uint32_t kept = compact_chunk_by_importance(g, sh, 0, 0.5, budget);
+    REQUIRE(kept == 1);
+    CHECK(g[0].position.x == doctest::Approx(0.0f)); // big_neg's marker
+    CHECK(budget == 0);
 }
 
 TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Single global ratio thins multiple chunks proportionally within cap") {

--- a/modules/gaussian_splatting/tests/test_resident_atlas_budget.h
+++ b/modules/gaussian_splatting/tests/test_resident_atlas_budget.h
@@ -4,6 +4,8 @@
 
 #include "../renderer/resident_atlas_budget.h"
 
+#include <limits>
+
 namespace ResidentAtlasBudgetTests {
 
 static constexpr uint64_t k2GB = uint64_t(2) * 1024 * 1024 * 1024;
@@ -253,4 +255,45 @@ TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Per-asset budget is proporti
     // Degenerate inputs are budget 0, never a divide-by-zero.
     CHECK(resident_asset_budget(100, 0, 400, 100) == 0u);
     CHECK(resident_asset_budget(100, 300, 0, 100) == 0u);
+}
+
+TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Importance is always finite (no selection UB on NaN/Inf data)") {
+    using namespace ResidentAtlasBudget;
+    using namespace ResidentAtlasBudgetTests;
+    const float qnan = std::numeric_limits<float>::quiet_NaN();
+    const float inf = std::numeric_limits<float>::infinity();
+
+    Gaussian partial_nan = make_g(1.0f, 1.0f, 0.0f);
+    partial_nan.scale = Vector3(qnan, 1.0f, 1.0f); // one axis NaN: MAX may mask it -> finite
+    Gaussian all_nan = make_g(1.0f, 1.0f, 1.0f);
+    all_nan.scale = Vector3(qnan, qnan, qnan); // size_factor NaN -> importance non-finite -> floored
+    Gaussian inf_scale = make_g(1.0f, 1.0f, 2.0f);
+    inf_scale.scale = Vector3(inf, 1.0f, 1.0f); // Inf -> non-finite -> floored
+    Gaussian nan_opacity = make_g(qnan, 1.0f, 3.0f); // NaN opacity -> non-finite -> floored
+    Gaussian normal = make_g(0.5f, 0.5f, 4.0f);
+
+    // The core guarantee: importance is ALWAYS finite, so the strict-weak-ordering comparator
+    // in select_top_k_indices never sees a non-finite value (which would be UB).
+    CHECK(Math::is_finite(gaussian_importance(partial_nan)));
+    CHECK(Math::is_finite(gaussian_importance(all_nan)));
+    CHECK(Math::is_finite(gaussian_importance(inf_scale)));
+    CHECK(Math::is_finite(gaussian_importance(nan_opacity)));
+    // Inputs that actually compute a non-finite importance are floored to the minimum.
+    CHECK(gaussian_importance(all_nan) == doctest::Approx(0.0001f));
+    CHECK(gaussian_importance(inf_scale) == doctest::Approx(0.0001f));
+    CHECK(gaussian_importance(nan_opacity) == doctest::Approx(0.0001f));
+    CHECK(gaussian_importance(normal) > 0.0001f);
+
+    // Selection over a mix of floored-degenerate + finite splats is deterministic and keeps
+    // the finite one.
+    LocalVector<Gaussian> g;
+    g.push_back(all_nan);     // index 0, marker 1.0 -> floored
+    g.push_back(normal);      // index 1, marker 4.0 -> highest finite importance
+    g.push_back(nan_opacity); // index 2, marker 3.0 -> floored
+    LocalVector<Vector3> sh;
+    uint32_t budget = 1;
+    const uint32_t kept = compact_chunk_by_importance(g, sh, 0, 1.0 / 3.0, budget); // keep 1 of 3
+    REQUIRE(kept == 1);
+    CHECK(g[0].position.x == doctest::Approx(4.0f)); // the finite splat survives
+    CHECK(budget == 0);
 }

--- a/modules/gaussian_splatting/tests/test_resident_atlas_budget.h
+++ b/modules/gaussian_splatting/tests/test_resident_atlas_budget.h
@@ -75,6 +75,21 @@ TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Subset plan: over budget -> 
     CHECK(plan.target_keep * uint64_t(144) <= cap);
 }
 
+TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] A source above the staging limit thins to fit, not reject") {
+    using namespace ResidentAtlasBudget;
+    // Unknown/UMA device budget => cap stays at the 2 GB staging ceiling.
+    const uint64_t cap = compute_effective_atlas_cap_bytes(0, 0);
+    CHECK(cap == ResidentAtlasBudgetTests::k2GB);
+    // A source ~3x the staging capacity (well over 2 GB) must still produce a thinned plan whose
+    // target fits the per-buffer staging upload -- so a direct resident node degrades instead of
+    // black-framing.
+    const uint64_t over_staging_splats = (cap / 144u) * 3u;
+    const SubsetPlan plan = compute_subset_plan(over_staging_splats, cap, 144);
+    CHECK(plan.reduced);
+    CHECK(plan.target_keep < plan.source_count);
+    CHECK(plan.target_keep * uint64_t(144) <= cap); // thinned atlas fits the 2 GB upload
+}
+
 TEST_CASE("[GaussianSplatting][ResidentAtlasBudget] Per-chunk keep count floors at 1 and respects the ratio") {
     using namespace ResidentAtlasBudget;
     CHECK(compute_chunk_keep_count(0, 0.5) == 0);          // empty stays empty


### PR DESCRIPTION
## Problem

A default `GaussianSplatNode3D` is **resident-only by contract**
(`nodes/gaussian_splat_node_3d.cpp:2451`; streaming is opt-in only via
`GaussianSplatWorld3D`). The resident publisher uploaded the **entire** packed
atlas (`total_gaussians * sizeof(PackedGaussian)`), gated only by a hardcoded
**2 GB *staging* limit** — it never consulted real device VRAM (the `#321`
`get_device_memory_budget()` query is used only by the streaming regulator). On a
low-end GPU this OOMs / device-losts. And because of the `#351` single-route
invariant, a resident publish reject **hard-skips the frame to black** rather than
falling back to streaming. This is the most likely alpha crash on low-end GPUs.

## Fix

Clamp the packed atlas to the device VRAM budget (or an explicit project override)
and, when it would not fit, pack an **importance-ordered subset** (a coarse LOD) so
the node keeps rendering at reduced quality instead of crashing / black-framing.
The publish **returns `true` with a smaller atlas** (never a reject), and the
reduction is **observable** (one-time `WARN` + render-stats telemetry) — never a
silent splat drop.

- **Effective cap** = `MIN(2 GB staging, 0.60 · device_budget, override_mb)`
  - device budget `0` / below the 256 MiB sane-floor ⇒ capacity unknown ⇒ cap stays
    at the staging ceiling (do-no-harm on UMA/iGPU/software/non-Vulkan).
  - On any GPU ≳3.3 GB the `0.60·budget` term doesn't bind ⇒ **capable GPUs are
    byte-identical to today** (effective cap == ceiling ⇒ no atlas-hash perturbation,
    no thinning).
  - `rendering/gaussian_splatting/resident/atlas_vram_budget_override_mb` (default
    `0` = off); `>0` forces the clamp (explicit low-end cap + validation lever).
- **Per-chunk proportional thinning** by the culler's own `opacity·max(scale)`
  importance (`interfaces/gpu_culler.cpp:291-293`) — preserves spatial coverage on
  real-scan content (vs a global top-K deleting whole low-opacity surfaces).
  View-independent and deterministic ⇒ stable atlas, no per-frame churn / flicker.
- `max_splats` keeps its current visible/sort-only meaning (default 1M ⇒ not
  overloaded to thin the atlas, which would be a global default-quality lowering).

New pure, host-testable helpers in `renderer/resident_atlas_budget.h`. **No new GPU
RIDs** (reuses the `resident_atlas_*` buffers + free paths) ⇒ no lifetime-gate
exposure.

## Risk

**R2 (renderer).** Inert on capable GPUs (cap == staging ceiling); only the
override / a low-end device budget activates thinning.

## Evidence

- **doctest** `*ResidentAtlasBudget*`: **11/11 cases, 54/54 assertions** — cap math,
  subset plan, per-chunk keep floor, top-K + tie-break, compaction + SH parity,
  determinism, multi-asset single-ratio.
- **GPU harness** (RTX 3090) `RendererPipeline`+`Lifetime`+`CompositorHazard`:
  **9/9 cases, 51/51 assertions, 0 RID leak** — 24 GB ⇒ cap = 2 GB ceiling ⇒ clamp
  inert ⇒ no regression.
- **Forced-clamp runtime proof** (RTX 3090): override ⇒ publisher thinned
  **80000 → 7281** splats by importance, `WARN` fired, valid contract published,
  cull+sort ran on the thinned atlas (`visible = 7281`). A control run with the
  override **off** confirmed identical pipeline behavior (and that an unrelated
  raster-skip is this CI session lacking a window surface, not the change).

## Not covered here

Real-scan pixel visual on **Grandma's House** — the automated session has no
presentable desktop surface (raster skipped regardless of the change), so coherent
pixels can't be captured here. Recommend running it on a real display session with
the override set before merge.

Base SHA: `dafb9bf32f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
