### PR TITLE
gaussian_splatting: fix unclamped lod_bias preset read; derive node range from one constant (B2)

### DIFF
--- a/modules/gaussian_splatting/core/gs_project_settings.h
+++ b/modules/gaussian_splatting/core/gs_project_settings.h
@@ -22,6 +22,21 @@
 #include "core/variant/variant.h"
 
 namespace gs {
+
+// Canonical user-facing lod_bias range for the scene-facing nodes
+// (GaussianSplatNode3D / GaussianSplatWorld3D). Single source of truth for the
+// setter CLAMP and the editor PROPERTY_HINT_RANGE so they can never drift.
+// The low-level GaussianSplatRenderer intentionally accepts a wider internal
+// range ([0.01, 8.0]) as a permissive superset — node values are always
+// pre-clamped to this range before reaching it, so the renderer's range never
+// narrows a node value; it only allows programmatic/preset callers a wider span.
+static constexpr float GS_LOD_BIAS_MIN = 0.1f;
+static constexpr float GS_LOD_BIAS_MAX = 4.0f;
+// Keep this hint string numerically equal to [GS_LOD_BIAS_MIN, GS_LOD_BIAS_MAX]
+// (PROPERTY_HINT_RANGE needs a compile-time string literal, so it can't embed
+// the constexpr floats directly).
+#define GS_LOD_BIAS_HINT_RANGE "0.1,4.0,0.1"
+
 namespace settings {
 
 /**

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_3d.cpp
@@ -101,7 +101,7 @@ void GaussianSplatNode3D::_bind_methods() {
 
     ClassDB::bind_method(D_METHOD("set_lod_bias", "bias"), &GaussianSplatNode3D::set_lod_bias);
     ClassDB::bind_method(D_METHOD("get_lod_bias"), &GaussianSplatNode3D::get_lod_bias);
-    ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "quality/lod_bias", PROPERTY_HINT_RANGE, "0.1,4.0,0.1"), "set_lod_bias", "get_lod_bias");
+    ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "quality/lod_bias", PROPERTY_HINT_RANGE, GS_LOD_BIAS_HINT_RANGE), "set_lod_bias", "get_lod_bias");
 
     ClassDB::bind_method(D_METHOD("set_max_render_distance", "distance"), &GaussianSplatNode3D::set_max_render_distance);
     ClassDB::bind_method(D_METHOD("get_max_render_distance"), &GaussianSplatNode3D::get_max_render_distance);
@@ -985,7 +985,7 @@ void GaussianSplatNode3D::set_quality_preset(QualityPreset p_preset) {
 }
 
 void GaussianSplatNode3D::set_lod_bias(float p_bias) {
-    lod_bias = CLAMP(p_bias, 0.1f, 4.0f);
+    lod_bias = CLAMP(p_bias, gs::GS_LOD_BIAS_MIN, gs::GS_LOD_BIAS_MAX);
     _update_quality_settings();
     _mark_render_state_dirty();
     _update_instance_params_in_director();

--- a/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_node_helpers.cpp
@@ -3,6 +3,7 @@
 #include "gaussian_splat_node_3d.h"
 #include "../core/effective_config_snapshot.h"
 #include "../core/gaussian_splat_settings_manager.h"
+#include "../core/gs_project_settings.h"
 #include "../core/gaussian_splat_scene_director.h"
 #include "../core/gaussian_streaming.h"
 #include "../core/quality_tier_config.h"
@@ -772,7 +773,7 @@ void GaussianSplatNodeQualityHelper::apply_quality_preset() {
         return (int)value;
     };
 
-    owner.lod_bias = CLAMP(get_float("lod_bias", owner.lod_bias), 0.1f, 4.0f);
+    owner.lod_bias = CLAMP(get_float("lod_bias", owner.lod_bias), gs::GS_LOD_BIAS_MIN, gs::GS_LOD_BIAS_MAX);
     owner.max_splat_count = MAX(1000, get_int("max_splat_count", owner.max_splat_count));
 
     update_quality_settings();
@@ -802,7 +803,11 @@ void GaussianSplatNodeQualityHelper::update_quality_settings() {
         return (bool)value;
     };
 
-    owner.lod_bias = get_float("lod_bias", owner.lod_bias);
+    // Clamp to the canonical node lod_bias range — matches apply_quality_preset
+    // and set_lod_bias. Without this, a preset-supplied lod_bias would overwrite
+    // the setter-clamped value and silently escape the [GS_LOD_BIAS_MIN,
+    // GS_LOD_BIAS_MAX] contract the node property + inspector advertise.
+    owner.lod_bias = CLAMP(get_float("lod_bias", owner.lod_bias), gs::GS_LOD_BIAS_MIN, gs::GS_LOD_BIAS_MAX);
     owner.max_splat_count = MAX(1000, get_int("max_splat_count", owner.max_splat_count));
 
     const float min_budget_fraction = CLAMP(get_float("min_budget_fraction", 0.1f), 0.0f, 1.0f);

--- a/modules/gaussian_splatting/nodes/gaussian_splat_world_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_world_3d.cpp
@@ -63,7 +63,7 @@ void GaussianSplatWorld3D::_bind_methods() {
 
     ADD_GROUP("Quality", "quality/");
     ADD_PROPERTY(PropertyInfo(Variant::BOOL, "quality/lod_enabled"), "set_lod_enabled", "is_lod_enabled");
-    ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "quality/lod_bias", PROPERTY_HINT_RANGE, "0.1,4.0,0.1"),
+    ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "quality/lod_bias", PROPERTY_HINT_RANGE, GS_LOD_BIAS_HINT_RANGE),
             "set_lod_bias", "get_lod_bias");
     ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "quality/max_render_distance", PROPERTY_HINT_RANGE, "0.0,10000.0,1.0,or_greater,suffix:m"),
             "set_max_render_distance", "get_max_render_distance");
@@ -243,7 +243,7 @@ void GaussianSplatWorld3D::set_lod_enabled(bool p_enabled) {
 }
 
 void GaussianSplatWorld3D::set_lod_bias(float p_bias) {
-    lod_bias = CLAMP(p_bias, 0.1f, 4.0f);
+    lod_bias = CLAMP(p_bias, gs::GS_LOD_BIAS_MIN, gs::GS_LOD_BIAS_MAX);
     _resubmit_world_submission_if_registered();
 }
 

--- a/modules/gaussian_splatting/renderer/render_quality_orchestrator.cpp
+++ b/modules/gaussian_splatting/renderer/render_quality_orchestrator.cpp
@@ -114,6 +114,11 @@ void RenderQualityOrchestrator::set_lod_enabled(bool p_enabled) {
 }
 
 void RenderQualityOrchestrator::set_lod_bias(float p_bias) {
+	// Intentionally WIDER than the scene-facing node range
+	// [gs::GS_LOD_BIAS_MIN, gs::GS_LOD_BIAS_MAX] = [0.1, 4.0]. This is the
+	// low-level renderer API; node values arrive already clamped to the
+	// narrower range, so this permissive superset never narrows a node value —
+	// it only gives programmatic/preset callers a wider span. Keep [0.01, 8.0].
 	float clamped = CLAMP(p_bias, 0.01f, 8.0f);
 	if (!Math::is_equal_approx(gpu_culler->get_config().lod_bias, clamped)) {
 		gpu_culler->get_config().lod_bias = clamped;


### PR DESCRIPTION
GaussianSplatNodeQualityHelper::update_quality_settings() (node_helpers.cpp:805)
re-read lod_bias from the preset config with NO clamp and overwrote the
setter-clamped value — so a preset could push owner.lod_bias outside the
[0.1, 4.0] contract that set_lod_bias and the node's inspector range both
advertise (a latent contract bug; downstream consumers only floor it, so no
crash, but the value silently escaped the documented range).

Fix: clamp that read to the canonical node range, matching apply_quality_preset
(:775) and set_lod_bias.

Per the "knobs derive from one shared constant" standard, the node-facing
lod_bias range is now a single source of truth: gs::GS_LOD_BIAS_MIN/MAX (0.1/4.0)
+ GS_LOD_BIAS_HINT_RANGE in core/gs_project_settings.h, used by both node/world
setters' CLAMP and their PROPERTY_HINT_RANGE so the clamp and the inspector hint
can never drift. The low-level GaussianSplatRenderer keeps its intentionally
wider internal range [0.01, 8.0] (now documented as a permissive superset —
node values arrive pre-clamped, so it never narrows them).

Panel-reviewed (3 Claude lenses + Codex, unanimous: :805 is a real bug, fix it;
canonical = [0.1,4.0]; keep+document the renderer superset).

Risk: R1. Evidence: full editor build compiles + links clean (scons ...
dev_build=yes tests=yes, exit 0); guards green (108 OK).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
