### PR TITLE
gaussian_splatting: derive the raster alpha-threshold from one shared host constant

### DIFF
--- a/modules/gaussian_splatting/core/gaussian_splat_manager.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_manager.cpp
@@ -10,6 +10,7 @@
 #include "module_string_names.h"
 #include "quality_tier_config.h"
 #include "streaming_vram_regulator.h"
+#include "../interfaces/gs_raster_thresholds.h"
 #include "../renderer/sorting_settings_utils.h"
 #include "../nodes/gaussian_splat_node_3d.h"
 #include "../logger/gs_logger.h"
@@ -1070,7 +1071,7 @@ void GaussianSplatManager::initialize_module() {
 	// Opacity-aware bounding (FlashGS optimization) - reduces tile-Gaussian pairs by ~94%
 	// When enabled, splat radii are calculated based on opacity: r = sqrt(2 * ln(alpha/tau) * lambda)
 	GLOBAL_DEF("rendering/gaussian_splatting/culling/opacity_aware_bounds", true);     // Enable opacity-aware bounding
-	GLOBAL_DEF("rendering/gaussian_splatting/culling/visibility_threshold", 1.0f / 255.0f); // tau: minimum visible contribution
+	GLOBAL_DEF("rendering/gaussian_splatting/culling/visibility_threshold", gs::RASTER_ALPHA_THRESHOLD); // tau: minimum visible contribution
 
 	// Optional per-splat hard cull at projection. Keep disabled by default:
 	// real captures often rely on many low-opacity splats accumulating, and

--- a/modules/gaussian_splatting/interfaces/gpu_culler.h
+++ b/modules/gaussian_splatting/interfaces/gpu_culler.h
@@ -2,6 +2,7 @@
 #define GS_GPU_CULLER_H
 
 #include "culler_interfaces.h"
+#include "gs_raster_thresholds.h"
 #include "core/math/aabb.h"
 #include "core/math/vector2i.h"
 #include "core/math/vector3.h"
@@ -69,7 +70,7 @@ public:
         // Opacity-aware bounding (FlashGS optimization)
         // When enabled, reduces tile-Gaussian pairs by ~94% using opacity-based radius
         bool opacity_aware_culling = true;
-        float visibility_threshold = 1.0f / 255.0f; // tau: minimum visible contribution
+        float visibility_threshold = gs::RASTER_ALPHA_THRESHOLD; // tau: minimum visible contribution
         // Optional per-splat hard cull at projection. Disabled by default so
         // low-opacity splats can still be boosted by opacity multipliers before
         // opacity-aware bounds make the final visibility decision.

--- a/modules/gaussian_splatting/interfaces/gs_raster_thresholds.h
+++ b/modules/gaussian_splatting/interfaces/gs_raster_thresholds.h
@@ -1,0 +1,15 @@
+#ifndef GS_RASTER_THRESHOLDS_H
+#define GS_RASTER_THRESHOLDS_H
+
+namespace gs {
+
+// Host mirror of shaders/includes/gs_alpha_threshold.glsl GS_RASTER_ALPHA_THRESHOLD.
+// Minimum visible per-splat contribution (tau): an 8-bit channel below this rounds
+// to 0, so the splat cannot affect the framebuffer. This is the single host source
+// of truth for that threshold. It is a parallel definition of the GLSL constant
+// (GLSL cannot share a C++ constexpr) — keep the two numerically equal.
+static constexpr float RASTER_ALPHA_THRESHOLD = 1.0f / 255.0f;
+
+} // namespace gs
+
+#endif // GS_RASTER_THRESHOLDS_H

--- a/modules/gaussian_splatting/interfaces/rasterizer_interfaces.h
+++ b/modules/gaussian_splatting/interfaces/rasterizer_interfaces.h
@@ -8,6 +8,7 @@
 #include "core/string/ustring.h"
 #include "servers/rendering/rendering_device.h"
 
+#include "gs_raster_thresholds.h"
 #include "../renderer/tile_render_types.h"
 
 // Rasterization parameters
@@ -50,7 +51,7 @@ struct RasterParams {
     // Opacity-aware bounding (FlashGS optimization)
     // When enabled, reduces tile-Gaussian pairs by ~94% using opacity-based radius calculation
     bool opacity_aware_culling = true;
-    float visibility_threshold = 1.0f / 255.0f;
+    float visibility_threshold = gs::RASTER_ALPHA_THRESHOLD;
     // Optional per-splat hard cull at projection. Disabled by default; projects
     // can opt into aggressive low-opacity splat removal.
     float alpha_clip = 0.0f;

--- a/modules/gaussian_splatting/renderer/render_quality_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_quality_orchestrator.cpp
@@ -1,5 +1,6 @@
 #include "render_quality_orchestrator.h"
 
+#include "../interfaces/gs_raster_thresholds.h"
 #include "../logger/gs_logger.h"
 #include "core/error/error_macros.h"
 #include "core/math/math_defs.h"
@@ -15,7 +16,7 @@ namespace {
 struct FidelityOverrideSnapshot {
 	bool lod_enabled = true;
 	bool opacity_aware_culling = true;
-	float visibility_threshold = 1.0f / 255.0f;
+	float visibility_threshold = gs::RASTER_ALPHA_THRESHOLD;
 	bool distance_cull_enabled = true;
 	float distance_cull_start = 30.0f;
 	float distance_cull_max_rate = 0.5f;

--- a/modules/gaussian_splatting/renderer/tile_render_types.h
+++ b/modules/gaussian_splatting/renderer/tile_render_types.h
@@ -10,6 +10,7 @@
 #include "gaussian_gpu_layout.h"
 #include "servers/rendering/rendering_device.h"
 
+#include "../interfaces/gs_raster_thresholds.h"
 #include "../resources/color_grading_resource.h"
 
 #include <array>
@@ -447,7 +448,7 @@ struct TileRenderParams {
 	bool jacobian_bypass_j_col2_clamp = false;
 	bool jacobian_invert_j_col2_sign = false;
 	bool opacity_aware_culling = true;
-	float visibility_threshold = 1.0f / 255.0f;
+	float visibility_threshold = gs::RASTER_ALPHA_THRESHOLD;
 		// Optional per-splat hard cull at projection. Disabled by default; projects
 		// can opt into aggressive low-opacity splat removal.
 		float alpha_clip = 0.0f;

--- a/modules/gaussian_splatting/renderer/tile_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/tile_renderer.cpp
@@ -23,6 +23,7 @@
 #include "sh_config.h"
 #include "shader_compilation_helper.h"
 #include "../logger/gs_logger.h"
+#include "../interfaces/gs_raster_thresholds.h"
 #include "../interfaces/render_device_manager.h"
 #include "../interfaces/sync_policy.h"
 #include "../core/performance_monitors.h"
@@ -1310,7 +1311,7 @@ GaussianSplatting::TileRenderParams::TileRenderParams() {
 	jacobian_invert_j_col2_sign = false;
 	// Opacity-aware bounding (FlashGS optimization) - enabled by default
 	opacity_aware_culling = true;
-	visibility_threshold = 1.0f / 255.0f;
+	visibility_threshold = gs::RASTER_ALPHA_THRESHOLD;
 		// Optional per-splat hard cull at projection.
 		alpha_clip = 0.0f;
 	// Distance-based culling - enabled by default


### PR DESCRIPTION
The raster alpha cutoff (tau = the minimum visible per-splat contribution, the
value below which an 8-bit channel rounds to 0) was hardcoded as the literal
1.0f / 255.0f in six host sites across core/, interfaces/, and renderer/
(gpu_culler.h, rasterizer_interfaces.h, tile_render_types.h,
render_quality_orchestrator.cpp, tile_renderer.cpp default; the
visibility_threshold GLOBAL_DEF in gaussian_splat_manager.cpp). Per the
"knobs must derive from one shared constant" standard, these now reference a
single gs::RASTER_ALPHA_THRESHOLD defined in the new leaf header
interfaces/gs_raster_thresholds.h, documented as the host mirror of the shader
constant GS_RASTER_ALPHA_THRESHOLD (shaders/includes/gs_alpha_threshold.glsl:8,
1.0/255.0 — numerically equal). GLSL cannot share a C++ constexpr, so the two
remain parallel definitions kept equal by the comment.

Value is byte-identical (1.0f / 255.0f), so this is behavior-preserving.

Risk: R2 (feeds the cull/raster path) but value-identical. Evidence: full
editor build compiles + links clean (scons ... dev_build=yes tests=yes, exit 0;
only pre-existing C4458 shadow warnings in gpu_buffer_manager.h, untouched);
guards green (run_module_tests.py --guard-only, 108 tests OK).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
