### PR TITLE
gaussian_splatting: quiesce pack threads before re-init persistent-buffer teardown

### DIFF
--- a/modules/gaussian_splatting/core/gaussian_streaming.cpp
+++ b/modules/gaussian_splatting/core/gaussian_streaming.cpp
@@ -1162,6 +1162,16 @@ void GaussianStreamingSystem::_bind_methods() {
 void GaussianStreamingSystem::initialize(Ref<::GaussianData> p_data) {
     _connect_project_settings();
     _layout_hint_reset_state(this);
+    // Re-init must quiesce the async upload path BEFORE touching any state. A
+    // prior initialize() may have left pack/upload worker threads running and
+    // uploads pending; tearing down chunks/atlas and freeing persistent_buffer
+    // below while a worker is mid-flight is a use-after-free. Mirror the
+    // destructor ordering (_stop_pack_threads -> _clear_pending_uploads). Both
+    // are idempotent and device-independent, so this is a no-op on first init.
+    // _clear_pending_uploads() rolls back against the still-valid prior
+    // chunk/atlas state, so it must run before the chunks/pending resets below.
+    _stop_pack_threads();
+    _clear_pending_uploads();
     streaming_initialized = false;
     last_streaming_update_usec = 0;
     last_streaming_frame_delta_seconds = ESTIMATED_FRAME_DELTA_60FPS;
@@ -1381,6 +1391,14 @@ void GaussianStreamingSystem::initialize_with_device(Ref<::GaussianData> p_data,
 void GaussianStreamingSystem::initialize_empty(RenderingDevice *p_device) {
     _connect_project_settings();
     _layout_hint_reset_state(this);
+    // Re-init must quiesce the async upload path BEFORE touching any state.
+    // See initialize() for the full rationale: a mid-flight pack/upload worker
+    // racing the chunks/atlas/persistent_buffer teardown below is a
+    // use-after-free. Mirror the destructor ordering; both calls are idempotent
+    // and device-independent (no-op on first init), and _clear_pending_uploads()
+    // must run before the chunks/pending resets so its rollback sees valid state.
+    _stop_pack_threads();
+    _clear_pending_uploads();
     streaming_initialized = false;
     last_streaming_update_usec = 0;
     last_streaming_frame_delta_seconds = ESTIMATED_FRAME_DELTA_60FPS;

--- a/modules/gaussian_splatting/core/gaussian_streaming.cpp
+++ b/modules/gaussian_splatting/core/gaussian_streaming.cpp
@@ -1242,8 +1242,9 @@ void GaussianStreamingSystem::initialize(Ref<::GaussianData> p_data) {
         RenderingDevice *rd = primary_device_override ? primary_device_override
                 : (last_upload_device ? last_upload_device
                         : (manager ? manager->get_primary_rendering_device() : nullptr));
-        // Clear-to-empty re-init path: drain submitted GPU uploads before
-        // freeing the registry meta buffers, same as the main path below.
+        // Clear-to-empty re-init path: drain local-upload-device in-flight work
+        // before freeing the registry meta buffers (no-op on the main device,
+        // where free() defers disposal safely — see the main path below).
         gs_device_utils::safe_submit_and_sync(rd);
         global_atlas_registry.cleanup(rd);
         atlas_allocator.clear();
@@ -1279,12 +1280,19 @@ void GaussianStreamingSystem::initialize(Ref<::GaussianData> p_data) {
             : (last_upload_device ? last_upload_device
                     : (manager ? manager->get_primary_rendering_device() : nullptr));
     last_upload_device = rd;
-    // Drain already-submitted GPU uploads before freeing the persistent buffer
-    // (and the registry meta buffers). Stopping the pack threads + clearing the
-    // queued uploads above prevents NEW work, but uploads already submitted to
-    // the device with a frame-delayed retirement still reference persistent_buffer;
-    // sync so they complete before the RID is freed. Mirrors the grow path
-    // (_grow_persistent_buffer), which also safe_submit_and_sync's before release.
+    // Re-init buffer-teardown safety has two parts:
+    //   (1) Worker race: _stop_pack_threads() + _clear_pending_uploads() above
+    //       prevent any NEW upload from being issued against persistent_buffer.
+    //   (2) In-flight uploads: safe_submit_and_sync(rd) drains submitted work on
+    //       a LOCAL upload device before the free (it is a deliberate no-op on the
+    //       main device, per interfaces/sync_policy.h). On the MAIN device no
+    //       explicit wait is needed or wanted: RenderingDevice::free() is
+    //       render-thread-only and DEFERS disposal until the frame index recycles
+    //       after the GPU completes (servers/rendering/rendering_device.cpp:6071,
+    //       "disposed next time this frame index is processed ... safe to do it"),
+    //       and the already-queued buffer_update runs against the still-live
+    //       resource. Forcing a main-device sync here would violate the
+    //       "never stall the main thread on the GPU" rule (renderer/AGENTS.md).
     gs_device_utils::safe_submit_and_sync(rd);
     global_atlas_registry.cleanup(rd);
     _release_persistent_buffer(rd, "initialize");
@@ -1487,7 +1495,8 @@ void GaussianStreamingSystem::initialize_empty(RenderingDevice *p_device) {
             : (last_upload_device ? last_upload_device
                     : (manager ? manager->get_primary_rendering_device() : nullptr));
     last_upload_device = rd;
-    // See initialize(): drain submitted GPU uploads before freeing the buffer.
+    // See initialize() for the two-part rationale: drain local-upload-device
+    // in-flight work (no-op on the main device, where free() defers disposal).
     gs_device_utils::safe_submit_and_sync(rd);
     global_atlas_registry.cleanup(rd);
     _release_persistent_buffer(rd, "initialize_empty");

--- a/modules/gaussian_splatting/core/gaussian_streaming.cpp
+++ b/modules/gaussian_splatting/core/gaussian_streaming.cpp
@@ -1276,6 +1276,13 @@ void GaussianStreamingSystem::initialize(Ref<::GaussianData> p_data) {
             : (last_upload_device ? last_upload_device
                     : (manager ? manager->get_primary_rendering_device() : nullptr));
     last_upload_device = rd;
+    // Drain already-submitted GPU uploads before freeing the persistent buffer
+    // (and the registry meta buffers). Stopping the pack threads + clearing the
+    // queued uploads above prevents NEW work, but uploads already submitted to
+    // the device with a frame-delayed retirement still reference persistent_buffer;
+    // sync so they complete before the RID is freed. Mirrors the grow path
+    // (_grow_persistent_buffer), which also safe_submit_and_sync's before release.
+    gs_device_utils::safe_submit_and_sync(rd);
     global_atlas_registry.cleanup(rd);
     _release_persistent_buffer(rd, "initialize");
 
@@ -1477,6 +1484,8 @@ void GaussianStreamingSystem::initialize_empty(RenderingDevice *p_device) {
             : (last_upload_device ? last_upload_device
                     : (manager ? manager->get_primary_rendering_device() : nullptr));
     last_upload_device = rd;
+    // See initialize(): drain submitted GPU uploads before freeing the buffer.
+    gs_device_utils::safe_submit_and_sync(rd);
     global_atlas_registry.cleanup(rd);
     _release_persistent_buffer(rd, "initialize_empty");
 

--- a/modules/gaussian_splatting/core/gaussian_streaming.cpp
+++ b/modules/gaussian_splatting/core/gaussian_streaming.cpp
@@ -1242,6 +1242,9 @@ void GaussianStreamingSystem::initialize(Ref<::GaussianData> p_data) {
         RenderingDevice *rd = primary_device_override ? primary_device_override
                 : (last_upload_device ? last_upload_device
                         : (manager ? manager->get_primary_rendering_device() : nullptr));
+        // Clear-to-empty re-init path: drain submitted GPU uploads before
+        // freeing the registry meta buffers, same as the main path below.
+        gs_device_utils::safe_submit_and_sync(rd);
         global_atlas_registry.cleanup(rd);
         atlas_allocator.clear();
         chunks.clear();


### PR DESCRIPTION
initialize() and initialize_empty() reset streaming state — including
chunks.clear(), atlas cleanup, and _release_persistent_buffer() — WITHOUT
first stopping the async pack/upload worker threads or clearing pending
uploads. The destructor (~line 923) correctly does _stop_pack_threads()
then _clear_pending_uploads() before any free, but the in-place re-init
paths did not. A re-initialize while a prior init's pack/upload worker is
mid-flight could issue buffer_update/submit against the persistent_buffer
being freed on the main thread — a use-after-free.

Fix: mirror the destructor ordering at the top of both re-init paths,
immediately after _layout_hint_reset_state() and before any state
mutation. Both calls are idempotent and device-independent
(stop_pack_threads only joins when threads are running; clear_pending_uploads
takes no device — the destructor already calls it before resolving the RD),
so this is a no-op on first init. _clear_pending_uploads() rolls back against
the still-valid prior chunk/atlas state, so it must run before the
chunks/pending resets that follow.

Surfaced by a two-audit re-verification (Claude + Codex independently
confirmed the missing guard and the fix ordering; Codex verified
stop_pack_threads idempotency).

Risk: R2 (streaming). Evidence: guards green locally
(python tests/ci/run_module_tests.py --guard-only — 108 tests OK, all
contract guards intact). CI build + GPU harness + visual gate validates.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
