### PR TITLE
gaussian_splatting: extract scene-director sphere-effector cluster into its own TU

### DIFF
--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -1,5 +1,6 @@
 #include "gaussian_splat_scene_director.h"
 
+#include "scene_director_internal.h"
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
 #include "core/math/math_funcs.h"
@@ -221,20 +222,6 @@ static NodeSceneEffectorFilterState _get_node_scene_effector_filter_state(const 
 	}
 
 	return filter;
-}
-
-static uint32_t _get_effector_scope_specificity(uint32_t p_scope_mode, bool p_has_scope_root) {
-	if (!p_has_scope_root) {
-		return 0u;
-	}
-	switch (p_scope_mode) {
-		case GaussianSplatSceneDirector::SPHERE_EFFECTOR_SCOPE_EXPLICIT_ROOT:
-			return 2u;
-		case GaussianSplatSceneDirector::SPHERE_EFFECTOR_SCOPE_SUBTREE:
-			return 1u;
-		default:
-			return 0u;
-	}
 }
 
 static float _encode_u32_as_float_bits(uint32_t p_value) {
@@ -499,134 +486,6 @@ uint32_t GaussianSplatSceneDirector::_build_scene_effector_mask_for_record(const
 		mask |= (1u << i);
 	}
 	return mask;
-}
-
-void GaussianSplatSceneDirector::_build_sorted_sphere_effector_payload(const SharedWorld &p_world,
-		LocalVector<SphereEffectorSelection> &r_out) {
-	r_out.clear();
-	if (p_world.sphere_effectors.is_empty()) {
-		return;
-	}
-
-	struct Candidate {
-		SphereEffectorSelection selection;
-		uint64_t registration_serial = 0u;
-		uint32_t specificity = 0u;
-	};
-
-	// Sort deterministically by (priority, specificity, registration serial,
-	// effector_id). Uses the record's monotonic registration serial instead of
-	// the effector's scene-path — the path would require a live `get_path()`
-	// call from the render thread (not thread-safe) and would reorder
-	// equal-priority slots on rename without bumping any generation, leaving
-	// cached per-instance masks pointing at the wrong slots.
-	auto candidate_precedes = [](const Candidate &p_a, const Candidate &p_b) {
-		if (p_a.selection.priority != p_b.selection.priority) {
-			return p_a.selection.priority > p_b.selection.priority;
-		}
-		if (p_a.specificity != p_b.specificity) {
-			return p_a.specificity > p_b.specificity;
-		}
-		if (p_a.registration_serial != p_b.registration_serial) {
-			return p_a.registration_serial < p_b.registration_serial;
-		}
-		return (uint64_t)p_a.selection.effector_id < (uint64_t)p_b.selection.effector_id;
-	};
-
-	LocalVector<Candidate> candidates;
-	candidates.reserve(p_world.sphere_effectors.size());
-	for (const SphereEffectorRecord &record : p_world.sphere_effectors) {
-		// Filter ineligible records BEFORE the slot cap so ineligible
-		// effectors can't consume a top-N slot and push a valid effector out.
-		//
-		// Rejected here:
-		//   - disabled / zero-radius (GPU rejects in the packers anyway)
-		//   - non-finite transform origins (same)
-		//   - can't-contribute: even if the affect_* flags are set, the
-		//     effector is inert when position strength is zero AND opacity
-		//     can't move the splat (opacity_strength==0 or target==1.0).
-		//     Without this, e.g. an affect_opacity-only effector with
-		//     target_opacity=1.0 still wins slots but contributes nothing.
-		if (!record.enabled || record.radius <= 0.0f ||
-				(!record.affect_position && !record.affect_opacity)) {
-			continue;
-		}
-		const Vector3 &center = record.transform.origin;
-		if (!Math::is_finite(center.x) || !Math::is_finite(center.y) || !Math::is_finite(center.z)) {
-			continue;
-		}
-		const bool position_can_contribute = record.affect_position && !Math::is_zero_approx(record.strength);
-		// target_opacity==1.0 is the neutral "fully opaque" target; combined
-		// with non-zero opacity_strength it still produces no visible change
-		// for already-opaque splats, so treat it as inert here. Matches the
-		// diagnostic gate in `get_scene_effector_debug_state_for_instance`.
-		const bool opacity_can_contribute = record.affect_opacity &&
-				!Math::is_zero_approx(record.opacity_strength) &&
-				!Math::is_equal_approx(record.target_opacity, 1.0f);
-		if (!position_can_contribute && !opacity_can_contribute) {
-			continue;
-		}
-
-		// SCOPE_SUBTREE / SCOPE_EXPLICIT_ROOT carry a resolved `scope_root_id`
-		// populated on the main thread at register/update time. Revalidate
-		// that the ObjectID still resolves to a live Node — scope-root
-		// deletion after sync would otherwise keep the effector eligible
-		// while matching no instances. `ObjectDB::get_instance()` is
-		// thread-safe, and we mutate the cached `scope_root_valid` flag
-		// under `world_mutex` (via const_cast — the world is actually
-		// addressable through the non-const caller that holds the mutex)
-		// plus bump `sphere_effector_generation` so cached instance
-		// bitmasks invalidate and rebuild without the dropped effector.
-		if (record.scope_mode != SPHERE_EFFECTOR_SCOPE_WORLD) {
-			const bool scope_alive = record.scope_root_id != ObjectID() &&
-					Object::cast_to<Node>(ObjectDB::get_instance(record.scope_root_id)) != nullptr;
-			if (!scope_alive) {
-				if (record.scope_root_valid) {
-					const_cast<SphereEffectorRecord &>(record).scope_root_valid = false;
-					const_cast<SharedWorld &>(p_world).sphere_effector_generation++;
-				}
-				continue;
-			}
-			if (!record.scope_root_valid) {
-				// Flipped back to alive (rare — node re-registered at the same ID).
-				const_cast<SphereEffectorRecord &>(record).scope_root_valid = true;
-				const_cast<SharedWorld &>(p_world).sphere_effector_generation++;
-			}
-		}
-
-		Candidate candidate;
-		candidate.selection.effector_id = record.effector_id;
-		candidate.selection.scenario = p_world.scenario;
-		candidate.selection.transform = record.transform;
-		candidate.selection.center = record.transform.origin;
-		candidate.selection.radius = record.radius;
-		candidate.selection.strength = record.strength;
-		candidate.selection.falloff = record.falloff;
-		candidate.selection.frequency = record.frequency;
-		candidate.selection.opacity_strength = record.opacity_strength;
-		candidate.selection.target_opacity = record.target_opacity;
-		candidate.selection.layer_mask = record.layer_mask;
-		candidate.selection.scope_mode = record.scope_mode;
-		candidate.selection.scope_root_id = record.scope_root_id;
-		candidate.selection.priority = record.priority;
-		candidate.selection.enabled = record.enabled;
-		candidate.selection.affect_position = record.affect_position;
-		candidate.selection.affect_opacity = record.affect_opacity;
-		candidate.registration_serial = record.registration_serial;
-		candidate.specificity = _get_effector_scope_specificity(record.scope_mode, record.scope_root_id != ObjectID());
-
-		int insert_at = candidates.size();
-		while (insert_at > 0 && candidate_precedes(candidate, candidates[insert_at - 1])) {
-			insert_at--;
-		}
-		candidates.insert(insert_at, candidate);
-	}
-
-	const uint32_t capped_count = MIN<uint32_t>(candidates.size(), GS_MAX_SPHERE_EFFECTORS);
-	r_out.reserve(capped_count);
-	for (uint32_t i = 0; i < capped_count; i++) {
-		r_out.push_back(candidates[i].selection);
-	}
 }
 
 GaussianSplatSceneDirector::SharedWorld *GaussianSplatSceneDirector::_find_world_for_renderer(const GaussianSplatRenderer *p_renderer) {
@@ -2235,27 +2094,6 @@ void GaussianSplatSceneDirector::unregister_sphere_effector(ObjectID p_effector_
 	_prune_world_if_unused(world->scenario);
 }
 
-void GaussianSplatSceneDirector::build_sphere_effector_payload_for_renderer(const GaussianSplatRenderer *p_renderer,
-		LocalVector<SphereEffectorSelection> &out, uint32_t *r_total_scene_effectors) const {
-	MutexLock lock(world_mutex);
-	out.clear();
-	if (r_total_scene_effectors) {
-		*r_total_scene_effectors = 0u;
-	}
-
-	const SharedWorld *world = _find_world_for_renderer(p_renderer);
-	if (!world) {
-		return;
-	}
-
-	_build_sorted_sphere_effector_payload(*world, out);
-	if (r_total_scene_effectors) {
-		// Raw count under the same lock as the payload build — main-thread
-		// mutations between the two reads cannot create a skew now.
-		*r_total_scene_effectors = world->sphere_effectors.size();
-	}
-}
-
 bool GaussianSplatSceneDirector::get_primary_sphere_effector_for_instance(ObjectID p_node_id,
 		SphereEffectorSelection *r_selection) const {
 	ERR_FAIL_NULL_V(r_selection, false);
@@ -2453,179 +2291,10 @@ bool GaussianSplatSceneDirector::get_scene_effector_match_summary_for_instance(O
 	return matched_count > 0u;
 }
 
-Dictionary GaussianSplatSceneDirector::get_scene_effector_debug_state_for_instance(ObjectID p_node_id) const {
-	Dictionary state;
-	state["matched_count"] = 0;
-	state["bound_count"] = 0;
-	state["truncated"] = false;
-	state["position_active"] = false;
-	state["opacity_active"] = false;
-	state["selected_effector_ids"] = Array();
-	state["selected_effector_names"] = PackedStringArray();
-	state["effective_layer_mask"] = int64_t(0);
-	state["scope_filter_present"] = false;
-	state["scope_filter_valid"] = true;
-	state["effective_scope_root_id"] = int64_t(0);
-	state["matched_position_active"] = false;
-	state["matched_opacity_active"] = false;
-
-	MutexLock lock(world_mutex);
-	const SharedWorld *world = nullptr;
-	for (const KeyValue<RID, SharedWorld> &E : worlds) {
-		if (E.value.instance_lookup.has(p_node_id)) {
-			world = &E.value;
-			break;
-		}
-	}
-	if (!world) {
-		return state;
-	}
-
-	const uint32_t *index_ptr = world->instance_lookup.getptr(p_node_id);
-	if (!index_ptr || *index_ptr >= world->instances.size()) {
-		return state;
-	}
-	const InstanceRecord &record = world->instances[*index_ptr];
-	state["effective_layer_mask"] = int64_t(record.scene_effector_layer_mask);
-	state["scope_filter_present"] = record.scene_effector_scope_filter_present;
-	state["scope_filter_valid"] = record.scene_effector_scope_filter_valid;
-	state["effective_scope_root_id"] = int64_t((uint64_t)record.scene_effector_scope_root_id);
-
-	if (!record.scene_effectors_enabled || record.scene_effector_layer_mask == 0u ||
-			(record.scene_effector_scope_filter_present && !record.scene_effector_scope_filter_valid)) {
-		return state;
-	}
-
-	// Helper: effector's scope is currently valid iff its cached scope_root_id
-	// still resolves to a live Node. ObjectDB lookups are thread-safe and catch
-	// the case where a scope-root node was deleted after the effector synced.
-	auto effector_scope_alive = [](const SphereEffectorRecord &eff) -> bool {
-		if (eff.scope_mode == SPHERE_EFFECTOR_SCOPE_WORLD) {
-			return true;
-		}
-		if (eff.scope_root_id == ObjectID()) {
-			return false;
-		}
-		return Object::cast_to<Node>(ObjectDB::get_instance(eff.scope_root_id)) != nullptr;
-	};
-
-	uint32_t matched_count = 0u;
-	bool matched_position_active = false;
-	bool matched_opacity_active = false;
-	for (const SphereEffectorRecord &effector : world->sphere_effectors) {
-		if (!effector.enabled || (!effector.affect_position && !effector.affect_opacity)) {
-			continue;
-		}
-		if ((effector.layer_mask & record.scene_effector_layer_mask) == 0u) {
-			continue;
-		}
-		if (effector.scope_mode != SPHERE_EFFECTOR_SCOPE_WORLD && !effector_scope_alive(effector)) {
-			continue;
-		}
-		if (record.scene_effector_scope_filter_present) {
-			if (effector.scope_root_id == ObjectID() ||
-					effector.scope_root_id != record.scene_effector_scope_root_id) {
-				continue;
-			}
-		} else if (effector.scope_mode != SPHERE_EFFECTOR_SCOPE_WORLD) {
-			if (effector.scope_root_id == ObjectID()) {
-				continue;
-			}
-			bool in_scope = false;
-			for (const ObjectID &ancestor_id : record.scene_tree_ancestor_ids) {
-				if (ancestor_id == effector.scope_root_id) {
-					in_scope = true;
-					break;
-				}
-			}
-			if (!in_scope) {
-				continue;
-			}
-		}
-
-		matched_count++;
-		// Radius <= 0 is inert on the GPU (see gs_apply_sphere_effectors'
-		// `effector_sphere.w <= 1e-6` early-out). Exclude from active flags so
-		// the diagnostic matches the shader.
-		const bool effector_radius_nonzero = effector.radius > 1e-6f;
-		if (effector_radius_nonzero && effector.affect_position && record.effect_position_scale > 0.0f &&
-				!Math::is_zero_approx(effector.strength)) {
-			matched_position_active = true;
-		}
-		if (effector_radius_nonzero && effector.affect_opacity && record.effect_opacity_scale > 0.0f && record.opacity > 0.0f &&
-				!Math::is_zero_approx(effector.opacity_strength) &&
-				!Math::is_equal_approx(effector.target_opacity, 1.0f)) {
-			matched_opacity_active = true;
-		}
-	}
-
-	// Bind-side stats: how many matched effectors actually survived the
-	// renderer's payload build + mask packing (limited by GS_MAX_SPHERE_EFFECTORS,
-	// invalid scope roots, etc). `_build_sorted_sphere_effector_payload` does the
-	// same scope_root liveness check via ObjectDB so the counts stay consistent.
-	LocalVector<SphereEffectorSelection> payload;
-	_build_sorted_sphere_effector_payload(*world, payload);
-	const uint32_t mask = _build_scene_effector_mask_for_record(record, payload);
-	uint32_t bound_count = 0u;
-	Array selected_effector_ids;
-	PackedStringArray selected_effector_names;
-	bool bound_position_active = false;
-	bool bound_opacity_active = false;
-	for (uint32_t i = 0; i < payload.size(); i++) {
-		if ((mask & (1u << i)) == 0u) {
-			continue;
-		}
-		bound_count++;
-		selected_effector_ids.push_back(int64_t((uint64_t)payload[i].effector_id));
-
-		String effector_name = String::num_uint64((uint64_t)payload[i].effector_id);
-		if (Object *effector_object = ObjectDB::get_instance(payload[i].effector_id)) {
-			if (Node *effector_node = Object::cast_to<Node>(effector_object)) {
-				effector_name = String(effector_node->get_name());
-			}
-		}
-		selected_effector_names.push_back(effector_name);
-
-		// Mirror the shader's early-out: `gs_apply_sphere_effectors` skips any
-		// slot with `effector_sphere.w <= 1e-6` (i.e. radius <= 0), so a
-		// matched/bound zero-radius effector contributes nothing. Treat it
-		// as inactive here so `is_scene_effector_*_active()` doesn't over-
-		// report "active" relative to what the GPU actually does.
-		const bool radius_nonzero = payload[i].radius > 1e-6f;
-		if (radius_nonzero && payload[i].affect_position && record.effect_position_scale > 0.0f &&
-				!Math::is_zero_approx(payload[i].strength)) {
-			bound_position_active = true;
-		}
-		if (radius_nonzero && payload[i].affect_opacity && record.effect_opacity_scale > 0.0f && record.opacity > 0.0f &&
-				!Math::is_zero_approx(payload[i].opacity_strength) &&
-				!Math::is_equal_approx(payload[i].target_opacity, 1.0f)) {
-			bound_opacity_active = true;
-		}
-	}
-
-	state["matched_count"] = int64_t(matched_count);
-	state["bound_count"] = int64_t(bound_count);
-	state["truncated"] = matched_count > bound_count;
-	state["position_active"] = bound_position_active;
-	state["opacity_active"] = bound_opacity_active;
-	state["selected_effector_ids"] = selected_effector_ids;
-	state["selected_effector_names"] = selected_effector_names;
-	state["matched_position_active"] = matched_position_active;
-	state["matched_opacity_active"] = matched_opacity_active;
-	return state;
-}
-
-uint32_t GaussianSplatSceneDirector::get_sphere_effector_count_for_renderer(const GaussianSplatRenderer *p_renderer) const {
-	MutexLock lock(world_mutex);
-	const SharedWorld *world = _find_world_for_renderer(p_renderer);
-	return world ? world->sphere_effectors.size() : 0u;
-}
-
-uint64_t GaussianSplatSceneDirector::get_sphere_effector_generation_for_renderer(const GaussianSplatRenderer *p_renderer) const {
-	MutexLock lock(world_mutex);
-	const SharedWorld *world = _find_world_for_renderer(p_renderer);
-	return world ? world->sphere_effector_generation : 0ull;
-}
+// NOTE: get_scene_effector_debug_state_for_instance,
+// get_sphere_effector_count_for_renderer and
+// get_sphere_effector_generation_for_renderer are defined in the partial-class
+// TU core/scene_director_sphere_effectors.cpp.
 
 bool GaussianSplatSceneDirector::submit_world_submission(const WorldSubmission &p_submission) {
 	if (p_submission.owner_id == ObjectID() || !p_submission.scenario.is_valid()) {

--- a/modules/gaussian_splatting/core/scene_director_internal.h
+++ b/modules/gaussian_splatting/core/scene_director_internal.h
@@ -1,0 +1,33 @@
+#ifndef GAUSSIAN_SCENE_DIRECTOR_INTERNAL_H
+#define GAUSSIAN_SCENE_DIRECTOR_INTERNAL_H
+
+// Small file-local helpers shared between gaussian_splat_scene_director.cpp and
+// its partial-class translation units (e.g. scene_director_sphere_effectors.cpp).
+// These were previously `static` free functions inside the god-file; they are
+// hoisted here unchanged so a sibling TU can see them without duplicating the
+// definition. Keep this header minimal — it is NOT a public module interface.
+
+#include "gaussian_splat_scene_director.h"
+
+#include <cstdint>
+
+// Scope specificity ranking used to break priority ties when ordering sphere
+// effectors. A scoped effector (subtree / explicit-root) is "more specific"
+// than a world-scoped one; explicit-root outranks subtree. Used by both the
+// render-path payload builder and the main-thread primary-effector query, so
+// it must live in shared scope to keep their orderings identical.
+static inline uint32_t _get_effector_scope_specificity(uint32_t p_scope_mode, bool p_has_scope_root) {
+	if (!p_has_scope_root) {
+		return 0u;
+	}
+	switch (p_scope_mode) {
+		case GaussianSplatSceneDirector::SPHERE_EFFECTOR_SCOPE_EXPLICIT_ROOT:
+			return 2u;
+		case GaussianSplatSceneDirector::SPHERE_EFFECTOR_SCOPE_SUBTREE:
+			return 1u;
+		default:
+			return 0u;
+	}
+}
+
+#endif // GAUSSIAN_SCENE_DIRECTOR_INTERNAL_H

--- a/modules/gaussian_splatting/core/scene_director_sphere_effectors.cpp
+++ b/modules/gaussian_splatting/core/scene_director_sphere_effectors.cpp
@@ -1,0 +1,347 @@
+/**
+ * @file scene_director_sphere_effectors.cpp
+ * @brief Sphere-effector coordination for GaussianSplatSceneDirector.
+ *
+ * Extracted verbatim from gaussian_splat_scene_director.cpp to shrink that
+ * god-file. All functions here are GaussianSplatSceneDirector member methods
+ * declared in gaussian_splat_scene_director.h — this is a partial-class
+ * translation unit, mirroring the streaming_lod_policy.cpp pattern. No new
+ * declarations are introduced.
+ *
+ * Contains the render-thread payload builder, the renderer-facing payload /
+ * count / generation accessors, and the main-thread per-instance debug-state
+ * query. The shared file-local helper `_get_effector_scope_specificity` lives
+ * in core/scene_director_internal.h so both this TU and the god-file (which
+ * still hosts get_primary_sphere_effector_for_instance) see the same ordering.
+ */
+
+#include "gaussian_splat_scene_director.h"
+
+#include "scene_director_internal.h"
+#include "core/math/math_funcs.h"
+#include "../renderer/gaussian_gpu_layout.h"
+#include "scene/3d/node_3d.h"
+#include "scene/main/node.h"
+
+void GaussianSplatSceneDirector::_build_sorted_sphere_effector_payload(const SharedWorld &p_world,
+		LocalVector<SphereEffectorSelection> &r_out) {
+	r_out.clear();
+	if (p_world.sphere_effectors.is_empty()) {
+		return;
+	}
+
+	struct Candidate {
+		SphereEffectorSelection selection;
+		uint64_t registration_serial = 0u;
+		uint32_t specificity = 0u;
+	};
+
+	// Sort deterministically by (priority, specificity, registration serial,
+	// effector_id). Uses the record's monotonic registration serial instead of
+	// the effector's scene-path — the path would require a live `get_path()`
+	// call from the render thread (not thread-safe) and would reorder
+	// equal-priority slots on rename without bumping any generation, leaving
+	// cached per-instance masks pointing at the wrong slots.
+	auto candidate_precedes = [](const Candidate &p_a, const Candidate &p_b) {
+		if (p_a.selection.priority != p_b.selection.priority) {
+			return p_a.selection.priority > p_b.selection.priority;
+		}
+		if (p_a.specificity != p_b.specificity) {
+			return p_a.specificity > p_b.specificity;
+		}
+		if (p_a.registration_serial != p_b.registration_serial) {
+			return p_a.registration_serial < p_b.registration_serial;
+		}
+		return (uint64_t)p_a.selection.effector_id < (uint64_t)p_b.selection.effector_id;
+	};
+
+	LocalVector<Candidate> candidates;
+	candidates.reserve(p_world.sphere_effectors.size());
+	for (const SphereEffectorRecord &record : p_world.sphere_effectors) {
+		// Filter ineligible records BEFORE the slot cap so ineligible
+		// effectors can't consume a top-N slot and push a valid effector out.
+		//
+		// Rejected here:
+		//   - disabled / zero-radius (GPU rejects in the packers anyway)
+		//   - non-finite transform origins (same)
+		//   - can't-contribute: even if the affect_* flags are set, the
+		//     effector is inert when position strength is zero AND opacity
+		//     can't move the splat (opacity_strength==0 or target==1.0).
+		//     Without this, e.g. an affect_opacity-only effector with
+		//     target_opacity=1.0 still wins slots but contributes nothing.
+		if (!record.enabled || record.radius <= 0.0f ||
+				(!record.affect_position && !record.affect_opacity)) {
+			continue;
+		}
+		const Vector3 &center = record.transform.origin;
+		if (!Math::is_finite(center.x) || !Math::is_finite(center.y) || !Math::is_finite(center.z)) {
+			continue;
+		}
+		const bool position_can_contribute = record.affect_position && !Math::is_zero_approx(record.strength);
+		// target_opacity==1.0 is the neutral "fully opaque" target; combined
+		// with non-zero opacity_strength it still produces no visible change
+		// for already-opaque splats, so treat it as inert here. Matches the
+		// diagnostic gate in `get_scene_effector_debug_state_for_instance`.
+		const bool opacity_can_contribute = record.affect_opacity &&
+				!Math::is_zero_approx(record.opacity_strength) &&
+				!Math::is_equal_approx(record.target_opacity, 1.0f);
+		if (!position_can_contribute && !opacity_can_contribute) {
+			continue;
+		}
+
+		// SCOPE_SUBTREE / SCOPE_EXPLICIT_ROOT carry a resolved `scope_root_id`
+		// populated on the main thread at register/update time. Revalidate
+		// that the ObjectID still resolves to a live Node — scope-root
+		// deletion after sync would otherwise keep the effector eligible
+		// while matching no instances. `ObjectDB::get_instance()` is
+		// thread-safe, and we mutate the cached `scope_root_valid` flag
+		// under `world_mutex` (via const_cast — the world is actually
+		// addressable through the non-const caller that holds the mutex)
+		// plus bump `sphere_effector_generation` so cached instance
+		// bitmasks invalidate and rebuild without the dropped effector.
+		if (record.scope_mode != SPHERE_EFFECTOR_SCOPE_WORLD) {
+			const bool scope_alive = record.scope_root_id != ObjectID() &&
+					Object::cast_to<Node>(ObjectDB::get_instance(record.scope_root_id)) != nullptr;
+			if (!scope_alive) {
+				if (record.scope_root_valid) {
+					const_cast<SphereEffectorRecord &>(record).scope_root_valid = false;
+					const_cast<SharedWorld &>(p_world).sphere_effector_generation++;
+				}
+				continue;
+			}
+			if (!record.scope_root_valid) {
+				// Flipped back to alive (rare — node re-registered at the same ID).
+				const_cast<SphereEffectorRecord &>(record).scope_root_valid = true;
+				const_cast<SharedWorld &>(p_world).sphere_effector_generation++;
+			}
+		}
+
+		Candidate candidate;
+		candidate.selection.effector_id = record.effector_id;
+		candidate.selection.scenario = p_world.scenario;
+		candidate.selection.transform = record.transform;
+		candidate.selection.center = record.transform.origin;
+		candidate.selection.radius = record.radius;
+		candidate.selection.strength = record.strength;
+		candidate.selection.falloff = record.falloff;
+		candidate.selection.frequency = record.frequency;
+		candidate.selection.opacity_strength = record.opacity_strength;
+		candidate.selection.target_opacity = record.target_opacity;
+		candidate.selection.layer_mask = record.layer_mask;
+		candidate.selection.scope_mode = record.scope_mode;
+		candidate.selection.scope_root_id = record.scope_root_id;
+		candidate.selection.priority = record.priority;
+		candidate.selection.enabled = record.enabled;
+		candidate.selection.affect_position = record.affect_position;
+		candidate.selection.affect_opacity = record.affect_opacity;
+		candidate.registration_serial = record.registration_serial;
+		candidate.specificity = _get_effector_scope_specificity(record.scope_mode, record.scope_root_id != ObjectID());
+
+		int insert_at = candidates.size();
+		while (insert_at > 0 && candidate_precedes(candidate, candidates[insert_at - 1])) {
+			insert_at--;
+		}
+		candidates.insert(insert_at, candidate);
+	}
+
+	const uint32_t capped_count = MIN<uint32_t>(candidates.size(), GS_MAX_SPHERE_EFFECTORS);
+	r_out.reserve(capped_count);
+	for (uint32_t i = 0; i < capped_count; i++) {
+		r_out.push_back(candidates[i].selection);
+	}
+}
+
+void GaussianSplatSceneDirector::build_sphere_effector_payload_for_renderer(const GaussianSplatRenderer *p_renderer,
+		LocalVector<SphereEffectorSelection> &out, uint32_t *r_total_scene_effectors) const {
+	MutexLock lock(world_mutex);
+	out.clear();
+	if (r_total_scene_effectors) {
+		*r_total_scene_effectors = 0u;
+	}
+
+	const SharedWorld *world = _find_world_for_renderer(p_renderer);
+	if (!world) {
+		return;
+	}
+
+	_build_sorted_sphere_effector_payload(*world, out);
+	if (r_total_scene_effectors) {
+		// Raw count under the same lock as the payload build — main-thread
+		// mutations between the two reads cannot create a skew now.
+		*r_total_scene_effectors = world->sphere_effectors.size();
+	}
+}
+
+Dictionary GaussianSplatSceneDirector::get_scene_effector_debug_state_for_instance(ObjectID p_node_id) const {
+	Dictionary state;
+	state["matched_count"] = 0;
+	state["bound_count"] = 0;
+	state["truncated"] = false;
+	state["position_active"] = false;
+	state["opacity_active"] = false;
+	state["selected_effector_ids"] = Array();
+	state["selected_effector_names"] = PackedStringArray();
+	state["effective_layer_mask"] = int64_t(0);
+	state["scope_filter_present"] = false;
+	state["scope_filter_valid"] = true;
+	state["effective_scope_root_id"] = int64_t(0);
+	state["matched_position_active"] = false;
+	state["matched_opacity_active"] = false;
+
+	MutexLock lock(world_mutex);
+	const SharedWorld *world = nullptr;
+	for (const KeyValue<RID, SharedWorld> &E : worlds) {
+		if (E.value.instance_lookup.has(p_node_id)) {
+			world = &E.value;
+			break;
+		}
+	}
+	if (!world) {
+		return state;
+	}
+
+	const uint32_t *index_ptr = world->instance_lookup.getptr(p_node_id);
+	if (!index_ptr || *index_ptr >= world->instances.size()) {
+		return state;
+	}
+	const InstanceRecord &record = world->instances[*index_ptr];
+	state["effective_layer_mask"] = int64_t(record.scene_effector_layer_mask);
+	state["scope_filter_present"] = record.scene_effector_scope_filter_present;
+	state["scope_filter_valid"] = record.scene_effector_scope_filter_valid;
+	state["effective_scope_root_id"] = int64_t((uint64_t)record.scene_effector_scope_root_id);
+
+	if (!record.scene_effectors_enabled || record.scene_effector_layer_mask == 0u ||
+			(record.scene_effector_scope_filter_present && !record.scene_effector_scope_filter_valid)) {
+		return state;
+	}
+
+	// Helper: effector's scope is currently valid iff its cached scope_root_id
+	// still resolves to a live Node. ObjectDB lookups are thread-safe and catch
+	// the case where a scope-root node was deleted after the effector synced.
+	auto effector_scope_alive = [](const SphereEffectorRecord &eff) -> bool {
+		if (eff.scope_mode == SPHERE_EFFECTOR_SCOPE_WORLD) {
+			return true;
+		}
+		if (eff.scope_root_id == ObjectID()) {
+			return false;
+		}
+		return Object::cast_to<Node>(ObjectDB::get_instance(eff.scope_root_id)) != nullptr;
+	};
+
+	uint32_t matched_count = 0u;
+	bool matched_position_active = false;
+	bool matched_opacity_active = false;
+	for (const SphereEffectorRecord &effector : world->sphere_effectors) {
+		if (!effector.enabled || (!effector.affect_position && !effector.affect_opacity)) {
+			continue;
+		}
+		if ((effector.layer_mask & record.scene_effector_layer_mask) == 0u) {
+			continue;
+		}
+		if (effector.scope_mode != SPHERE_EFFECTOR_SCOPE_WORLD && !effector_scope_alive(effector)) {
+			continue;
+		}
+		if (record.scene_effector_scope_filter_present) {
+			if (effector.scope_root_id == ObjectID() ||
+					effector.scope_root_id != record.scene_effector_scope_root_id) {
+				continue;
+			}
+		} else if (effector.scope_mode != SPHERE_EFFECTOR_SCOPE_WORLD) {
+			if (effector.scope_root_id == ObjectID()) {
+				continue;
+			}
+			bool in_scope = false;
+			for (const ObjectID &ancestor_id : record.scene_tree_ancestor_ids) {
+				if (ancestor_id == effector.scope_root_id) {
+					in_scope = true;
+					break;
+				}
+			}
+			if (!in_scope) {
+				continue;
+			}
+		}
+
+		matched_count++;
+		// Radius <= 0 is inert on the GPU (see gs_apply_sphere_effectors'
+		// `effector_sphere.w <= 1e-6` early-out). Exclude from active flags so
+		// the diagnostic matches the shader.
+		const bool effector_radius_nonzero = effector.radius > 1e-6f;
+		if (effector_radius_nonzero && effector.affect_position && record.effect_position_scale > 0.0f &&
+				!Math::is_zero_approx(effector.strength)) {
+			matched_position_active = true;
+		}
+		if (effector_radius_nonzero && effector.affect_opacity && record.effect_opacity_scale > 0.0f && record.opacity > 0.0f &&
+				!Math::is_zero_approx(effector.opacity_strength) &&
+				!Math::is_equal_approx(effector.target_opacity, 1.0f)) {
+			matched_opacity_active = true;
+		}
+	}
+
+	// Bind-side stats: how many matched effectors actually survived the
+	// renderer's payload build + mask packing (limited by GS_MAX_SPHERE_EFFECTORS,
+	// invalid scope roots, etc). `_build_sorted_sphere_effector_payload` does the
+	// same scope_root liveness check via ObjectDB so the counts stay consistent.
+	LocalVector<SphereEffectorSelection> payload;
+	_build_sorted_sphere_effector_payload(*world, payload);
+	const uint32_t mask = _build_scene_effector_mask_for_record(record, payload);
+	uint32_t bound_count = 0u;
+	Array selected_effector_ids;
+	PackedStringArray selected_effector_names;
+	bool bound_position_active = false;
+	bool bound_opacity_active = false;
+	for (uint32_t i = 0; i < payload.size(); i++) {
+		if ((mask & (1u << i)) == 0u) {
+			continue;
+		}
+		bound_count++;
+		selected_effector_ids.push_back(int64_t((uint64_t)payload[i].effector_id));
+
+		String effector_name = String::num_uint64((uint64_t)payload[i].effector_id);
+		if (Object *effector_object = ObjectDB::get_instance(payload[i].effector_id)) {
+			if (Node *effector_node = Object::cast_to<Node>(effector_object)) {
+				effector_name = String(effector_node->get_name());
+			}
+		}
+		selected_effector_names.push_back(effector_name);
+
+		// Mirror the shader's early-out: `gs_apply_sphere_effectors` skips any
+		// slot with `effector_sphere.w <= 1e-6` (i.e. radius <= 0), so a
+		// matched/bound zero-radius effector contributes nothing. Treat it
+		// as inactive here so `is_scene_effector_*_active()` doesn't over-
+		// report "active" relative to what the GPU actually does.
+		const bool radius_nonzero = payload[i].radius > 1e-6f;
+		if (radius_nonzero && payload[i].affect_position && record.effect_position_scale > 0.0f &&
+				!Math::is_zero_approx(payload[i].strength)) {
+			bound_position_active = true;
+		}
+		if (radius_nonzero && payload[i].affect_opacity && record.effect_opacity_scale > 0.0f && record.opacity > 0.0f &&
+				!Math::is_zero_approx(payload[i].opacity_strength) &&
+				!Math::is_equal_approx(payload[i].target_opacity, 1.0f)) {
+			bound_opacity_active = true;
+		}
+	}
+
+	state["matched_count"] = int64_t(matched_count);
+	state["bound_count"] = int64_t(bound_count);
+	state["truncated"] = matched_count > bound_count;
+	state["position_active"] = bound_position_active;
+	state["opacity_active"] = bound_opacity_active;
+	state["selected_effector_ids"] = selected_effector_ids;
+	state["selected_effector_names"] = selected_effector_names;
+	state["matched_position_active"] = matched_position_active;
+	state["matched_opacity_active"] = matched_opacity_active;
+	return state;
+}
+
+uint32_t GaussianSplatSceneDirector::get_sphere_effector_count_for_renderer(const GaussianSplatRenderer *p_renderer) const {
+	MutexLock lock(world_mutex);
+	const SharedWorld *world = _find_world_for_renderer(p_renderer);
+	return world ? world->sphere_effectors.size() : 0u;
+}
+
+uint64_t GaussianSplatSceneDirector::get_sphere_effector_generation_for_renderer(const GaussianSplatRenderer *p_renderer) const {
+	MutexLock lock(world_mutex);
+	const SharedWorld *world = _find_world_for_renderer(p_renderer);
+	return world ? world->sphere_effector_generation : 0ull;
+}


### PR DESCRIPTION
Decomposition of the GaussianSplatSceneDirector god-file (the second-largest in
the module). Moves the five sphere-effector coordination member methods
(_build_sorted_sphere_effector_payload, build_sphere_effector_payload_for_renderer,
get_scene_effector_debug_state_for_instance, get_sphere_effector_count_for_renderer,
get_sphere_effector_generation_for_renderer) out of gaussian_splat_scene_director.cpp
into a new partial-class TU core/scene_director_sphere_effectors.cpp (the proven
partial-class pattern; declarations stay in the header, so the live
get_scene_effector_debug_state_for_instance caller in gaussian_splat_node_3d.cpp
is unaffected).

The file-static _get_effector_scope_specificity helper is shared with a method
that stays behind, so it was hoisted (not moved) to a new minimal
core/scene_director_internal.h as `static inline`; both TUs include it. The
const_cast-on-SharedWorld + world_mutex reliance in _build_sorted_* is preserved
verbatim (not "fixed").

Result: gaussian_splat_scene_director.cpp 2976 -> 2645 LOC. Pure code move,
behavior-preserving.

Note: this branch and chore/gs-remove-dead-effector-queries both edit
gaussian_splat_scene_director.cpp off master; apply them in sequence at
integration (trivial conflict).

Risk: R1/R2. Evidence: full editor build compiles + links clean
(scons ... dev_build=yes tests=yes, exit 0); guards green
(run_module_tests.py --guard-only, 108 OK).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
