### PR TITLE
gaussian_splatting: single source of truth for sort-key bit defaults (no silent 32-bit fallback)

### DIFF
--- a/modules/gaussian_splatting/renderer/gpu_sorting_config.cpp
+++ b/modules/gaussian_splatting/renderer/gpu_sorting_config.cpp
@@ -132,9 +132,13 @@ void GPUSortingConfig::load_from_project_settings() {
 
     radix_bits = ps->get_setting(RADIX_BITS_PATH, GPUSortingConstants::DEFAULT_RADIX_BITS);
     workgroup_size = ps->get_setting(WORKGROUP_SIZE_PATH, GPUSortingConstants::DEFAULT_WORKGROUP_SIZE);
-    key_bits = ps->get_setting(KEY_BITS_PATH, 32);
-    tile_bits = ps->get_setting(TILE_BITS_PATH, 16);
-    depth_bits = ps->get_setting(DEPTH_BITS_PATH, 16);
+    // Fallbacks MUST match the registered GLOBAL_DEF (and the shippable
+    // contract): 64/32/32. The old 32/16/16 fallbacks were the known-bad
+    // flicker config (GS-298) and would be silently selected by any read that
+    // happened before GLOBAL_DEF registration. See GPUSortingConstants.
+    key_bits = ps->get_setting(KEY_BITS_PATH, GPUSortingConstants::DEFAULT_KEY_BITS);
+    tile_bits = ps->get_setting(TILE_BITS_PATH, GPUSortingConstants::DEFAULT_TILE_BITS);
+    depth_bits = ps->get_setting(DEPTH_BITS_PATH, GPUSortingConstants::DEFAULT_DEPTH_BITS);
     enable_tie_breaker = ps->get_setting(ENABLE_TIE_BREAKER_PATH, false);
 
     enable_performance_logging = ps->get_setting(PERFORMANCE_LOGGING_PATH, false);
@@ -612,9 +616,9 @@ void initialize_gpu_sorting_config() {
     GLOBAL_DEF(GPUSortingConfig::MAX_RASTER_SPLATS_PER_TILE_PATH, 65536);
     GLOBAL_DEF(GPUSortingConfig::RADIX_BITS_PATH, GPUSortingConstants::DEFAULT_RADIX_BITS);
     GLOBAL_DEF(GPUSortingConfig::WORKGROUP_SIZE_PATH, GPUSortingConstants::DEFAULT_WORKGROUP_SIZE);
-    GLOBAL_DEF(GPUSortingConfig::KEY_BITS_PATH, 64);
-    GLOBAL_DEF(GPUSortingConfig::TILE_BITS_PATH, 32);
-    GLOBAL_DEF(GPUSortingConfig::DEPTH_BITS_PATH, 32);
+    GLOBAL_DEF(GPUSortingConfig::KEY_BITS_PATH, GPUSortingConstants::DEFAULT_KEY_BITS);
+    GLOBAL_DEF(GPUSortingConfig::TILE_BITS_PATH, GPUSortingConstants::DEFAULT_TILE_BITS);
+    GLOBAL_DEF(GPUSortingConfig::DEPTH_BITS_PATH, GPUSortingConstants::DEFAULT_DEPTH_BITS);
     GLOBAL_DEF(GPUSortingConfig::ENABLE_TIE_BREAKER_PATH, false);
     GLOBAL_DEF(GPUSortingConfig::PERFORMANCE_LOGGING_PATH, g_gpu_sorting_config.enable_performance_logging);
     GLOBAL_DEF(GPUSortingConfig::LOG_INTERVAL_PATH, g_gpu_sorting_config.performance_log_interval);

--- a/modules/gaussian_splatting/renderer/gpu_sorting_constants.h
+++ b/modules/gaussian_splatting/renderer/gpu_sorting_constants.h
@@ -20,6 +20,16 @@ static constexpr uint32_t RADIX_SIZE = 1u << RADIX_BITS;
 static constexpr uint32_t MAX_WORKGROUP_SIZE = 1024;
 static constexpr uint32_t HISTOGRAM_BINS = RADIX_SIZE;
 
+// Sort-key bit layout defaults. 64-bit (32 tile + 32 depth) is the ONLY
+// shippable layout: 32-bit quantized depth keys flicker/band on real-scan data
+// (GS-298). These are the single source of truth for the key-width defaults so
+// the ProjectSettings GLOBAL_DEF and every get_setting() fallback agree — a read
+// before registration can then never silently select the broken 32-bit path.
+// (32-bit remains reachable only via an explicit gpu_preset="custom" opt-in.)
+static constexpr uint32_t DEFAULT_KEY_BITS = 64;
+static constexpr uint32_t DEFAULT_TILE_BITS = 32;
+static constexpr uint32_t DEFAULT_DEPTH_BITS = 32;
+
 } // namespace GPUSortingConstants
 
 #endif // GPU_SORTING_CONSTANTS_H


### PR DESCRIPTION
GPUSortingConfig::load_from_project_settings() fell back to key_bits=32,
tile_bits=16, depth_bits=16 when a setting was missing — the known-bad
32-bit quantized-depth layout that flickers/bands on real-scan data
(GS-298). Every OTHER site (struct member defaults, reset_to_defaults, all
presets, and the GLOBAL_DEF registration) already used the shippable
64/32/32 layout, so these fallbacks were the lone divergent values. They are
dead in the normal flow (GLOBAL_DEF registers before the first load), but any
read before registration would silently select the broken layout.

Fix (per the knobs-from-one-shared-constant standard): add
GPUSortingConstants::DEFAULT_KEY_BITS / DEFAULT_TILE_BITS / DEFAULT_DEPTH_BITS
(64/32/32) as the single source of truth and reference them from both the
get_setting() fallbacks and the GLOBAL_DEF, mirroring the adjacent
DEFAULT_RADIX_BITS / DEFAULT_WORKGROUP_SIZE pattern. The defaults can no
longer diverge. The explicit gpu_preset="custom" + key_bits=32 opt-in path is
unchanged (validate() still accepts 32).

Risk: R2 (renderer). Compile-safe (same uint32_t-constant pattern as the
adjacent radix/workgroup fallbacks). Evidence: guards green
(python tests/ci/run_module_tests.py --guard-only, 108 tests OK). CI build +
GPU gate validates.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
