### PR TITLE
gaussian_splatting: mark AssetDependencyManager experimental/incomplete on construction (Task-5)

### DIFF
--- a/modules/gaussian_splatting/asset_management/asset_dependency_manager.cpp
+++ b/modules/gaussian_splatting/asset_management/asset_dependency_manager.cpp
@@ -129,6 +129,17 @@ AssetDependencyManager::AssetDependencyManager() {
         singleton = this;
     }
     current_project_id = "default";
+    // Honest-about-incompleteness gate (no runtime driver wires this class; it is
+    // only reachable via an explicit GDScript `AssetDependencyManager.new()`).
+    // The asset-registration / dependency-graph / cycle-detection / validation
+    // surface is real and usable, but the sharing, versioning, repair, and
+    // cleanup operations are unimplemented and return ERR_UNAVAILABLE. Warn once
+    // so a consumer is not misled into thinking those are functional.
+    WARN_PRINT_ONCE("AssetDependencyManager is an EXPERIMENTAL, partially-implemented subsystem: "
+                    "export_asset_for_sharing / import_shared_asset / create_asset_version / "
+                    "revert_to_version / repair_missing_dependencies / cleanup_orphaned_assets "
+                    "are not implemented (return ERR_UNAVAILABLE). The registration, dependency-graph, "
+                    "cycle-detection, and validation APIs are functional.");
 }
 
 AssetDependencyManager::~AssetDependencyManager() {


### PR DESCRIPTION
AssetDependencyManager is GDREGISTER_CLASS'd and GDScript-instantiable but has
no runtime driver and zero in-repo callers; six of its public methods
(export_asset_for_sharing, import_shared_asset, create_asset_version,
revert_to_version, repair_missing_dependencies, cleanup_orphaned_assets) are
unimplemented stubs that return ERR_UNAVAILABLE — and those six are not even
bound to GDScript. Its registration/dependency-graph/cycle-detection/validation
core, however, is real and bound.

Be honest about the incompleteness without breaking the registered/instantiable
API: emit a one-time WARN_PRINT_ONCE on construction stating the class is
experimental and naming the unimplemented operations, while leaving the working
surface usable. A RefCounted .new() can't be truly gated, so a construction
warning is the correct explicit+observable mechanism (and removal would need no
shim — there are no serialized/script references — but is deferred as a
breaking-API decision).

NOT changed (panel decision): the animation/persistence classes
(GaussianAnimationStateMachine / GaussianSceneSerializer / GaussianIncrementalSaver)
are KEPT — they are fully implemented and have live in-repo GDScript consumers
(scripts/export_gaussian_scene.gd, import_gaussian_scene.gd); gating/removing them
would break those. Their "no C++ per-frame driver" status is already self-documented
in animation_state_machine.h. The separate cubic-bezier easing bug is fixed in its
own commit.

Panel-reviewed (3 Claude lenses + Codex): gate experimental / be honest, don't break.

Risk: R1/R2. Evidence: full editor build compiles + links clean
(scons ... dev_build=yes tests=yes, exit 0); guards green (108 OK).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
