### PR TITLE
gaussian_splatting: consolidate debug-log gates onto canonical helper (honor GS_SILENCE_LOGS) (D10)

### DIFF
--- a/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
+++ b/modules/gaussian_splatting/core/gaussian_splat_scene_director.cpp
@@ -1,5 +1,6 @@
 #include "gaussian_splat_scene_director.h"
 
+#include "gs_project_settings.h"
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
 #include "core/math/math_funcs.h"
@@ -15,17 +16,8 @@
 #include <cstring>
 
 static bool _is_scene_director_log_enabled() {
-	ProjectSettings *ps = ProjectSettings::get_singleton();
-	if (!ps) {
-		return false;
-	}
-	if (ps->get_setting("rendering/gaussian_splatting/debug/enable_all_debug", false)) {
-		return true;
-	}
-	if (ps->get_setting("rendering/gaussian_splatting/debug/enable_frame_logging", false)) {
-		return true;
-	}
-	return ps->get_setting("rendering/gaussian_splatting/debug/enable_data_logging", false);
+	// Canonical gate: all_debug || frame || data, honoring GS_SILENCE_LOGS.
+	return gs::settings::is_any_debug_log_enabled();
 }
 
 static void _bump_instance_generation(uint64_t &r_generation) {

--- a/modules/gaussian_splatting/core/gs_project_settings.h
+++ b/modules/gaussian_splatting/core/gs_project_settings.h
@@ -162,6 +162,18 @@ static inline bool is_frame_log_enabled() {
 #endif
 }
 
+/**
+ * @brief Whether ANY debug logging (frame-level or data-level) is enabled.
+ *
+ * Canonical replacement for the per-file `all_debug || frame || data` gate
+ * functions. Like is_frame_log_enabled()/is_data_log_enabled(), this honors the
+ * GS_SILENCE_LOGS build flag (returns false in a silenced build), which the
+ * old hand-rolled local copies did not.
+ */
+static inline bool is_any_debug_log_enabled() {
+	return is_frame_log_enabled() || is_data_log_enabled();
+}
+
 // Streaming route policy constants.
 enum GSStreamingRoutePolicy {
 	GS_ROUTE_RESIDENT = 0,

--- a/modules/gaussian_splatting/core/streaming_global_atlas_registry.cpp
+++ b/modules/gaussian_splatting/core/streaming_global_atlas_registry.cpp
@@ -7,6 +7,7 @@
 #include "streaming_global_atlas_registry.h"
 
 #include "gaussian_streaming.h"
+#include "gs_project_settings.h"
 #include "core/config/project_settings.h"
 #include "core/templates/span.h"
 #include "../logger/gs_logger.h"
@@ -20,17 +21,8 @@ constexpr uint32_t CHUNK_META_FULL_UPLOAD_RANGE_THRESHOLD = 16;
 constexpr uint32_t CHUNK_META_FULL_UPLOAD_DIRTY_DIVISOR = 4;
 
 bool _is_streaming_debug_enabled() {
-	ProjectSettings *ps = ProjectSettings::get_singleton();
-	if (!ps) {
-		return false;
-	}
-	if (ps->get_setting("rendering/gaussian_splatting/debug/enable_all_debug", false)) {
-		return true;
-	}
-	if (ps->get_setting("rendering/gaussian_splatting/debug/enable_frame_logging", false)) {
-		return true;
-	}
-	return ps->get_setting("rendering/gaussian_splatting/debug/enable_data_logging", false);
+	// Canonical gate: all_debug || frame || data, honoring GS_SILENCE_LOGS.
+	return gs::settings::is_any_debug_log_enabled();
 }
 
 void _clear_dirty_flags(LocalVector<uint8_t> &flags) {

--- a/modules/gaussian_splatting/nodes/gaussian_splat_world_3d.cpp
+++ b/modules/gaussian_splatting/nodes/gaussian_splat_world_3d.cpp
@@ -16,17 +16,8 @@
 namespace {
 
 static bool _is_world_debug_enabled() {
-    ProjectSettings *ps = ProjectSettings::get_singleton();
-    if (!ps) {
-        return false;
-    }
-    if (ps->get_setting("rendering/gaussian_splatting/debug/enable_all_debug", false)) {
-        return true;
-    }
-    if (ps->get_setting("rendering/gaussian_splatting/debug/enable_frame_logging", false)) {
-        return true;
-    }
-    return ps->get_setting("rendering/gaussian_splatting/debug/enable_data_logging", false);
+    // Canonical gate: all_debug || frame || data, honoring GS_SILENCE_LOGS.
+    return gs::settings::is_any_debug_log_enabled();
 }
 
 } // namespace


### PR DESCRIPTION
Three per-file debug-log gate functions hand-rolled the same
`all_debug || frame_logging || data_logging` test but did NOT honor the
GS_SILENCE_LOGS build flag, while the canonical gs::settings::is_*_enabled
helpers do (#ifdef GS_SILENCE_LOGS return false). A "silenced" perf-test build
therefore still evaluated these gates as enabled.

Add one canonical gs::settings::is_any_debug_log_enabled()
(= is_frame_log_enabled() || is_data_log_enabled(), both of which short-circuit
on all_debug and honor GS_SILENCE_LOGS) and route the three duplicate gates to
it: _is_scene_director_log_enabled (gaussian_splat_scene_director.cpp),
_is_streaming_debug_enabled (streaming_global_atlas_registry.cpp), and
_is_world_debug_enabled (gaussian_splat_world_3d.cpp). Single source of truth +
the gates now honor the flag.

Behavior-preserving for every shipped/default/editor build (GS_SILENCE_LOGS is
the opt-in gs_silence_logs=yes perf-test build only, where the GS_LOG_* macros
are already compiled to no-ops, so no observable logging changes). The
renderer's cached FrameLogSettingsRegistry is intentionally left as-is — it is a
separate caching mechanism already shielded via the GS_SILENCE_LOGS short-circuit
in the _is_frame_log_enabled() free function — as are the single-flag
enable_all_debug reads that are not the canonical log-gate pattern.

Panel-reviewed (3 Claude lenses + Codex, unanimous: consolidate).

Risk: R1. Evidence: full editor build (gs_project_settings.h cascade) compiles +
links clean (scons ... dev_build=yes tests=yes, exit 0); guards green (108 OK).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
