### PR TITLE
gaussian_splatting: remove dead StreamingChunk::gpu_buffer field

### DIFF
--- a/modules/gaussian_splatting/core/gaussian_streaming.cpp
+++ b/modules/gaussian_splatting/core/gaussian_streaming.cpp
@@ -931,12 +931,6 @@ GaussianStreamingSystem::~GaussianStreamingSystem() {
     _release_persistent_buffer(rd, "destructor");
     global_atlas_registry.cleanup(rd);
 
-    for (auto &chunk : chunks) {
-        if (chunk.gpu_buffer.is_valid() && rd) {
-            rd->free(chunk.gpu_buffer);
-        }
-    }
-
     // Clean up quantization buffer
     _release_quantization_buffer(rd, "destructor", false);
 }

--- a/modules/gaussian_splatting/core/streaming_asset_types.h
+++ b/modules/gaussian_splatting/core/streaming_asset_types.h
@@ -53,7 +53,6 @@ struct StreamingChunk {
     uint32_t start_idx = 0;
     uint32_t count = 0;
     bool source_index_remapped = false;
-    RID gpu_buffer;
     Vector3 center;
     AABB bounds;
     float max_radius = 0.0f;


### PR DESCRIPTION
StreamingChunk::gpu_buffer (a per-chunk RID) is never assigned anywhere in
the module — resident chunks live inside the shared persistent_buffer via
atlas buffer_slot offsets, not per-chunk buffers. Its only references were
the declaration and an unreachable free-loop in the destructor (the loop
could never fire because the RID is always null). Verified no writer exists
repo-wide (Claude + Codex audits and a direct grep all agree).

This is a runtime-only struct: the on-disk bake format is the separate
StreamingChunkBakeRecord (static_assert sizeof==48), so removing this field
has no ABI/serialization impact.

Risk: R2 (streaming), but pure dead-code deletion — no behavior change.
Evidence: guards green (python tests/ci/run_module_tests.py --guard-only,
108 tests OK incl. gaussian-layout-check).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
