### PR TITLE
gaussian_splatting: invert RenderConfigOrchestrator's renderer back-pointer to injected ports

### DIFF
--- a/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
+++ b/modules/gaussian_splatting/renderer/gaussian_splat_renderer.cpp
@@ -1015,10 +1015,20 @@ GaussianSplatRenderer::GaussianSplatRenderer(RenderingDevice *p_device) {
     sorting_orchestrator = std::make_unique<RenderSortingOrchestrator>(sorting_dependencies);
 
     RenderConfigOrchestrator::Dependencies config_dependencies;
-    config_dependencies.renderer = this;
     config_dependencies.interactive_state_manager = &subsystem_state.interactive_state_manager;
     config_dependencies.painterly_renderer = &subsystem_state.painterly_renderer;
-    config_dependencies.runtime_ports.invalidate_cached_render = &GaussianSplatRenderer::invalidate_cached_render;
+    config_dependencies.invalidate_cached_render = [this]() { invalidate_cached_render(); };
+    config_dependencies.default_grading_changed_callable =
+            callable_mp(this, &GaussianSplatRenderer::_on_renderer_default_grading_changed);
+    config_dependencies.invalidate_grading_via_director = [this]() {
+        if (GaussianSplatSceneDirector *d = GaussianSplatSceneDirector::get_singleton()) {
+            d->invalidate_grading_for_renderer(this);
+        }
+    };
+    config_dependencies.apply_interactive_state = [this](GaussianSplatRenderer::InteractiveState s) -> bool {
+        return subsystem_state.interactive_state_manager.is_valid() &&
+                subsystem_state.interactive_state_manager->apply_renderer_state(this, s);
+    };
     config_orchestrator = std::make_unique<RenderConfigOrchestrator>(config_dependencies);
 
     RenderInstancingOrchestrator::Dependencies instancing_dependencies;

--- a/modules/gaussian_splatting/renderer/render_config_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_config_orchestrator.cpp
@@ -21,8 +21,17 @@ RenderConfigOrchestrator::RenderConfigOrchestrator(const Dependencies &p_depende
 		apply_interactive_state(p_dependencies.apply_interactive_state) {
 	ERR_FAIL_NULL(interactive_state_manager);
 	ERR_FAIL_NULL(painterly_renderer);
+	// Validate every injected port up front, restoring the fail-fast contract the
+	// old `ERR_FAIL_NULL(renderer)` provided. A miswired (empty) port would
+	// otherwise invoke an empty std::function / Callable and crash at use time.
 	ERR_FAIL_COND_MSG(!invalidate_cached_render,
 			"RenderConfigOrchestrator requires invalidate_cached_render runtime port.");
+	ERR_FAIL_COND_MSG(!default_grading_changed_callable.is_valid(),
+			"RenderConfigOrchestrator requires a valid default_grading_changed_callable.");
+	ERR_FAIL_COND_MSG(!invalidate_grading_via_director,
+			"RenderConfigOrchestrator requires invalidate_grading_via_director runtime port.");
+	ERR_FAIL_COND_MSG(!apply_interactive_state,
+			"RenderConfigOrchestrator requires apply_interactive_state runtime port.");
 }
 
 void RenderConfigOrchestrator::set_render_mode(GaussianSplatRenderer::RenderMode p_mode) {

--- a/modules/gaussian_splatting/renderer/render_config_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_config_orchestrator.cpp
@@ -13,14 +13,15 @@
 #include "core/math/math_funcs.h"
 
 RenderConfigOrchestrator::RenderConfigOrchestrator(const Dependencies &p_dependencies) :
-		renderer(p_dependencies.renderer),
 		interactive_state_manager(p_dependencies.interactive_state_manager),
 		painterly_renderer(p_dependencies.painterly_renderer),
-		runtime_ports(p_dependencies.runtime_ports) {
-	ERR_FAIL_NULL(renderer);
+		invalidate_cached_render(p_dependencies.invalidate_cached_render),
+		default_grading_changed_callable(p_dependencies.default_grading_changed_callable),
+		invalidate_grading_via_director(p_dependencies.invalidate_grading_via_director),
+		apply_interactive_state(p_dependencies.apply_interactive_state) {
 	ERR_FAIL_NULL(interactive_state_manager);
 	ERR_FAIL_NULL(painterly_renderer);
-	ERR_FAIL_COND_MSG(!runtime_ports.invalidate_cached_render,
+	ERR_FAIL_COND_MSG(!invalidate_cached_render,
 			"RenderConfigOrchestrator requires invalidate_cached_render runtime port.");
 }
 
@@ -39,8 +40,8 @@ void RenderConfigOrchestrator::set_opacity_multiplier(float p_opacity) {
 		return;
 	}
 	render_config.opacity_multiplier = clamped;
-	if (renderer) {
-		(renderer->*runtime_ports.invalidate_cached_render)();
+	if (invalidate_cached_render) {
+		invalidate_cached_render();
 	}
 }
 
@@ -51,8 +52,8 @@ void RenderConfigOrchestrator::set_color_grading(const Ref<ColorGradingResource>
 	// Disconnect the signal on the OLD resource (if any) before swapping. Without
 	// this, dangling `changed` connections on replaced resources would keep calling
 	// the renderer handler after the resource is no longer the active default.
-	const Callable grading_changed = callable_mp(renderer, &GaussianSplatRenderer::_on_renderer_default_grading_changed);
-	if (render_config.color_grading.is_valid() && renderer &&
+	const Callable &grading_changed = default_grading_changed_callable;
+	if (render_config.color_grading.is_valid() && default_grading_changed_callable.is_valid() &&
 			render_config.color_grading->is_connected("changed", grading_changed)) {
 		render_config.color_grading->disconnect("changed", grading_changed);
 	}
@@ -61,12 +62,12 @@ void RenderConfigOrchestrator::set_color_grading(const Ref<ColorGradingResource>
 	// without swapping the Ref) re-run the invalidation path. Without this,
 	// mutating the resource behind the scenes leaves fallback-graded rows
 	// stale until an unrelated content change forces a rebuild.
-	if (render_config.color_grading.is_valid() && renderer &&
+	if (render_config.color_grading.is_valid() && default_grading_changed_callable.is_valid() &&
 			!render_config.color_grading->is_connected("changed", grading_changed)) {
 		render_config.color_grading->connect("changed", grading_changed);
 	}
-	if (renderer) {
-		(renderer->*runtime_ports.invalidate_cached_render)();
+	if (invalidate_cached_render) {
+		invalidate_cached_render();
 		// Per-instance grading path: records without an explicit per-instance
 		// grading ref fall back to this renderer-wide default at build time.
 		// The director's invalidate call bumps both the world's instance
@@ -74,8 +75,8 @@ void RenderConfigOrchestrator::set_color_grading(const Ref<ColorGradingResource>
 		// that the streaming/resident upload fingerprints include — so the
 		// SSBO re-uploads on the next frame for both world-bound and direct-
 		// data flows.
-		if (GaussianSplatSceneDirector *director = GaussianSplatSceneDirector::get_singleton()) {
-			director->invalidate_grading_for_renderer(renderer);
+		if (invalidate_grading_via_director) {
+			invalidate_grading_via_director();
 		}
 	}
 }
@@ -86,7 +87,7 @@ void RenderConfigOrchestrator::set_interactive_state(GaussianSplatRenderer::Inte
 	}
 
 	if (interactive_state_manager->is_valid()) {
-		if (!interactive_state_manager->ptr()->apply_renderer_state(renderer, p_state)) {
+		if (!apply_interactive_state(p_state)) {
 			return;
 		}
 		return;

--- a/modules/gaussian_splatting/renderer/render_config_orchestrator.h
+++ b/modules/gaussian_splatting/renderer/render_config_orchestrator.h
@@ -3,20 +3,20 @@
 
 #include "gaussian_splat_renderer.h"
 
+#include <functional>
+
 class InteractiveStateManager;
 class PainterlyRenderer;
 
 class RenderConfigOrchestrator {
 public:
-	struct RuntimePorts {
-		void (GaussianSplatRenderer::*invalidate_cached_render)() = &GaussianSplatRenderer::invalidate_cached_render;
-	};
-
 	struct Dependencies {
-		GaussianSplatRenderer *renderer = nullptr;
 		Ref<InteractiveStateManager> *interactive_state_manager = nullptr;
 		Ref<PainterlyRenderer> *painterly_renderer = nullptr;
-		RuntimePorts runtime_ports;
+		std::function<void()> invalidate_cached_render;
+		Callable default_grading_changed_callable;
+		std::function<void()> invalidate_grading_via_director;
+		std::function<bool(GaussianSplatRenderer::InteractiveState)> apply_interactive_state;
 	};
 
 	explicit RenderConfigOrchestrator(const Dependencies &p_dependencies);
@@ -49,10 +49,12 @@ public:
 	const GaussianSplatRenderer::PainterlyConfig &get_painterly_config() const { return painterly_config; }
 
 private:
-	GaussianSplatRenderer *renderer = nullptr;
 	Ref<InteractiveStateManager> *interactive_state_manager = nullptr;
 	Ref<PainterlyRenderer> *painterly_renderer = nullptr;
-	RuntimePorts runtime_ports;
+	std::function<void()> invalidate_cached_render;
+	Callable default_grading_changed_callable;
+	std::function<void()> invalidate_grading_via_director;
+	std::function<bool(GaussianSplatRenderer::InteractiveState)> apply_interactive_state;
 	GaussianSplatRenderer::RenderConfig render_config;
 	GaussianSplatRenderer::InteractiveStateConfig interactive_state;
 	GaussianSplatRenderer::CullingConfig culling_config;


### PR DESCRIPTION
First cut of the renderer god-object back-pointer inversion (the audits' #1
architectural concern). RenderConfigOrchestrator no longer holds a
GaussianSplatRenderer *renderer back-pointer; its five uses are replaced by
explicit data-in ports supplied by the renderer at construction:
  - std::function<void()> invalidate_cached_render   (was a PMF on the renderer)
  - Callable default_grading_changed_callable        (the grading "changed" handler)
  - std::function<void()> invalidate_grading_via_director
  - std::function<bool(InteractiveState)> apply_interactive_state

The renderer wires these as lambdas / callable_mp capturing `this`, so each
port performs the IDENTICAL operation the back-pointer did. Behavior-preserving:
  - The grading-changed connect/disconnect/is_connected use the SAME Callable
    object (callable_mp(this, &_on_renderer_default_grading_changed)), just
    injected — signal behavior is unchanged. The prior `&& renderer` guards
    (renderer was ERR_FAIL_NULL-guaranteed non-null) become
    `&& default_grading_changed_callable.is_valid()` (the injected callable is
    always valid) — equivalent always-true guards.
  - The director-invalidate lambda replicates the exact get_singleton()-guarded
    call; the apply-interactive-state lambda replicates the exact is_valid()
    short-circuit. The orchestrator keeps interactive_state_manager (its L88
    is_valid() guard provides an "invalid -> fall through" branch a bool port
    cannot reproduce) and painterly_renderer as direct collaborator deps.

Also retires the GaussianSplatRenderer member-function-pointer port (benign here
since the type is complete, but PMFs are an ODR-trap class in this codebase).

Risk: R2 (renderer). Evidence: full editor build compiles + links clean
(scons ... dev_build=yes tests=yes, exit 0); guards green
(run_module_tests.py --guard-only, 108 OK). Diff reviewed for 1:1 behavior
equivalence at each of the 5 sites + the construction wiring.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
