### PR TITLE
gaussian_splatting: remove dead _recalculate_totals lock-wrapper

### DIFF
--- a/modules/gaussian_splatting/core/gaussian_splat_manager.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_manager.cpp
@@ -703,12 +703,6 @@ void GaussianSplatManager::_bind_methods() {
             "set_shared_submission_device_enabled", "is_shared_submission_device_enabled");
 }
 
-void GaussianSplatManager::_recalculate_totals() {
-    GS_LOCK_ORDER_GUARD(GaussianSplatManager::LOCK_LEVEL_RESOURCE_MAPS, "resource_maps_mutex");
-    MutexLock resource_lock(resource_maps_mutex);
-    _recalculate_totals_unlocked();
-}
-
 void GaussianSplatManager::_recalculate_totals_unlocked() {
     total_gaussians = 0;
     total_memory_usage = 0;

--- a/modules/gaussian_splatting/core/gaussian_splat_manager.h
+++ b/modules/gaussian_splatting/core/gaussian_splat_manager.h
@@ -180,7 +180,6 @@ private:
 
 protected:
     static void _bind_methods();
-    void _recalculate_totals();
     void _recalculate_totals_unlocked();
 
 public:


### PR DESCRIPTION
GaussianSplatManager::_recalculate_totals() is a pure lock-taking wrapper
(GS_LOCK_ORDER_GUARD + MutexLock + delegate) around
_recalculate_totals_unlocked(). It has zero callers anywhere in the module
and is not ClassDB-bound — every real caller already holds resource_maps_mutex
and calls the _unlocked variant directly. Pure dead-code deletion, no
behavior change.

Risk: R1. Evidence: guards green (run_module_tests.py --guard-only, 108 OK).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
