### PR TITLE
gaussian_splatting: remove dead renderer functions (sweep)

### DIFF
--- a/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
+++ b/modules/gaussian_splatting/renderer/render_pipeline_stages.cpp
@@ -225,10 +225,6 @@ static float _get_float_setting(ProjectSettings *p_settings, const StringName &p
 	return gs::settings::get_float(p_settings, p_name, p_fallback);
 }
 
-static int _get_int_setting(ProjectSettings *p_settings, const StringName &p_name, int p_fallback) {
-	return static_cast<int>(gs::settings::get_uint(p_settings, p_name, static_cast<uint32_t>(p_fallback)));
-}
-
 static _FORCE_INLINE_ uint64_t _hash_u64(uint64_t p_value, uint64_t p_seed);
 static _FORCE_INLINE_ uint64_t _hash_float_bits(float p_value, uint64_t p_seed);
 static _FORCE_INLINE_ uint64_t _hash_bool(bool p_value, uint64_t p_seed);

--- a/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_streaming_orchestrator.cpp
@@ -863,52 +863,6 @@ void RenderStreamingOrchestrator::consume_visible_lod_selection_for_residency(
 	p_streaming_system->finalize_residency_requests();
 }
 
-bool RenderStreamingOrchestrator::should_throttle_streaming_rebuild(uint32_t p_chunks_loaded, uint32_t p_chunks_evicted,
-		uint32_t p_visible_evicted, uint64_t p_current_frame) {
-	GaussianSplatRenderer::FrameStateProvider state_provider(renderer);
-	GaussianSplatRenderer::IFrameMutationAccess &state_mut = state_provider;
-	StreamingState &streaming_state = state_mut.get_streaming_state_mut();
-
-	uint32_t total_chunks_changed = p_chunks_loaded + p_chunks_evicted;
-
-	// Only throttle if:
-	// 1. We have a valid cache to use
-	// 2. Changes are small (below threshold)
-	// 3. We rebuilt recently
-	if (!streaming_state.cached_streamed_indices_valid) {
-		return false;
-	}
-
-	// CRITICAL FIX: Never throttle when chunks have JUST loaded!
-	// The previous logic had a bug where:
-	// - Frame N: Chunk 1 loads, cache rebuilt with chunk 1 only
-	// - Frame N+1: Chunk 0 loads, but throttled (within MIN_FRAMES window)
-	// - Frame N+30+: No more chunks_loaded events, cache NEVER rebuilt!
-	// This caused chunk 0's indices to be permanently missing.
-	//
-	// Fix: Only throttle evictions, not loads. When chunks load, we MUST
-	// update the cache immediately to include the new data.
-	if (p_chunks_loaded > 0) {
-		return false; // Never throttle loads - new data must be visible immediately!
-	}
-
-	bool is_small_change = total_chunks_changed > 0 &&
-			total_chunks_changed <= StreamingState::SMALL_CHANGE_THRESHOLD;
-	uint64_t frames_since_rebuild = p_current_frame - streaming_state.last_rebuild_frame;
-
-	if (is_small_change && frames_since_rebuild < StreamingState::MIN_FRAMES_BETWEEN_SMALL_REBUILDS) {
-		// Log throttle decision periodically
-		if (p_current_frame - streaming_state.last_throttle_log_frame >= StreamingState::LOG_THROTTLE_FRAMES) {
-			GS_LOG_STREAMING_DEBUG(vformat("[PERF-THROTTLE] Skipping rebuild (changed=%d, frames_since=%d)",
-					total_chunks_changed, frames_since_rebuild));
-			streaming_state.last_throttle_log_frame = p_current_frame;
-		}
-		return true;
-	}
-
-	return false;
-}
-
 bool RenderStreamingOrchestrator::ensure_instance_streaming_system(const GaussianSplatRenderer::FrameBackendPlan &p_backend_plan) {
 	GaussianSplatRenderer::FrameStateProvider state_provider(renderer);
 	GaussianSplatRenderer::IFrameMutationAccess &state_mut = state_provider;

--- a/modules/gaussian_splatting/renderer/render_streaming_orchestrator.h
+++ b/modules/gaussian_splatting/renderer/render_streaming_orchestrator.h
@@ -47,8 +47,6 @@ public:
 			const GaussianSplatRenderer::FrameBackendPlan &p_backend_plan);
 	void tick_streaming_only(const Transform3D &p_camera_to_world_transform, const Projection &p_projection,
 			const GaussianSplatRenderer::FrameBackendPlan &p_backend_plan);
-	bool should_throttle_streaming_rebuild(uint32_t p_chunks_loaded, uint32_t p_chunks_evicted,
-			uint32_t p_visible_evicted, uint64_t p_current_frame);
 
 	struct VisibleLODSelection {
 		uint32_t residency_request_count = 0;


### PR DESCRIPTION
Two provably-dead functions in the renderer, each with zero callers
repo-wide (verified by grep + Claude/Codex audits):

- RenderStreamingOrchestrator::should_throttle_streaming_rebuild
  (render_streaming_orchestrator.{h,cpp}) — ~45-LOC method, never called,
  not bound/virtual. The streaming-rebuild throttle it once implemented is
  no longer wired into any path.
- _get_int_setting (render_pipeline_stages.cpp) — file-static helper, never
  referenced in its translation unit (the sibling _get_float_setting and its
  callers are untouched), so unreachable.

Pure dead-code deletion, no behavior change.

Risk: R2 (renderer), deletions only. Evidence: guards green
(python tests/ci/run_module_tests.py --guard-only, 108 tests OK).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
