### PR TITLE
gaussian_splatting: dead-code sweep #2 (decl-only fields, write-only flags, uncalled methods)

### DIFF
--- a/modules/gaussian_splatting/core/gaussian_data.cpp
+++ b/modules/gaussian_splatting/core/gaussian_data.cpp
@@ -181,11 +181,6 @@ void GaussianData::_on_gaussian_storage_changed() {
 // animation caches are the only derived state that genuinely went stale.
 void GaussianData::_invalidate_derived_caches_locked() {
     octree.clear();
-    octree_dirty = true;
-    {
-        MutexLock anim_lock(animation_cache_mutex);
-        animation_cache_dirty = true;
-    }
     _invalidate_streaming_bake_locked();
 }
 
@@ -217,7 +212,6 @@ void GaussianData::_debug_check_raw_storage_access(const char *p_method) {
 
 void GaussianData::_on_gaussian_storage_changed_locked() {
     octree.clear();
-    octree_dirty = true;
 
     _clear_runtime_modifications_locked();
     _clear_brush_strokes_locked();
@@ -231,8 +225,6 @@ void GaussianData::_on_gaussian_storage_changed_locked() {
         animated_positions_valid_cache.clear();
         animated_colors_valid_cache.clear();
         animated_opacities_valid_cache.clear();
-        last_animation_time = -1.0f;
-        animation_cache_dirty = true;
         if (animation_state_machine.is_valid()) {
             animation_state_machine->set_splat_count(gaussians.size());
         }
@@ -312,7 +304,6 @@ void GaussianData::set_gaussian_payload(const LocalVector<Gaussian> &p_gaussians
     _clear_brush_strokes_locked();
     _invalidate_streaming_bake_locked();
     octree.clear();
-    octree_dirty = true;
 
     {
         MutexLock anim_lock(animation_cache_mutex);
@@ -322,8 +313,6 @@ void GaussianData::set_gaussian_payload(const LocalVector<Gaussian> &p_gaussians
         animated_positions_valid_cache.clear();
         animated_colors_valid_cache.clear();
         animated_opacities_valid_cache.clear();
-        last_animation_time = -1.0f;
-        animation_cache_dirty = true;
         if (animation_state_machine.is_valid()) {
             animation_state_machine->set_splat_count(gaussians.size());
         }
@@ -414,11 +403,6 @@ void GaussianData::set_gaussian(int p_index, const Gaussian &p_gaussian) {
     RWLockWrite lock(data_rwlock);
     ERR_FAIL_INDEX(p_index, (int)gaussians.size());
     gaussians[p_index] = p_gaussian;
-    octree_dirty = true;
-    {
-        MutexLock anim_lock(animation_cache_mutex);
-        animation_cache_dirty = true;
-    }
     _invalidate_streaming_bake_locked();
     _bump_content_revision();
 }
@@ -845,8 +829,6 @@ void GaussianData::_set_spherical_harmonics_locked(int p_index, const float *p_c
         degree++;
     }
     sh_degree = degree > 0 ? degree - 1 : 0;
-
-    octree_dirty = true;
 
 #ifndef GS_SILENCE_LOGS
     // DEBUG: Log first gaussian SH data after setting

--- a/modules/gaussian_splatting/core/gaussian_data.h
+++ b/modules/gaussian_splatting/core/gaussian_data.h
@@ -327,8 +327,6 @@ private:
     mutable LocalVector<bool> animated_positions_valid_cache;
     mutable LocalVector<bool> animated_colors_valid_cache;
     mutable LocalVector<bool> animated_opacities_valid_cache;
-    mutable float last_animation_time = -1.0f;
-    mutable bool animation_cache_dirty = true;
 
     // Cached RenderingDevice singleton to prevent recreation
     static RenderingDevice *cached_rd;
@@ -351,7 +349,6 @@ private:
         uint8_t level;
     };
     LocalVector<OctreeNode> octree;
-    mutable bool octree_dirty = true;
 
     // Streaming-chunk bake mirror (Phase B.1). Populated by
     // GaussianSplatAsset::populate_gaussian_data() so the runtime streaming

--- a/modules/gaussian_splatting/core/gaussian_data_animation.cpp
+++ b/modules/gaussian_splatting/core/gaussian_data_animation.cpp
@@ -25,7 +25,6 @@ void GaussianData::set_animation_state_machine(const Ref<GaussianSplatting::Gaus
                 animation_state_machine->set_incremental_saver(incremental_saver);
             }
         }
-        animation_cache_dirty = true;
     }
 }
 
@@ -46,7 +45,6 @@ void GaussianData::set_incremental_saver(const Ref<GaussianSplatting::GaussianIn
     if (incremental_saver.is_valid() && animation_state_machine.is_valid()) {
         animation_state_machine->set_incremental_saver(incremental_saver);
     }
-    animation_cache_dirty = true;
 }
 
 Ref<GaussianSplatting::GaussianIncrementalSaver> GaussianData::get_incremental_saver() const {
@@ -74,7 +72,6 @@ void GaussianData::update_animation(float p_delta) {
     {
         MutexLock anim_lock(animation_cache_mutex);
         animation->update(p_delta);
-        animation_cache_dirty = true;
     }
 }
 
@@ -82,10 +79,6 @@ void GaussianData::set_animation_enabled(bool p_enabled) {
     {
         RWLockWrite lock(data_rwlock);
         animation_enabled = p_enabled;
-    }
-    {
-        MutexLock anim_lock(animation_cache_mutex);
-        animation_cache_dirty = true;
     }
 }
 

--- a/modules/gaussian_splatting/core/gaussian_data_edits.cpp
+++ b/modules/gaussian_splatting/core/gaussian_data_edits.cpp
@@ -217,11 +217,6 @@ void GaussianData::commit_runtime_changes() {
 
         _clear_runtime_modifications_locked();
         if (committed_changes) {
-            octree_dirty = true;
-            {
-                MutexLock anim_lock(animation_cache_mutex);
-                animation_cache_dirty = true;
-            }
             _invalidate_streaming_bake_locked();
             _bump_content_revision();
         }

--- a/modules/gaussian_splatting/core/gaussian_splat_manager.h
+++ b/modules/gaussian_splatting/core/gaussian_splat_manager.h
@@ -159,7 +159,6 @@ private:
     // Module configuration
     bool gpu_sorting_enabled = true;
     bool shared_submission_device_enabled = false;
-    int max_gpu_buffer_count = 128;
 
     // RenderDoc compatibility mode - when enabled, skips creating local devices
     // which cause crashes when RenderDoc hooks Vulkan (multiple devices not supported)

--- a/modules/gaussian_splatting/interfaces/gpu_culler.h
+++ b/modules/gaussian_splatting/interfaces/gpu_culler.h
@@ -43,7 +43,6 @@ public:
         float lod_bias = 1.0f;
         bool frustum_culling = true;
         bool gpu_culling_enabled = true;
-        bool gpu_culling_readback_enabled = true; // enable GPU readback so GPU cull can drive visibility
         bool temporal_coherence = true;
 
         float lod_min_screen_size = 1.5f;

--- a/modules/gaussian_splatting/interfaces/output_compositor.h
+++ b/modules/gaussian_splatting/interfaces/output_compositor.h
@@ -116,7 +116,6 @@ public:
         bool render_buffers_commit_pending = false;
         Size2i pending_render_buffers_size = Size2i();
         bool pending_painterly_commit = false;
-        bool painterly_depth_override_active = false;
         HashMap<uint64_t, CachedFramebuffer> cached_framebuffers;
         HashMap<uint64_t, FramebufferValidationCacheEntry> framebuffer_validation_cache;
     };

--- a/modules/gaussian_splatting/renderer/gpu_performance_monitor.cpp
+++ b/modules/gaussian_splatting/renderer/gpu_performance_monitor.cpp
@@ -164,14 +164,6 @@ void GPUPerformanceMonitor::detect_pipeline_stalls(RID timeline_semaphore) {
     last_poll_usec = poll_usec;
 }
 
-GPUPerformanceMonitor::FrameMetrics GPUPerformanceMonitor::get_frame_metrics_nonblocking(uint64_t frame_id) const {
-    MutexLock lock(metrics_mutex);
-    if (const FrameMetrics *frame = metrics.getptr(frame_id)) {
-        return *frame;
-    }
-    return FrameMetrics();
-}
-
 GPUPerformanceMonitor::SummaryMetrics GPUPerformanceMonitor::get_summary_metrics() const {
     MutexLock lock(metrics_mutex);
     SummaryMetrics summary;

--- a/modules/gaussian_splatting/renderer/gpu_performance_monitor.h
+++ b/modules/gaussian_splatting/renderer/gpu_performance_monitor.h
@@ -88,7 +88,6 @@ public:
     // The RID parameter is ignored (retained for API compatibility).
     void detect_pipeline_stalls(RID timeline_semaphore = RID());
 
-    FrameMetrics get_frame_metrics_nonblocking(uint64_t frame_id) const;
     SummaryMetrics get_summary_metrics() const;
 
 private:

--- a/modules/gaussian_splatting/renderer/spirv_disk_cache.cpp
+++ b/modules/gaussian_splatting/renderer/spirv_disk_cache.cpp
@@ -219,14 +219,6 @@ bool SPIRVDiskCache::_ensure_dir(const String &p_dir) {
     return err == OK;
 }
 
-String SPIRVDiskCache::cache_dir() const {
-    MutexLock lock(mutex);
-    if (!cached_device_dir.is_empty()) {
-        return cached_device_dir;
-    }
-    return String(CACHE_ROOT_BASE) + "/";
-}
-
 String SPIRVDiskCache::compute_key(const String &p_source, const Vector<String> &p_defines, RenderingDevice *p_device) {
     // No side effects on cached_device_dir here — try_load/store/invalidate
     // now resolve the per-device subdir themselves under their own lock so a

--- a/modules/gaussian_splatting/renderer/spirv_disk_cache.h
+++ b/modules/gaussian_splatting/renderer/spirv_disk_cache.h
@@ -30,8 +30,6 @@ public:
 
     void prune_above(uint64_t p_max_bytes);
 
-    String cache_dir() const;
-
 private:
     SPIRVDiskCache() = default;
 


### PR DESCRIPTION
Conservative removal of provably-dead code (each verified zero real references
repo-wide, not ClassDB-bound, non-virtual, not in any public-API baseline):

- gpu_culling_readback_enabled (interfaces/gpu_culler.h) — decl-only, never used.
- painterly_depth_override_active (interfaces/output_compositor.h) — decl-only.
- GaussianData::octree_dirty / animation_cache_dirty / last_animation_time
  (core/gaussian_data.h) — write-only mutable flags (assigned, never read);
  removed the members and their plain `= ...;` write sites. Two write sites
  left an otherwise-empty mutex critical section, which was removed as a
  behavior-preserving no-op (no shared state was accessed under it); locks that
  protect live cache/state ops were retained.
- GaussianSplatManager::max_gpu_buffer_count MEMBER — write-never-read; removed
  the member only. The project setting + its GLOBAL_DEF (public-API baseline)
  are intentionally left untouched.
- SPIRVDiskCache::cache_dir() and GPUPerformanceMonitor::get_frame_metrics_nonblocking()
  — zero callers, non-virtual, unbound.

~55 LOC removed across 11 files. Pure dead-code deletion, no behavior change.

Risk: R1/R2. Evidence: full editor build (header cascade) compiles + links clean
(scons ... dev_build=yes tests=yes, exit 0; only pre-existing C4458 warnings in
gpu_buffer_manager.h); guards green (run_module_tests.py --guard-only, 108 OK).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
