### PR TITLE
gaussian_splatting: derive the min max_splat_count floor from one shared constant

### DIFF
--- a/modules/gaussian_splatting/core/gs_project_settings.h
+++ b/modules/gaussian_splatting/core/gs_project_settings.h
@@ -22,6 +22,9 @@
 #include "core/variant/variant.h"
 
 namespace gs {
+
+static constexpr int GS_MIN_MAX_SPLAT_COUNT = 1000;  // Minimum allowed quality/max_splat_count floor.
+
 namespace settings {
 
 /**

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -999,7 +999,7 @@ void GaussianSplatNode3D::set_max_render_distance(float p_distance) {
 }
 
 void GaussianSplatNode3D::set_max_splat_count(int p_count) {
-    max_splat_count = MAX(1000, p_count);
+    max_splat_count = MAX(gs::GS_MIN_MAX_SPLAT_COUNT, p_count);
     _update_quality_settings();
     if (renderer.is_valid()) {
         _apply_renderer_settings();

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
@@ -5,6 +5,7 @@
 #include "../core/gaussian_splat_settings_manager.h"
 #include "../core/gaussian_splat_scene_director.h"
 #include "../core/gaussian_streaming.h"
+#include "../core/gs_project_settings.h"
 #include "../core/quality_tier_config.h"
 #include "../io/io_settings_utils.h"
 #include "../renderer/gaussian_splat_renderer.h"
@@ -773,7 +774,7 @@ void GaussianSplatNodeQualityHelper::apply_quality_preset() {
     };
 
     owner.lod_bias = CLAMP(get_float("lod_bias", owner.lod_bias), 0.1f, 4.0f);
-    owner.max_splat_count = MAX(1000, get_int("max_splat_count", owner.max_splat_count));
+    owner.max_splat_count = MAX(gs::GS_MIN_MAX_SPLAT_COUNT, get_int("max_splat_count", owner.max_splat_count));
 
     update_quality_settings();
     owner._update_instance_params_in_director();
@@ -803,7 +804,7 @@ void GaussianSplatNodeQualityHelper::update_quality_settings() {
     };
 
     owner.lod_bias = get_float("lod_bias", owner.lod_bias);
-    owner.max_splat_count = MAX(1000, get_int("max_splat_count", owner.max_splat_count));
+    owner.max_splat_count = MAX(gs::GS_MIN_MAX_SPLAT_COUNT, get_int("max_splat_count", owner.max_splat_count));
 
     const float min_budget_fraction = CLAMP(get_float("min_budget_fraction", 0.1f), 0.0f, 1.0f);
     const float importance_threshold = MAX(0.0f, get_float("importance_threshold", 0.1f));
@@ -938,7 +939,7 @@ void GaussianSplatNodeQualityHelper::update_quality_settings() {
     float lod3_distance = compute_distance(lod3_ratio, lod2_distance);
     lod3_distance = MAX(lod3_distance, effective_distance);
 
-    owner.max_splat_count = MAX(1000, effective_max_splats);
+    owner.max_splat_count = MAX(gs::GS_MIN_MAX_SPLAT_COUNT, effective_max_splats);
     const uint32_t max_budget = MAX(1, owner.max_splat_count);
     uint32_t min_budget = (uint32_t)(max_budget * min_budget_fraction);
     min_budget = MAX((uint32_t)1000, min_budget);

--- a/modules/gaussian_splatting/nodes/gaussian_splat_world_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_world_3d.cpp
@@ -253,7 +253,7 @@ void GaussianSplatWorld3D::set_max_render_distance(float p_distance) {
 }
 
 void GaussianSplatWorld3D::set_max_splat_count(int p_count) {
-    max_splat_count = MAX(1000, p_count);
+    max_splat_count = MAX(gs::GS_MIN_MAX_SPLAT_COUNT, p_count);
     _resubmit_world_submission_if_registered();
 }
 
@@ -334,7 +334,7 @@ Dictionary GaussianSplatWorld3D::_build_desired_renderer_overrides() const {
     }
 
     const int desired_max_splats = max_splat_count > 0 ? max_splat_count : int(tier_config.max_splats);
-    overrides[StringName("max_splats")] = int64_t(MAX(1000, MIN(int(tier_config.max_splats), desired_max_splats)));
+    overrides[StringName("max_splats")] = int64_t(MAX(gs::GS_MIN_MAX_SPLAT_COUNT, MIN(int(tier_config.max_splats), desired_max_splats)));
 
     Dictionary streaming_overrides;
     streaming_overrides[StringName("override_prefetch")] = true;


### PR DESCRIPTION
The minimum allowed quality/max_splat_count (the literal 1000 used as a MAX()
floor) was hardcoded at six sites across nodes/ (gaussian_splat_node_3d.cpp,
gaussian_splat_world_3d.cpp, gaussian_splat_node_helpers.cpp). Per the "knobs
must derive from one shared constant" standard, these now reference a single
gs::GS_MIN_MAX_SPLAT_COUNT (added to core/gs_project_settings.h);
gaussian_splat_node_helpers.cpp gains the include (it did not pull it in
transitively).

Value is byte-identical (1000), so behavior-preserving. The property-range
hint strings ("1000,10000000,1000") and the default initializers (1000000)
are intentionally untouched (different semantics), as is the unrelated
min_budget uint32_t floor.

Risk: R1. Evidence: full editor build (header cascade) compiles + links clean
(scons ... dev_build=yes tests=yes, exit 0); guards green
(run_module_tests.py --guard-only, 108 OK).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
