### PR TITLE
gaussian_splatting: extract chunk-invariant validators into their own TU (decomposition slice 2)

### DIFF
--- a/modules/gaussian_splatting/core/gaussian_streaming.cpp
+++ b/modules/gaussian_splatting/core/gaussian_streaming.cpp
@@ -2,6 +2,7 @@
 #include "../io/streaming_chunk_bake.h"
 #include "gs_project_settings.h"
 #include "residency_budget_controller.h"
+#include "streaming_chunk_invariants.h"
 #include "streaming_layout_hint.h"
 #include "streaming_queue_pressure_controller.h"
 #include "streaming_telemetry_adapter.h"
@@ -29,6 +30,9 @@
 // Layout-hint validation/diagnostics subsystem extracted to streaming_layout_hint.{h,cpp}.
 // The using-directive keeps the existing call sites below unqualified.
 using namespace gs_layout_hint;
+// Chunk slot/upload-lifecycle invariant validators extracted to
+// streaming_chunk_invariants.{h,cpp} (decomposition slice 2).
+using namespace gs_chunk_invariants;
 
 namespace {
 
@@ -163,139 +167,6 @@ void _validate_queue_pressure_latched_state(bool &r_active, String &r_source, St
             p_context ? String(p_context) : String("unknown"),
             latch_error));
     StreamingQueuePressureController::reset_latched_state(r_active, r_source, r_reason);
-}
-
-void _release_chunk_slot_if_matches(GaussianAtlasAllocator &p_allocator, uint64_t p_chunk_key, uint32_t p_expected_slot) {
-    uint32_t mapped_slot = UINT32_MAX;
-    if (!p_allocator.get_slot(p_chunk_key, mapped_slot)) {
-        return;
-    }
-    if (p_expected_slot != UINT32_MAX && mapped_slot != p_expected_slot) {
-        return;
-    }
-    p_allocator.release_slot(p_chunk_key);
-}
-
-bool _chunk_slot_matches_allocator(const GaussianAtlasAllocator &p_allocator, uint64_t p_chunk_key, uint32_t p_expected_slot, uint32_t *r_mapped_slot = nullptr) {
-    uint32_t mapped_slot = UINT32_MAX;
-    const bool has_slot = p_allocator.get_slot(p_chunk_key, mapped_slot);
-    if (r_mapped_slot) {
-        *r_mapped_slot = mapped_slot;
-    }
-    return has_slot && mapped_slot == p_expected_slot;
-}
-
-bool _record_streaming_invariant(bool p_invalid_state,
-        GaussianStreamingTypes::DiagnosticsState &r_diagnostics,
-        uint64_t &r_counter,
-        const char *p_context,
-        const String &p_message) {
-    if (!p_invalid_state) {
-        return false;
-    }
-    r_counter++;
-    r_diagnostics.last_invariant_context = p_context;
-    r_diagnostics.last_invariant_message = p_message;
-    WARN_PRINT(p_message);
-    return true;
-}
-
-bool _validate_pending_upload_chunk_invariant(const GaussianAtlasAllocator &p_allocator,
-        const GaussianStreamingTypes::StreamingChunk &p_chunk,
-        uint64_t p_chunk_key,
-        uint32_t p_asset_id,
-        uint32_t p_chunk_idx,
-        const char *p_context,
-        GaussianStreamingTypes::DiagnosticsState &r_diagnostics) {
-    if (_record_streaming_invariant(p_chunk.is_loaded, r_diagnostics,
-                r_diagnostics.invariant_upload_lifecycle_violations,
-                p_context,
-                vformat("[Streaming] Invalid chunk state (%s): asset=%d chunk=%d cannot be both loaded and upload_pending.",
-                        p_context, p_asset_id, p_chunk_idx))) {
-        return true;
-    }
-    if (_record_streaming_invariant(p_chunk.gpu_resident, r_diagnostics,
-                r_diagnostics.invariant_upload_lifecycle_violations,
-                p_context,
-                vformat("[Streaming] Invalid chunk state (%s): asset=%d chunk=%d pending upload cannot be GPU-resident.",
-                        p_context, p_asset_id, p_chunk_idx))) {
-        return true;
-    }
-    if (_record_streaming_invariant(p_chunk.buffer_slot == UINT32_MAX, r_diagnostics,
-                r_diagnostics.invariant_upload_lifecycle_violations,
-                p_context,
-                vformat("[Streaming] Invalid chunk state (%s): asset=%d chunk=%d upload_pending requires a valid buffer_slot.",
-                        p_context, p_asset_id, p_chunk_idx))) {
-        return true;
-    }
-
-    uint32_t mapped_slot = UINT32_MAX;
-    const bool slot_match = _chunk_slot_matches_allocator(p_allocator, p_chunk_key, p_chunk.buffer_slot, &mapped_slot);
-    return _record_streaming_invariant(!slot_match, r_diagnostics,
-            r_diagnostics.invariant_slot_ownership_violations,
-            p_context,
-            vformat("[Streaming] Invalid chunk state (%s): asset=%d chunk=%d upload_pending slot=%d not tracked by allocator (mapped=%d).",
-                    p_context, p_asset_id, p_chunk_idx, p_chunk.buffer_slot,
-                    mapped_slot == UINT32_MAX ? -1 : int(mapped_slot)));
-}
-
-bool _validate_loaded_chunk_invariant(const GaussianAtlasAllocator &p_allocator,
-        const GaussianStreamingTypes::StreamingChunk &p_chunk,
-        uint64_t p_chunk_key,
-        uint32_t p_asset_id,
-        uint32_t p_chunk_idx,
-        const char *p_context,
-        GaussianStreamingTypes::DiagnosticsState &r_diagnostics) {
-    if (_record_streaming_invariant(!p_chunk.gpu_resident, r_diagnostics,
-                r_diagnostics.invariant_upload_lifecycle_violations,
-                p_context,
-                vformat("[Streaming] Invalid chunk state (%s): asset=%d chunk=%d loaded chunk is not GPU-resident.",
-                        p_context, p_asset_id, p_chunk_idx))) {
-        return true;
-    }
-    if (_record_streaming_invariant(p_chunk.buffer_slot == UINT32_MAX, r_diagnostics,
-                r_diagnostics.invariant_upload_lifecycle_violations,
-                p_context,
-                vformat("[Streaming] Invalid chunk state (%s): asset=%d chunk=%d loaded chunk is missing buffer_slot.",
-                        p_context, p_asset_id, p_chunk_idx))) {
-        return true;
-    }
-
-    uint32_t mapped_slot = UINT32_MAX;
-    const bool slot_match = _chunk_slot_matches_allocator(p_allocator, p_chunk_key, p_chunk.buffer_slot, &mapped_slot);
-    return _record_streaming_invariant(!slot_match, r_diagnostics,
-            r_diagnostics.invariant_slot_ownership_violations,
-            p_context,
-            vformat("[Streaming] Invalid chunk state (%s): asset=%d chunk=%d loaded slot=%d not tracked by allocator (mapped=%d).",
-                    p_context, p_asset_id, p_chunk_idx, p_chunk.buffer_slot,
-                    mapped_slot == UINT32_MAX ? -1 : int(mapped_slot)));
-}
-
-void _validate_idle_chunk_invariant(const GaussianAtlasAllocator &p_allocator,
-        const GaussianStreamingTypes::StreamingChunk &p_chunk,
-        uint64_t p_chunk_key,
-        uint32_t p_asset_id,
-        uint32_t p_chunk_idx,
-        const char *p_context,
-        bool p_allow_deferred_allocator_release,
-        GaussianStreamingTypes::DiagnosticsState &r_diagnostics) {
-    uint32_t mapped_slot = UINT32_MAX;
-    const bool slot_tracked = p_allocator.get_slot(p_chunk_key, mapped_slot);
-    if (_record_streaming_invariant(p_chunk.buffer_slot != UINT32_MAX, r_diagnostics,
-                r_diagnostics.invariant_upload_lifecycle_violations,
-                p_context,
-                vformat("[Streaming] Invalid chunk state (%s): asset=%d chunk=%d has buffer_slot=%d while not loaded/pending.",
-                        p_context, p_asset_id, p_chunk_idx, p_chunk.buffer_slot))) {
-        return;
-    }
-    if (p_allow_deferred_allocator_release) {
-        return;
-    }
-    _record_streaming_invariant(slot_tracked, r_diagnostics,
-            r_diagnostics.invariant_slot_ownership_violations,
-            p_context,
-            vformat("[Streaming] Invalid chunk state (%s): asset=%d chunk=%d allocator tracks slot=%d while chunk is not loaded/pending.",
-                    p_context, p_asset_id, p_chunk_idx, mapped_slot));
 }
 
 void _subtract_pending_upload_bytes(GaussianStreamingTypes::BudgetState &r_budget, uint64_t p_bytes) {

--- a/modules/gaussian_splatting/core/streaming_chunk_invariants.cpp
+++ b/modules/gaussian_splatting/core/streaming_chunk_invariants.cpp
@@ -1,0 +1,141 @@
+#include "streaming_chunk_invariants.h"
+
+#include "core/error/error_macros.h"
+#include "core/string/ustring.h"
+
+namespace gs_chunk_invariants {
+
+void _release_chunk_slot_if_matches(GaussianAtlasAllocator &p_allocator, uint64_t p_chunk_key, uint32_t p_expected_slot) {
+    uint32_t mapped_slot = UINT32_MAX;
+    if (!p_allocator.get_slot(p_chunk_key, mapped_slot)) {
+        return;
+    }
+    if (p_expected_slot != UINT32_MAX && mapped_slot != p_expected_slot) {
+        return;
+    }
+    p_allocator.release_slot(p_chunk_key);
+}
+
+bool _chunk_slot_matches_allocator(const GaussianAtlasAllocator &p_allocator, uint64_t p_chunk_key, uint32_t p_expected_slot, uint32_t *r_mapped_slot) {
+    uint32_t mapped_slot = UINT32_MAX;
+    const bool has_slot = p_allocator.get_slot(p_chunk_key, mapped_slot);
+    if (r_mapped_slot) {
+        *r_mapped_slot = mapped_slot;
+    }
+    return has_slot && mapped_slot == p_expected_slot;
+}
+
+bool _record_streaming_invariant(bool p_invalid_state,
+        GaussianStreamingTypes::DiagnosticsState &r_diagnostics,
+        uint64_t &r_counter,
+        const char *p_context,
+        const String &p_message) {
+    if (!p_invalid_state) {
+        return false;
+    }
+    r_counter++;
+    r_diagnostics.last_invariant_context = p_context;
+    r_diagnostics.last_invariant_message = p_message;
+    WARN_PRINT(p_message);
+    return true;
+}
+
+bool _validate_pending_upload_chunk_invariant(const GaussianAtlasAllocator &p_allocator,
+        const GaussianStreamingTypes::StreamingChunk &p_chunk,
+        uint64_t p_chunk_key,
+        uint32_t p_asset_id,
+        uint32_t p_chunk_idx,
+        const char *p_context,
+        GaussianStreamingTypes::DiagnosticsState &r_diagnostics) {
+    if (_record_streaming_invariant(p_chunk.is_loaded, r_diagnostics,
+                r_diagnostics.invariant_upload_lifecycle_violations,
+                p_context,
+                vformat("[Streaming] Invalid chunk state (%s): asset=%d chunk=%d cannot be both loaded and upload_pending.",
+                        p_context, p_asset_id, p_chunk_idx))) {
+        return true;
+    }
+    if (_record_streaming_invariant(p_chunk.gpu_resident, r_diagnostics,
+                r_diagnostics.invariant_upload_lifecycle_violations,
+                p_context,
+                vformat("[Streaming] Invalid chunk state (%s): asset=%d chunk=%d pending upload cannot be GPU-resident.",
+                        p_context, p_asset_id, p_chunk_idx))) {
+        return true;
+    }
+    if (_record_streaming_invariant(p_chunk.buffer_slot == UINT32_MAX, r_diagnostics,
+                r_diagnostics.invariant_upload_lifecycle_violations,
+                p_context,
+                vformat("[Streaming] Invalid chunk state (%s): asset=%d chunk=%d upload_pending requires a valid buffer_slot.",
+                        p_context, p_asset_id, p_chunk_idx))) {
+        return true;
+    }
+
+    uint32_t mapped_slot = UINT32_MAX;
+    const bool slot_match = _chunk_slot_matches_allocator(p_allocator, p_chunk_key, p_chunk.buffer_slot, &mapped_slot);
+    return _record_streaming_invariant(!slot_match, r_diagnostics,
+            r_diagnostics.invariant_slot_ownership_violations,
+            p_context,
+            vformat("[Streaming] Invalid chunk state (%s): asset=%d chunk=%d upload_pending slot=%d not tracked by allocator (mapped=%d).",
+                    p_context, p_asset_id, p_chunk_idx, p_chunk.buffer_slot,
+                    mapped_slot == UINT32_MAX ? -1 : int(mapped_slot)));
+}
+
+bool _validate_loaded_chunk_invariant(const GaussianAtlasAllocator &p_allocator,
+        const GaussianStreamingTypes::StreamingChunk &p_chunk,
+        uint64_t p_chunk_key,
+        uint32_t p_asset_id,
+        uint32_t p_chunk_idx,
+        const char *p_context,
+        GaussianStreamingTypes::DiagnosticsState &r_diagnostics) {
+    if (_record_streaming_invariant(!p_chunk.gpu_resident, r_diagnostics,
+                r_diagnostics.invariant_upload_lifecycle_violations,
+                p_context,
+                vformat("[Streaming] Invalid chunk state (%s): asset=%d chunk=%d loaded chunk is not GPU-resident.",
+                        p_context, p_asset_id, p_chunk_idx))) {
+        return true;
+    }
+    if (_record_streaming_invariant(p_chunk.buffer_slot == UINT32_MAX, r_diagnostics,
+                r_diagnostics.invariant_upload_lifecycle_violations,
+                p_context,
+                vformat("[Streaming] Invalid chunk state (%s): asset=%d chunk=%d loaded chunk is missing buffer_slot.",
+                        p_context, p_asset_id, p_chunk_idx))) {
+        return true;
+    }
+
+    uint32_t mapped_slot = UINT32_MAX;
+    const bool slot_match = _chunk_slot_matches_allocator(p_allocator, p_chunk_key, p_chunk.buffer_slot, &mapped_slot);
+    return _record_streaming_invariant(!slot_match, r_diagnostics,
+            r_diagnostics.invariant_slot_ownership_violations,
+            p_context,
+            vformat("[Streaming] Invalid chunk state (%s): asset=%d chunk=%d loaded slot=%d not tracked by allocator (mapped=%d).",
+                    p_context, p_asset_id, p_chunk_idx, p_chunk.buffer_slot,
+                    mapped_slot == UINT32_MAX ? -1 : int(mapped_slot)));
+}
+
+void _validate_idle_chunk_invariant(const GaussianAtlasAllocator &p_allocator,
+        const GaussianStreamingTypes::StreamingChunk &p_chunk,
+        uint64_t p_chunk_key,
+        uint32_t p_asset_id,
+        uint32_t p_chunk_idx,
+        const char *p_context,
+        bool p_allow_deferred_allocator_release,
+        GaussianStreamingTypes::DiagnosticsState &r_diagnostics) {
+    uint32_t mapped_slot = UINT32_MAX;
+    const bool slot_tracked = p_allocator.get_slot(p_chunk_key, mapped_slot);
+    if (_record_streaming_invariant(p_chunk.buffer_slot != UINT32_MAX, r_diagnostics,
+                r_diagnostics.invariant_upload_lifecycle_violations,
+                p_context,
+                vformat("[Streaming] Invalid chunk state (%s): asset=%d chunk=%d has buffer_slot=%d while not loaded/pending.",
+                        p_context, p_asset_id, p_chunk_idx, p_chunk.buffer_slot))) {
+        return;
+    }
+    if (p_allow_deferred_allocator_release) {
+        return;
+    }
+    _record_streaming_invariant(slot_tracked, r_diagnostics,
+            r_diagnostics.invariant_slot_ownership_violations,
+            p_context,
+            vformat("[Streaming] Invalid chunk state (%s): asset=%d chunk=%d allocator tracks slot=%d while chunk is not loaded/pending.",
+                    p_context, p_asset_id, p_chunk_idx, mapped_slot));
+}
+
+} // namespace gs_chunk_invariants

--- a/modules/gaussian_splatting/core/streaming_chunk_invariants.h
+++ b/modules/gaussian_splatting/core/streaming_chunk_invariants.h
@@ -1,0 +1,51 @@
+#ifndef STREAMING_CHUNK_INVARIANTS_H
+#define STREAMING_CHUNK_INVARIANTS_H
+
+#include "gaussian_streaming.h"
+
+#include "core/string/ustring.h"
+
+#include <cstdint>
+
+// Chunk slot-ownership and upload-lifecycle invariant validators, extracted
+// verbatim from gaussian_streaming.cpp's anonymous namespace (decomposition
+// slice 2). These are free helpers over GaussianAtlasAllocator + the streaming
+// chunk/diagnostics state; they call only each other and their parameters, so
+// they live cleanly in their own translation unit. The upload-retirement and
+// pending-byte helpers were intentionally NOT moved (they are function
+// templates and/or depend on non-moved anon helpers).
+namespace gs_chunk_invariants {
+
+void _release_chunk_slot_if_matches(GaussianAtlasAllocator &p_allocator, uint64_t p_chunk_key, uint32_t p_expected_slot);
+bool _chunk_slot_matches_allocator(const GaussianAtlasAllocator &p_allocator, uint64_t p_chunk_key, uint32_t p_expected_slot, uint32_t *r_mapped_slot = nullptr);
+bool _record_streaming_invariant(bool p_invalid_state,
+        GaussianStreamingTypes::DiagnosticsState &r_diagnostics,
+        uint64_t &r_counter,
+        const char *p_context,
+        const String &p_message);
+bool _validate_pending_upload_chunk_invariant(const GaussianAtlasAllocator &p_allocator,
+        const GaussianStreamingTypes::StreamingChunk &p_chunk,
+        uint64_t p_chunk_key,
+        uint32_t p_asset_id,
+        uint32_t p_chunk_idx,
+        const char *p_context,
+        GaussianStreamingTypes::DiagnosticsState &r_diagnostics);
+bool _validate_loaded_chunk_invariant(const GaussianAtlasAllocator &p_allocator,
+        const GaussianStreamingTypes::StreamingChunk &p_chunk,
+        uint64_t p_chunk_key,
+        uint32_t p_asset_id,
+        uint32_t p_chunk_idx,
+        const char *p_context,
+        GaussianStreamingTypes::DiagnosticsState &r_diagnostics);
+void _validate_idle_chunk_invariant(const GaussianAtlasAllocator &p_allocator,
+        const GaussianStreamingTypes::StreamingChunk &p_chunk,
+        uint64_t p_chunk_key,
+        uint32_t p_asset_id,
+        uint32_t p_chunk_idx,
+        const char *p_context,
+        bool p_allow_deferred_allocator_release,
+        GaussianStreamingTypes::DiagnosticsState &r_diagnostics);
+
+} // namespace gs_chunk_invariants
+
+#endif // STREAMING_CHUNK_INVARIANTS_H


### PR DESCRIPTION
Stacked on the layout-hint extraction (slice 1). Moves the six self-contained
chunk slot-ownership / upload-lifecycle invariant validators out of
gaussian_streaming.cpp's anonymous namespace into a new translation unit
core/streaming_chunk_invariants.{h,cpp} (namespace gs_chunk_invariants):
_release_chunk_slot_if_matches, _chunk_slot_matches_allocator,
_record_streaming_invariant, _validate_pending_upload_chunk_invariant,
_validate_loaded_chunk_invariant, _validate_idle_chunk_invariant.

These six are free helpers over GaussianAtlasAllocator + the streaming
chunk/diagnostics state that reference only each other and their parameters —
a clean partial-class move. The adjacent upload-retirement helpers were
deliberately left in place: four are function templates (instantiated with the
class-nested PendingUploadRetirement) and they depend on non-moved anon
helpers (_subtract_pending_upload_bytes / _release_pending_upload_slot, also
used by out-of-scope code), so moving them is a different, larger change.

gaussian_streaming.cpp includes the new header + adds
`using namespace gs_chunk_invariants;` so all call sites compile unchanged.
The default argument on _chunk_slot_matches_allocator now lives only on the
header declaration (not the definition).

Result: gaussian_streaming.cpp 5592 -> 5459 LOC (6051 at the start of the
decomposition; -592 across slices 1+2).

Risk: R2 (streaming). Evidence: incremental editor build of the combined
slice1+slice2 tree compiles + links clean (scons ... dev_build=yes tests=yes,
exit 0); guards green (run_module_tests.py --guard-only, 108 OK).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
